### PR TITLE
optimize Postgres bulk update 

### DIFF
--- a/src/orm/mormot.orm.base.pas
+++ b/src/orm/mormot.orm.base.pas
@@ -3427,7 +3427,10 @@ begin
               W.AddShort(PG_FT[Decoder.DecodedFieldTypesToUnnest^[f]]);
               W.AddShorter('[]),');
             end;
-            W.AddShort(' unnest(?::int8[]) ) as v('); // last param is ID
+            //
+            W.AddShort(' unnest(?::int8[]) order by '); // last param is ID
+            W.Add(Decoder.FieldCount + 1); // order by ID to mimimize locks wait
+            W.AddShort(') as v(');
             for f := 0 to Decoder.FieldCount - 1 do
             begin
               W.AddNoJsonEscape(Decoder.DecodedFieldNames^[f]);


### PR DESCRIPTION
optimize Postgres bulk update  by updating table in primary key order to minimize locks