### PR TITLE
TDynArray.Copy: Do not dereference PDynArray arguments

### DIFF
--- a/src/core/mormot.core.data.pas
+++ b/src/core/mormot.core.data.pas
@@ -7632,7 +7632,7 @@ begin
     LoadFromJson(pointer(Source.SaveToJson))
   else
   begin
-    DynArrayCopy(fValue^, Source.fValue^, fInfo.Info, Source.fCountP);
+    DynArrayCopy(fValue, Source.fValue, fInfo.Info, Source.fCountP);
     if fCountP <> nil then
       fCountP^ := GetCapacity;
   end;


### PR DESCRIPTION
TDynArray.Copy: Do not dereference PDynArray arguments when passing them to DynArrayCopy, they might be nil and cause an access violation.
I encountered this issue when TSQLPropInfoRTTIDynArray.CopySameClassProp tried to copy a TRawUTF8DynArray where both src and dst were empty.