### PR TITLE
Fix output directory for the extraction of downloaded static files and make sure ONLYUSEHTTPSOCKET is honored in mormot.rest.http.server.

### DIFF
--- a/get_latest_static.sh
+++ b/get_latest_static.sh
@@ -17,4 +17,4 @@ wget -q -O $DOWNLOAD_PATH "$LATEST_URL"
 
 echo "Unpacking to ./static ..."
 rm -Rf ./static
-7za x $DOWNLOAD_PATH -o./
+7za x $DOWNLOAD_PATH -o./static

--- a/src/rest/mormot.rest.http.server.pas
+++ b/src/rest/mormot.rest.http.server.pas
@@ -153,7 +153,12 @@ const
   // connections - creating one thread per HTTP/1.1 connection - so is a good
   // idea behind a nginx reverse proxy using HTTP/1.0, whereas our new
   // useHttpAsync server scales much better with high number of connections
-  HTTP_DEFAULT_MODE = useHttpAsync;
+  
+    {$ifdef ONLYUSEHTTPSOCKET}
+      HTTP_DEFAULT_MODE = useHttpSocket;
+    {$else}
+      HTTP_DEFAULT_MODE = useHttpAsync;
+    {$endif ONLYUSEHTTPSOCKET}  
   {$endif USEHTTPSYS}
 
   /// the kind of HTTP server to be used by default for WebSockets support


### PR DESCRIPTION
Fix output directory for the extraction of downloaded static files and make sure ONLYUSEHTTPSOCKET is honored in mormot.rest.http.server