### PR TITLE
Fix Utf8ToConsole to work with non-ascii characters

### DIFF
--- a/src/core/mormot.core.os.windows.inc
+++ b/src/core/mormot.core.os.windows.inc
@@ -1696,7 +1696,7 @@ begin
   utf16 := Utf8Decode(Utf8);
   tmp.Init(length(utf16) * 3);
   CharToOemBuffW(pointer(utf16), tmp.buf, length(utf16) + 1); // +1 = ending #0
-  FastSetRawByteString(Console, tmp.buf, StrLen(tmp.buf));
+  FastSetStringCP(Console, tmp.buf, StrLen(tmp.buf), CP_OEMCP);
   tmp.Done;
 end;
 


### PR DESCRIPTION
Utf8ToConsoleDoConv does not set code page for resulting RawByteString, so system.write tries to convert ANSI -> Unicode -> OEM, and prints nothing.

Also, "no conversion needed" is not true. It's converted ANSI -> Unicode -> OEM, but conversion succeeded.
```
function Utf8ToConsole(const S: RawUtf8): RawByteString;
begin
  if IsAnsiCompatible(S) then
    result := S // conversion in system.write: ANSI -> Unicode -> OEM
  else
    Utf8ToConsoleDoConv(S, result);
end;
```