### PR TITLE
two errors related to SendEmail

### DIFF
--- a/src/net/mormot.net.client.pas
+++ b/src/net/mormot.net.client.pas
@@ -29,7 +29,7 @@ uses
   mormot.net.sock,
   mormot.net.http,
   {$ifdef USEWININET}  // as set in mormot.defines.inc
-  WinINet;
+  WinINet,
   mormot.lib.winhttp,
   {$endif USEWININET}
   {$ifdef USELIBCURL}  // as set in mormot.defines.inc
@@ -2174,7 +2174,7 @@ var
   end;
 
 var
-  P: PAnsiChar;
+  P: PUTF8Char;
   rec, ToList, head: RawUTF8;
 begin
   result := false;


### PR DESCRIPTION
[dcc32 Error] mormot.net.client.pas(33): E2029 Declaration expected but identifier 'mormot' found
Change ";" for "," in USEWININET uses

[dcc32 Error] mormot.net.client.pas(2203): E2250 There is no overloaded version of 'GetNextItem' that can be called with these arguments
Change P: PAnsiChar;   forh   P: PUTF8Char;