### PR TITLE
lets accepted socket inherit timeout value from binded one

### DIFF
--- a/src/net/mormot.net.sock.pas
+++ b/src/net/mormot.net.sock.pas
@@ -2235,7 +2235,7 @@ begin
     exit;
   if ResultClass = nil then
     ResultClass := TCrtSocket;
-  result := ResultClass.Create;
+  result := ResultClass.Create(Timeout);
   result.AcceptRequest(client, @addr);
   result.CreateSockIn; // use SockIn with 1KB input buffer: 2x faster
 end;


### PR DESCRIPTION
This fix a situation 
```
 ServerSock := TCrtSocket.Bind(fPort, cslTCP, 0); // set timeout to 0 to wait on read loop until closed
 AcceptedSocket := ServerSock.AcceptIncoming(); // AcceptedSocket.timeout is 10000 (default) but should be 0
```