### PR TITLE
Update mormot.core.os.pas

### DIFF
--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -5871,6 +5871,8 @@ end;
 
 procedure TSynLocker.Lock;
 begin
+  if fSection.LockCount<0 then
+    Exit;
   case fRWUse of
     uSharedLock:
       begin


### PR DESCRIPTION
under Delphi Win32/64 there are av's, when doing this in TSQLHttpServer.HttpThreadStart:

fLock.Lock; --> here AV
try
...
finally
  fLock.Unlock;
end;

fLock is a private field of instance of TSQLHttpServer here.