### PR TITLE
Solved TFB /rawqueries and /rawupdates performance problems

### DIFF
--- a/src/db/mormot.db.raw.postgres.pas
+++ b/src/db/mormot.db.raw.postgres.pas
@@ -123,6 +123,8 @@ const
   PGRES_PIPELINE_SYNC = 10;   // pipeline synchronization point
   PGRES_PIPELINE_ABORTED= 11; // Command didn't run because of an abort
 
+  PQ_PIPELINE_OFF = 0;
+
   CONNECTION_OK = 0;
   CONNECTION_BAD = 1;
   CONNECTION_STARTED = 2;


### PR DESCRIPTION
- PostgreSQL pipeline mode has been rethought - better to use Flush after each statement instead of PipelineSync after last statement; In this case server starts to execute queries ASAP;
- TFB `/rawupdates` - use `::bigint[]` instead of `::NUMERIC[]` typecast (NUMERIC is a floating point type, but we need Int64); added `order by id` to minimize locks waits (as in ORM)