### PR TITLE
fix keep-alive for HTTP 1.1

### DIFF
--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -1124,7 +1124,7 @@ begin
   if not IdemPChar(P, 'HTTP/1.') then
     exit;
   if not (hfConnectionClose in HeaderFlags) then
-    if not (hfConnectionKeepAlive in HeaderFlags) or
+    if not (hfConnectionKeepAlive in HeaderFlags) and
        (P[7] <> '1')then
       include(HeaderFlags, hfConnectionClose);
   ParseHeaderFinalize;


### PR DESCRIPTION
For HTTP 1.1 default behavior is keep-alive connection even if  `Connetion: keep-alive` header is missing
with wrk after fix I got ~80000 RPS compared to ~17000 RPS before fix. also verified with curl:
- before fix - wrong connection closing
```
$ curl -v http://localhost:8888/echo
*   Trying 127.0.0.1:8888...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8888 (#0)
> GET /echo HTTP/1.1
> Host: localhost:8888
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
* HTTP 1.0, assume close after body
< HTTP/1.0 200 OK
< Server: mORMot2 (Linux)
< X-Powered-By: mORMot 2 synopse.info
< Content-Length: 35
< Connection: Close
< 
* Closing connection 0
```

- after fix: valid behavior for bot 1.1 and 1.0
```
$ curl -v http://localhost:8888/echo
*   Trying 127.0.0.1:8888...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8888 (#0)
> GET /echo HTTP/1.1
> Host: localhost:8888
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Server: mORMot2 (Linux)
< X-Powered-By: mORMot 2 synopse.info
< Content-Length: 30
< Connection: Keep-Alive
< 
* Connection #0 to host localhost left intact


$ curl -v --http1.0 http://localhost:8888/echo
*   Trying 127.0.0.1:8888...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8888 (#0)
> GET /echo HTTP/1.0
> Host: localhost:8888
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
* HTTP 1.0, assume close after body
< HTTP/1.0 200 OK
< Server: mORMot2 (Linux)
< X-Powered-By: mORMot 2 synopse.info
< Content-Length: 30
< Connection: Close
< 
* Closing connection 0
```