### PR TITLE
Fix Split when Str is empty

### DIFF
--- a/src/core/mormot.core.base.pas
+++ b/src/core/mormot.core.base.pas
@@ -8000,6 +8000,11 @@ var
   len, i: PtrInt;
 begin
   len := length(Str);
+  if len = 0 then
+  begin
+    result := '';
+    exit;
+  end;
   if StartPos > len then
     StartPos := len
   else if StartPos <= 0 then


### PR DESCRIPTION
When Str is empty, StartPos  assigned value 0, and last line failed with AV:
`FastSetString(result, @PByteArray(Str)[-1], 1)`