### PR TITLE
added share interface support for LibCurl (back-port form mORMot1 pr376)

### DIFF
--- a/src/net/mormot.net.client.pas
+++ b/src/net/mormot.net.client.pas
@@ -1818,6 +1818,8 @@ begin
   if not IsAvailable then
     raise ECurlHttp.CreateFmt('No available %s', [LIBCURL_DLL]);
   fHandle := curl.easy_init;
+  if curl.globalShare <> nil then
+    curl.easy_setopt(fHandle, coShare, curl.globalShare);
   ConnectionTimeOut := ConnectionTimeOut div 1000; // curl expects seconds
   if ConnectionTimeOut = 0 then
     ConnectionTimeOut := 1;


### PR DESCRIPTION
Back-port from https://github.com/synopse/mORMot/pull/376 with subsequent changes.

Also added misisng in mORMot2 call of curl.global_cleanup in TLibCurl destructor to ensure all shared resources are disposed correctly (sockets are closed, for example) 
 