### PR TITLE
Use correct ORM props in TOrm.RttiJsonWrite.

### DIFF
--- a/src/orm/mormot.orm.core.pas
+++ b/src/orm/mormot.orm.core.pas
@@ -9030,7 +9030,7 @@ begin
   end;
   W.BlockBegin('{', Options);
   W.AddPropJSONInt64('RowID', TOrm(Instance).fID);
-  props := OrmProps.Fields;
+  props := TOrm(Instance).OrmProps.Fields;
   cur := pointer(props.List);
   n := props.Count;
   repeat


### PR DESCRIPTION
Calling OrmProps directly returned props for TOrm, not the actual instance class OrmProps. 
I noticed it because the TOrm class doesn't have any fields, so I got an access violation when the method was called from `mormot.core.json._JS_RttiCustom` (`TOnRttiJsonWrite(nfo.fJsonWriter)(c.W, Data, c.Options)`).

