### PR TITLE
Revert "ServiceUndefine/DeleteInterface implementation and TestCase."

### DIFF
--- a/src/core/mormot.core.interfaces.pas
+++ b/src/core/mormot.core.interfaces.pas
@@ -983,8 +983,6 @@ type
       overload; virtual;
     /// check if a given interface can be resolved, from its RTTI
     function Implements(aInterface: PRttiInfo): boolean; override;
-    /// delete a previously registered resolver. aResolver can be re-registered afterwards
-    procedure DeleteResolver(aResolver: TInterfaceResolver);
     /// release all used instances
     // - including all TInterfaceStub instances as specified to Inject(aStubsByGUID)
     // - will call _Release on all TInterfacedObject dependencies
@@ -5393,11 +5391,6 @@ begin
   end;
 end;
 
-procedure TInterfaceResolverInjected.DeleteResolver(aResolver: TInterfaceResolver);
-begin
-  ObjArrayDelete(fResolversToBeReleased, aResolver);
-  ObjArrayDelete(fResolvers, aResolver);
-end;
 
 { TInjectableObject }
 

--- a/src/rest/mormot.rest.client.pas
+++ b/src/rest/mormot.rest.client.pas
@@ -748,8 +748,6 @@ type
     function ServiceDefineSharedApi(const aInterface: TGUID;
       const aContractExpected: RawUtf8 = SERVICE_CONTRACT_NONE_EXPECTED;
       aIgnoreAnyException: boolean = false): TServiceFactoryClient;
-    /// undefine previously defined Interfaces
-    procedure ServiceUndefine(const aInterfaces: array of TGUID);
     /// allow to notify a server the services this client may be actually capable
     // - when this client will connect to a remote server to access its services,
     // it will register its own services, supplying its TRestServer instance,
@@ -2662,11 +2660,6 @@ begin
     else
       raise;
   end;
-end;
-
-procedure TRestClientURI.ServiceUndefine(const aInterfaces: array of TGUID);
-begin
-  (ServiceContainer as TServiceContainerClient).DeleteInterface(TInterfaceFactory.GUID2TypeInfo(aInterfaces));
 end;
 
 function TRestClientUri.ServiceRetrieveAssociated(const aServiceName: RawUtf8;

--- a/src/rest/mormot.rest.mvc.pas
+++ b/src/rest/mormot.rest.mvc.pas
@@ -615,7 +615,6 @@ type
     procedure RunOnRestServerSub(Ctxt: TRestServerUriContext);
     procedure InternalRunOnRestServer(Ctxt: TRestServerUriContext;
       const MethodName: RawUtf8);
-    procedure UnregisterMethods;
   public
     /// this constructor will publish some views to a TRestServer instance
     // - the associated RestModel can match the supplied TRestServer, or be
@@ -632,8 +631,6 @@ type
       aViews: TMvcViewsAbstract = nil;
       aPublishOptions: TMvcPublishOptions=
         [low(TMvcPublishOption) .. high(TMvcPublishOption)]); reintroduce;
