### PR TITLE
Improve HTTP header parser

### DIFF
--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -973,16 +973,16 @@ end;
 const
   PARSEDHEADERS: array[0..11] of PAnsiChar = (
     'CONTENT-',                    // 0
-    'HOST:',                       // 10 -> 1
+    'HOST:',                       // 1
     'CONNECTION: ',                // 2
     'ACCEPT',                      // 3
-    'USER-AGENT:',                 // 9 -> 4
+    'USER-AGENT:',                 // 4
     'SERVER-INTERNALSTATE:',       // 5
     'X-POWERED-BY:',               // 6
     'EXPECT: 100',                 // 7
     HEADER_BEARER_UPPER,           // 8
-    'UPGRADE:',                    // 4 -> 9
-    'TRANSFER-ENCODING: CHUNKED',  // 1 -> 10
+    'UPGRADE:',                    // 9
+    'TRANSFER-ENCODING: CHUNKED',  // 10
     nil);
   PARSEDHEADERS2: array[0..3] of PAnsiChar = (
     'LENGTH:',    // 0
@@ -1048,9 +1048,13 @@ begin
       else
         HeadersUnFiltered := true;
       end;
-    10:
-      // 'TRANSFER-ENCODING: CHUNKED'
-      include(HeaderFlags, hfTransferChunked);
+    1:
+      begin
+        // 'HOST:'
+        inc(P, 5);
+        GetTrimmed(P, Host);
+        HeadersUnFiltered := true; // may still be needed by some code
+      end;
     2:
       begin
         // 'CONNECTION: '
@@ -1092,9 +1096,12 @@ begin
         else //Accept:, Accept-Language: etc.
           HeadersUnFiltered := true;
       end;
-    9:
-      // 'UPGRADE:'
-      GetTrimmed(P + 8, Upgrade);
+    4:
+      begin
+        // 'USER-AGENT:'
+        inc(P, 11);
+        GetTrimmed(P, UserAgent);
+      end;
     5:
       begin
         // 'SERVER-INTERNALSTATE:'
@@ -1119,19 +1126,12 @@ begin
           // always allow FindNameValue(..., HEADER_BEARER_UPPER, ...) search
           HeadersUnFiltered := true;
       end;
-    4:
-      begin
-        // 'USER-AGENT:'
-        inc(P, 11);
-        GetTrimmed(P, UserAgent);
-      end;
-    1:
-      begin
-        // 'HOST:'
-        inc(P, 5);
-        GetTrimmed(P, Host);
-        HeadersUnFiltered := true; // may still be needed by some code
-      end;
+    9:
+      // 'UPGRADE:'
+      GetTrimmed(P + 8, Upgrade);
+    10:
+      // 'TRANSFER-ENCODING: CHUNKED'
+      include(HeaderFlags, hfTransferChunked);
   else
     // unrecognized name should be stored in Headers
     HeadersUnFiltered := true;

--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -973,16 +973,16 @@ end;
 const
   PARSEDHEADERS: array[0..11] of PAnsiChar = (
     'CONTENT-',                    // 0
-    'TRANSFER-ENCODING: CHUNKED',  // 1
+    'HOST:',                       // 10 -> 1
     'CONNECTION: ',                // 2
-    'ACCEPT-ENCODING:',            // 3
-    'UPGRADE:',                    // 4
+    'ACCEPT',                      // 3
+    'USER-AGENT:',                 // 9 -> 4
     'SERVER-INTERNALSTATE:',       // 5
     'X-POWERED-BY:',               // 6
     'EXPECT: 100',                 // 7
     HEADER_BEARER_UPPER,           // 8
-    'USER-AGENT:',                 // 9
-    'HOST:',                       // 10
+    'UPGRADE:',                    // 4 -> 9
+    'TRANSFER-ENCODING: CHUNKED',  // 1 -> 10
     nil);
   PARSEDHEADERS2: array[0..3] of PAnsiChar = (
     'LENGTH:',    // 0
@@ -1048,7 +1048,7 @@ begin
       else
         HeadersUnFiltered := true;
       end;
-    1:
+    10:
       // 'TRANSFER-ENCODING: CHUNKED'
       include(HeaderFlags, hfTransferChunked);
     2:
@@ -1084,11 +1084,15 @@ begin
       end;
     3:
       begin
-        // 'ACCEPT-ENCODING:'
-        inc(P, 17);
-        GetTrimmed(P, AcceptEncoding);
+        // 'ACCEPT
+        if IdemPChar(P + 6, '-ENCODING:') then begin
+          inc(P, 17);
+          GetTrimmed(P, AcceptEncoding);
+        end
+        else //Accept:, Accept-Language: etc.
+          HeadersUnFiltered := true;
       end;
-    4:
+    9:
       // 'UPGRADE:'
       GetTrimmed(P + 8, Upgrade);
     5:
@@ -1115,13 +1119,13 @@ begin
           // always allow FindNameValue(..., HEADER_BEARER_UPPER, ...) search
           HeadersUnFiltered := true;
       end;
-    9:
+    4:
       begin
         // 'USER-AGENT:'
         inc(P, 11);
         GetTrimmed(P, UserAgent);
       end;
-    10:
+    1:
       begin
         // 'HOST:'
         inc(P, 5);


### PR DESCRIPTION
The idea is to move most useful headers up in IdemPPChar array.
This decrease CPU time spend in ParseHeader function from 17.5% to 15.9% (measured on /json TFB test using valgrind) and should help a little on real-life browser request.

/json RPS improved by 0.4%  ~500000 -> ~504000