### PR TITLE
TFB bench: more flexible threads tuning

### DIFF
--- a/ex/techempower-bench/raw.lpi
+++ b/ex/techempower-bench/raw.lpi
@@ -84,15 +84,14 @@
       </Debugging>
     </Linking>
     <Other>
-      <CustomOptions Value="-dFPC_X64MM
--dFPCMM_SERVER
--dFPCMM_REPORTMEMORYLEAKS
--dFPCMM_DEBUG"/>
-      <OtherDefines Count="4">
+      <CustomOptions Value="-dFPC_LIBCMM"/>
+      <OtherDefines Count="6">
         <Define0 Value="FPC_X64MM"/>
         <Define1 Value="FPCMM_SERVER"/>
         <Define2 Value="FPCMM_REPORTMEMORYLEAKS"/>
         <Define3 Value="FPCMM_DEBUG"/>
+        <Define4 Value="USE_SQLITE3"/>
+        <Define5 Value="FPC_LIBCMM"/>
       </OtherDefines>
     </Other>
   </CompilerOptions>

--- a/ex/techempower-bench/raw.pas
+++ b/ex/techempower-bench/raw.pas
@@ -604,8 +604,8 @@ begin
     cores := 16;
   if not TryStrToInt(ParamStr(3), servers) then
     servers := 1;
-  if threads < 16 then
-    threads := 16
+  if threads < 2 then
+    threads := 2
   else if threads > 256 then
     threads := 256; // max. threads for THttpAsyncServer
   {if SystemInfo.dwNumberOfProcessors > cores then
@@ -622,7 +622,7 @@ var
 begin
   // automatically guess best parameters depending on available CPU cores
   logicalcores := SystemInfo.dwNumberOfProcessors;
-  if logicalcores > 12 then
+  if logicalcores >= 12 then
   begin
     // high-end CPU - scale using several listeners (one per core)
     // see https://synopse.info/forum/viewtopic.php?pid=39263#p39263


### PR DESCRIPTION
- allow 2 thread per server in manual mode (instead of 16 min)
- use several servers for CPU>=12 (instead of > 12)