### PR TITLE
Fix Websocket over HTTPS

### DIFF
--- a/src/net/mormot.net.ws.async.pas
+++ b/src/net/mormot.net.ws.async.pas
@@ -470,7 +470,8 @@ function TWebSocketAsyncProcess.ComputeContext(
   out RequestProcess: TOnHttpServerRequest): THttpServerRequestAbstract;
 begin
   result := THttpServerRequest.Create(
-    fConnection.fServer, fProtocol.ConnectionID, nil, fProtocol.ConnectionFlags,
+    fConnection.fServer, fProtocol.ConnectionID, nil, 
+    HTTP_TLS_FLAGS[fConnection.fServer.Sock.TLS.Enabled] + fProtocol.ConnectionFlags,
     fProtocol.ConnectionOpaque);
   RequestProcess :=  fConnection.fServer.Request;
 end;

--- a/src/net/mormot.net.ws.server.pas
+++ b/src/net/mormot.net.ws.server.pas
@@ -237,7 +237,9 @@ var
 begin
   server := (fSocket as TWebSocketServerSocket).Server;
   result := THttpServerRequest.Create(server, fProtocol.ConnectionID,
-    fOwnerThread, fProtocol.ConnectionFlags, fProtocol.ConnectionOpaque);
+    fOwnerThread, fProtocol.ConnectionFlags,
+    HTTP_TLS_FLAGS[fSocket.TLS.Enabled] + fProtocol.ConnectionFlags,
+    fProtocol.ConnectionOpaque);
   RequestProcess := server.Request;
 end;
 


### PR DESCRIPTION
Websocket connection over HTTPS does not work (returns 404) because hsrHttps is missing in Ctxt.ConnectionFlags and TRestHttpServer.Request cannot find REST server instance (in `if (Security in SEC_TLS) = tls then...`). 

This patch changes ComputeContext to include hsrHttps in ConnectionFlags.

Not sure if we need to do this in TWebSocketProcessClient.ComputeContext.