### PR TITLE
prefer mORMot StrLen over PQGetLength + prevent unnecessary PQGetIsNull calls

### DIFF
--- a/src/db/mormot.db.sql.postgres.pas
+++ b/src/db/mormot.db.sql.postgres.pas
@@ -806,11 +806,11 @@ begin
     raise ESqlDBPostgres.CreateUtf8('%.ColumnToJson unexpected', [self]);
   with fColumns[Col] do
   begin
-    if PQ.GetIsNull(fRes, fCurrentRow, Col) = 1 then
+    P := PQ.GetValue(fRes, fCurrentRow, Col);
+    if (PUtf8Char(P)^ = #0) and (PQ.GetIsNull(fRes, fCurrentRow, Col) = 1) then
       W.AddNull
     else
     begin
-      P := PQ.GetValue(fRes, fCurrentRow, Col);
       case ColumnType of
         ftNull:
           W.AddNull;

--- a/src/db/mormot.db.sql.postgres.pas
+++ b/src/db/mormot.db.sql.postgres.pas
@@ -817,11 +817,11 @@ begin
         ftInt64,
         ftDouble,
         ftCurrency:
-          W.AddNoJsonEscape(P, PQ.GetLength(fRes, fCurrentRow, Col));
+          W.AddNoJsonEscape(P);
         ftUtf8:
           if (ColumnAttr = JSONOID) or
              (ColumnAttr = JSONBOID) then
-            W.AddNoJsonEscape(P, PQ.GetLength(fRes, fCurrentRow, Col))
+            W.AddNoJsonEscape(P) // let's mORMOt calc string length - it's faster than PQ.GetLength
           else
           begin
             W.Add('"');


### PR DESCRIPTION
`StrLen` is twice faster compared to `PQGetLength` 0.2% vs 0.4% on TFB `/db`