### PR TITLE
Add missing unit

### DIFF
--- a/src/db/mormot.db.rad.firedac.pas
+++ b/src/db/mormot.db.rad.firedac.pas
@@ -209,6 +209,7 @@ type
 {$else}
 
 uses
+  mormot.core.data,
   uADPhysIntf,
   uADStanDef,
   uADDAptManager,


### PR DESCRIPTION
Compilation under Delphi 10.3.3 stops with:
[dcc32 Error] mormot.db.rad.firedac.pas(322): E2003 Undeclared identifier: 'TDynArray'
Adding mormot.core.data, to the uses clause solves it