-    /// finalize this MVC server logic instance
-    destructor Destroy; override;
     /// define some content for a static file
     // - only used if cacheStatic has been defined
     function AddStaticCache(const aFileName: TFileName;
@@ -1903,12 +1900,6 @@ begin
   fRestServer.Options := fRestServer.Options + [rsoNoTableURI, rsoNoInternalState];
 end;
 
-destructor TMvcRunOnRestServer.Destroy;
-begin
-  UnregisterMethods;
-  inherited Destroy;
-end;
-
 function TMvcRunOnRestServer.AddStaticCache(const aFileName: TFileName;
   const aFileContent: RawByteString): RawByteString;
 begin
@@ -2063,18 +2054,6 @@ begin
     InternalRunOnRestServer(Ctxt, Ctxt.UriBlobFieldName);
 end;
 
-procedure TMvcRunOnRestServer.UnregisterMethods;
-var m: integer;
-    method: RawUTF8;
-begin
-  for m := 0 to fApplication.fFactory.MethodsCount-1 do
-  begin
-    method := fApplication.fFactory.Methods[m].URI;
-    if method[1]='_' then
-      delete(method,1,1); // e.g. IService._Start() -> /service/start
-    fRestServer.ServiceMethodUnregister(method);
-  end;
-end;
 
 { TMvcRendererReturningData }
 

--- a/src/rest/mormot.rest.server.pas
+++ b/src/rest/mormot.rest.server.pas
@@ -1978,6 +1978,7 @@ type
     /// the HTTP server should call this method so that ServicesPublishedInterfaces
     // registration will be able to work
     procedure SetPublicUri(const Address, Port: RawUtf8);
+
     /// add all published methods of a given object instance to the method-based
     // list of services
     // - all those published method signature should match TOnRestServerCallBack
@@ -1987,8 +1988,6 @@ type
     procedure ServiceMethodRegister(aMethodName: RawUtf8;
       const aEvent: TOnRestServerCallBack;
       aByPassAuthentication: boolean = false);
-    /// direct unregistration of a method for a given low-level event handler
-    procedure ServiceMethodUnregister(aMethodName: RawUTF8);
     /// call this method to disable Authentication method check for a given
     // published method-based service name
     // - by default, only Auth and Timestamp methods do not require the RESTful
@@ -2087,8 +2086,6 @@ type
     function ServiceDefine(aClient: TRest; const aInterfaces: array of TGUID;
       aInstanceCreation: TServiceInstanceImplementation = sicSingle;
       const aContractExpected: RawUtf8 = ''): boolean; overload;
-    /// undefine services.
-    procedure ServiceUndefine(const aInterfaces: array of TGUID);
     /// the routing classs of the service remote request
     // - by default, will use TRestRoutingRest, i.e. an URI-based
     // layout which is secure (since will use our RESTful authentication scheme),
@@ -3022,74 +3019,65 @@ procedure TRestServerUriContext.ExecuteSoaByMethod;
 var
   timstart, timstop: Int64;
   sessionstat: TSynMonitorInputOutput;
-  method: PRestServerMethod;
 begin
-  method := @Server.fPublishedMethod[MethodIndex];
-  if mlMethods in Server.fStatLevels then
+  with Server.fPublishedMethod[MethodIndex] do
   begin
-    QueryPerformanceMicroSeconds(timstart);
-    if method^.Stats = nil then
+    if mlMethods in Server.fStatLevels then
     begin
-      Server.fStats.Lock; // global lock for thread-safe initialization
-      try
-        if (method^.Stats = nil) then
-          method^.Stats := TSynMonitorInputOutput.Create(method^.Name);
-      finally
-        Server.fStats.UnLock;
+      QueryPerformanceMicroSeconds(timstart);
+      if Stats = nil then
+      begin
+        Server.fStats.Lock; // global lock for thread-safe initialization
+        try
+          if Stats = nil then
+            Stats := TSynMonitorInputOutput.Create(Name);
+        finally
+          Server.fStats.UnLock;
+        end;
       end;
+      Stats.Processing := true;
     end;
-    method^.Stats.Processing := true;
-  end;
-  if Parameters <> nil then
-    Server.InternalLog('% %', [method^.Name, Parameters], sllServiceCall);
-  method^.CallBack(self);
-  // CallBack(self) might have changed the fPublishedMethod array if there was any
-  // code involved unregistering interfaces. Might lead to AV with Stats enabled.
-  // Recalculate MethodIndex and reassing method pointer.
-  if mlMethods in Server.fStatLevels then
-  begin
-    UriDecodeSoaByMethod;
-    if (MethodIndex <> -1) then
-      method := @Server.fPublishedMethod[MethodIndex] else
-      method := nil;
-  end;
-  if (method <> nil) and (method^.Stats <> nil) then
-  begin
-    QueryPerformanceMicroSeconds(timstop);
-    dec(timstop, timstart);
-    StatsFromContext(method^.Stats, timstop);
-    if Server.fStatUsage <> nil then
-      Server.fStatUsage.Modified(method^.Stats, []);
-    if (mlSessions in Server.fStatLevels) and
-       (fAuthSession <> nil) then
+    if Parameters <> nil then
+      Server.InternalLog('% %', [Name, Parameters], sllServiceCall);
+    CallBack(self);
+    if Stats <> nil then
     begin
-      if fAuthSession.fMethods = nil then
+      QueryPerformanceMicroSeconds(timstop);
+      dec(timstop, timstart);
+      StatsFromContext(Stats, timstop);
+      if Server.fStatUsage <> nil then
+        Server.fStatUsage.Modified(Stats, []);
+      if (mlSessions in Server.fStatLevels) and
+         (fAuthSession <> nil) then
       begin
-        Server.fStats.Lock;
-        try
-          if fAuthSession.fMethods = nil then
-            SetLength(fAuthSession.fMethods, length(Server.fPublishedMethod));
-        finally
-          Server.fStats.UnLock;
-        end;
-      end;
-      sessionstat := fAuthSession.fMethods[MethodIndex];
-      if sessionstat = nil then
-      begin
-        Server.fStats.Lock;
-        try
-          sessionstat := fAuthSession.fMethods[MethodIndex];
-          if sessionstat = nil then
-          begin
-            sessionstat := TSynMonitorInputOutput.Create(method^.Name);
-            fAuthSession.fMethods[MethodIndex] := sessionstat;
+        if fAuthSession.fMethods = nil then
+        begin
+          Server.fStats.Lock;
+          try
+            if fAuthSession.fMethods = nil then
+              SetLength(fAuthSession.fMethods, length(Server.fPublishedMethod));
+          finally
+            Server.fStats.UnLock;
           end;
-        finally
-          Server.fStats.UnLock;
         end;
+        sessionstat := fAuthSession.fMethods[MethodIndex];
+        if sessionstat = nil then
+        begin
+          Server.fStats.Lock;
+          try
+            sessionstat := fAuthSession.fMethods[MethodIndex];
+            if sessionstat = nil then
+            begin
+              sessionstat := TSynMonitorInputOutput.Create(Name);
+              fAuthSession.fMethods[MethodIndex] := sessionstat;
+            end;
+          finally
+            Server.fStats.UnLock;
+          end;
+        end;
+        StatsFromContext(sessionstat, timstop);
+        // mlSessions stats are not yet tracked per Client
       end;
-      StatsFromContext(sessionstat, timstop);
-      // mlSessions stats are not yet tracked per Client
     end;
   end;
   LockedInc64(@Server.fStats.fServiceMethod);
@@ -6521,21 +6509,6 @@ begin
   end;
 end;
 
-procedure TRestServer.ServiceMethodUnregister(aMethodName: RawUTF8);
-var
-  ix: Integer;
-begin
-  aMethodName := TrimU(aMethodName);
-  if aMethodName = '' then
-    raise EServiceException.CreateUTF8('%.ServiceMethodRegister('''')', [self]);
-  ix := fPublishedMethods.FindHashed(aMethodName);
-  if ix >= 0 then begin
-    fPublishedMethod[ix].Stats.Free;
-    fPublishedMethods.Delete(ix);
-    fPublishedMethods.ReHash();
-  end;
-end;
-
 function TRestServer.ServiceMethodByPassAuthentication(
   const aMethodName: RawUtf8): integer;
 var
@@ -6634,11 +6607,6 @@ var
 begin
   ti := TInterfaceFactory.Guid2TypeInfo(aInterfaces);
   result := ServiceRegister(aClient, ti, aInstanceCreation, aContractExpected);
-end;
-
-procedure TRestServer.ServiceUndefine(const aInterfaces: array of TGUID);
-begin
-  (ServiceContainer as TServiceContainerServer).DeleteInterface(TInterfaceFactory.GUID2TypeInfo(aInterfaces));
 end;
 
 const

--- a/src/soa/mormot.soa.core.pas
+++ b/src/soa/mormot.soa.core.pas
@@ -689,8 +689,6 @@ type
     /// retrieve all registered Services contracts as a JSON array
     // - i.e. a JSON array of TServiceFactory.Contract JSON objects
     function AsJson: RawJson;
-    /// delete previously registered Interfaces
-    procedure DeleteInterface(const aInterfaces: PRttiInfoDynArray);
     /// retrieve a service provider from its URI
     // - it expects the supplied URI variable  to be e.g. '00amyWGct0y_ze4lIsj2Mw'
     // or 'Calculator', depending on the ExpectMangledUri property
@@ -1592,37 +1590,7 @@ begin
   result := false; // nothing to be done here
 end;
 
-procedure TServiceContainer.DeleteInterface(const aInterfaces: PRttiInfoDynArray);
-var
-  iInterfaces: integer;
-  iMethods: integer;
-  Idx: integer;
-  MethodName: RawUTF8;
-  InterfaceName: RawUTF8;
-  tmpInterfaceName: RawUTF8;
-begin
-  for iInterfaces := Low(aInterfaces) to High(aInterfaces) do begin
-    tmpInterfaceName := ShortStringToUtf8(aInterfaces[iInterfaces]^.RawName);
-    if tmpInterfaceName[1] in ['I','i'] then
-      Delete(tmpInterfaceName,1,1);
-    //idx := fInterfaces.IndexOf(tmpInterfaceName);
-    idx := fInterfaces.FindHashed(tmpInterfaceName);
-    if idx > -1 then begin
-      fInterface[idx].Service.Free;
-      fInterfaces.Delete(idx);
-      fInterfaces.ReHash();
-    end;
-    for iMethods := High(fInterfaceMethod) downto Low(fInterfaceMethod) do
-    begin
-      Split(fInterfaceMethod[iMethods].InterfaceDotMethodName, '.', InterfaceName, MethodName);
-      if InterfaceName = tmpInterfaceName then
-      begin
-        fInterfaceMethods.Delete(iMethods);
-        fInterfaceMethods.ReHash();
-      end;
-    end;
-  end;
-end;
+
 { ***************** TServicesPublishedInterfacesList Services Catalog }
 
 { TRestServerUri }

--- a/test/test.soa.core.pas
+++ b/test/test.soa.core.pas
@@ -1395,17 +1395,6 @@ begin
   Check(fClient.Server.Services <> nil);
   if CheckFailed(fClient.Server.Services.Count = 1) then
     exit;
-  // Undefine service
-  fClient.Server.ServiceUndefine([ICalculator]);
-  if CheckFailed(fClient.Server.Services.Count = 0) then
-    exit;
-  Check(fClient.Server.Services['Calculator'] = nil );
-  // Re-register service
-  Check(fClient.Server.ServiceRegister(TServiceCalculator,
-    [TypeInfo(ICalculator)], sicShared) <> nil,
-    're-register TServiceCalculator as the ICalculator implementation on the server');
-  if CheckFailed(fClient.Server.Services.Count = 1) then
-    exit;
   S := fClient.Server.Services.Index(0);
   if CheckFailed(S <> nil) then
     exit;

--- a/test/test.soa.network.pas
+++ b/test/test.soa.network.pas
@@ -276,7 +276,7 @@ procedure TTestBidirectionalRemoteConnection.WebsocketsLowLevel(
     try
       for i := 1 to 100 do
       begin
-        C1.Prepare('url', 'POST', 'headers', content, contentType, '');
+        C1.Prepare('url', 'POST', 'headers', content, contentType, '', '', '');
         noAnswer1 := opcode = focBinary;
         noAnswer2 := not noAnswer1;
         TWebSocketProtocolRestHook(protocol).InputToFrame(C1, noAnswer1, frame, head);


### PR DESCRIPTION
Reverts synopse/mORMot2#72

Code added into `TRestServerUriContext.ExecuteSoaByMethod` slows down execution of regular methods, and I am not sure it is very stable about the actual methods process.