### PR TITLE
improve AddColumns speed - +500RPS on TFB /db endpoint

### DIFF
--- a/src/db/mormot.db.core.pas
+++ b/src/db/mormot.db.core.pas
@@ -2561,7 +2561,8 @@ end;
 
 procedure TResultsWriter.AddColumns(aKnownRowsCount: integer);
 var
-  i: PtrInt;
+  i, l: PtrInt;
+  new: PAnsiChar;
 begin
   if fExpand then
   begin
@@ -2569,8 +2570,15 @@ begin
       for i := 0 to length(ColNames) - 1 do
         ColNames[i] := ColNames[i] + ':'
     else
-      for i := 0 to length(ColNames) - 1 do
-        ColNames[i] := '"' + ColNames[i] + '":';
+      for i := 0 to length(ColNames) - 1 do begin
+        // faster version of ColNames[i] := '"' + ColNames[i] + '":';
+        l := length(ColNames[i]);
+        new := FastNewString(l+2, CP_UTF8);
+        MoveFast(pointer(ColNames[i]), new[1], l);
+        new[0] := '"';
+        new[l-1] := '"';
+        FastAssignNew(ColNames[i], new);
+      end;
   end
   else
   begin

--- a/src/db/mormot.db.core.pas
+++ b/src/db/mormot.db.core.pas
@@ -2573,10 +2573,11 @@ begin
       for i := 0 to length(ColNames) - 1 do begin
         // faster version of ColNames[i] := '"' + ColNames[i] + '":';
         l := length(ColNames[i]);
-        new := FastNewString(l+2, CP_UTF8);
+        new := FastNewString(l+3, CP_UTF8);
         MoveFast(pointer(ColNames[i]), new[1], l);
         new[0] := '"';
-        new[l-1] := '"';
+        new[l-2] := '"';
+        new[l-1] := ':';
         FastAssignNew(ColNames[i], new);
       end;
   end


### PR DESCRIPTION
Before this optimization AddColumns takes 2.17% (fpc_ansistr_concat_multy = 1.92%) CPU on TFB `/db`, after - 0.95. As a result +500 RPS
 
