### PR TITLE
Fixes for ACME client

### DIFF
--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -7674,8 +7674,10 @@ begin
   FinalizeSpecificUnit; // in mormot.core.os.posix/windows.inc files
   DeleteCriticalSection(ConsoleCriticalSection);
   DeleteCriticalSection(GlobalCriticalSection);
+  {$ifndef NOEXCEPTIONINTERCEPT}
   _RawLogException := nil;
   RawExceptionIntercepted := true;
+  {$endif}
 end;
 
 

--- a/src/lib/mormot.lib.openssl11.pas
+++ b/src/lib/mormot.lib.openssl11.pas
@@ -7216,7 +7216,7 @@ begin
   if @self = nil then
     exit;
   pub := nil;
-  publen := EC_KEY_key2buf(EC_KEY_get0_public_key(@self),
+  publen := EC_KEY_key2buf(EVP_PKEY_get0_EC_KEY(@self),
     POINT_CONVERSION_COMPRESSED, @pub, nil);
   FastSetRawByteString(k, pub, publen);
   OPENSSL_free(pub);
@@ -7230,7 +7230,7 @@ begin
   if @self = nil then
     exit;
   pub := nil;
-  publen := EC_KEY_key2buf(EC_KEY_get0_public_key(@self),
+  publen := EC_KEY_key2buf(EVP_PKEY_get0_EC_KEY(@self),
     POINT_CONVERSION_UNCOMPRESSED, @pub, nil);
   if publen = 0 then
     exit;

--- a/src/net/mormot.net.acme.pas
+++ b/src/net/mormot.net.acme.pas
@@ -436,6 +436,7 @@ end;
 constructor TAcmeClient.Create(const aCert: ICryptCert;
   const aDirectoryUrl, aContact, aDomain, aSubjects: RawUtf8);
 begin
+  inherited Create;
   fDirectoryUrl := aDirectoryUrl;
   fContact := aContact;
   fDomain := aDomain;
@@ -446,6 +447,7 @@ end;
 destructor TAcmeClient.Destroy;
 begin
   FreeAndNil(fHttpClient);
+  inherited Destroy;
 end;
 
 procedure TAcmeClient.ReadDirectory;


### PR DESCRIPTION
Some small fixes after refactoring.

About EccGetPubKey. Instead of EC_KEY_key2buf you can use EC_KEY_get0_public_key + EC_KEY_get0_group + EC_POINT_point2buf.