### PR TITLE
av in case of empty Model

### DIFF
--- a/src/orm/mormot.orm.server.pas
+++ b/src/orm/mormot.orm.server.pas
@@ -500,6 +500,10 @@ begin
     // rows are identified as RecordRef
     fTrackChangesHistoryTableIndexCount := 64;
   SetLength(fTrackChangesHistoryTableIndex, fTrackChangesHistoryTableIndexCount);
+  
+  if fTrackChangesHistoryTableIndexCount=0 then
+    exit;
+  
   for t := 0 to fTrackChangesHistoryTableIndexCount - 1 do
     fTrackChangesHistoryTableIndex[t] := -1;
   fOrmVersionDeleteTable := TOrmTableDeleted;


### PR DESCRIPTION
t is of PtrInt and if fModel.Tables=0 under Delphi XE6 Win64 fTrackChangesHistoryTableIndex[t] := -1; is called with t=0