### PR TITLE
Postgres: bind int4 and int8 parameters as binary

### DIFF
--- a/src/db/mormot.db.raw.postgres.pas
+++ b/src/db/mormot.db.raw.postgres.pas
@@ -80,6 +80,7 @@ const
   CIDROID = 650;
   INT2ARRAYOID = 1005;
   INT4ARRAYOID = 1007;
+  INT8ARRAYOID = 1016;
   TEXTARRAYOID= 1009;
   OIDARRAYOID = 1028;
   FLOAT4ARRAYOID = 1021;
@@ -171,6 +172,9 @@ type
     Exec: function(conn: PPGconn; query: PUtf8Char): PPGresult; cdecl;
     Prepare: function(conn: PPGconn; stmtName, query: PUtf8Char; nParams: integer;
       paramTypes: PCardinal): PPGresult; cdecl;
+    DescribePrepared: function(conn: PPGconn; stmtName: PUtf8Char): PPGresult; cdecl;
+    NParams: function(res: PPGresult): integer; cdecl;
+    ParamType: function(res: PPGresult; param_number: integer): word; cdecl;
     ExecPrepared: function(conn: PPGconn; stmtName: PUtf8Char; nParams: integer;
       paramValues: PPchar; paramLengths, paramFormats: PInteger;
       resultFormat: integer): PPGresult; cdecl;
@@ -238,7 +242,7 @@ implementation
 { ************ PostgreSQL Client Library Loading }
 
 const
-  PQ_ENTRIES: array[0..32] of RawUtf8 = (
+  PQ_ENTRIES: array[0..35] of RawUtf8 = (
     'libVersion',
     'isthreadsafe',
     'setdbLogin',
@@ -252,6 +256,9 @@ const
     'freemem',
     'exec',
     'prepare',
+    'describePrepared',
+    'nparams',
+    'paramtype',
     'execPrepared',
     'execParams',
     'nfields',

--- a/src/db/mormot.db.sql.postgres.pas
+++ b/src/db/mormot.db.sql.postgres.pas
@@ -232,7 +232,6 @@ type
 implementation
 
 uses
-  sockets, // htonl
   mormot.db.raw.postgres; // raw libpq library API access
 
 
@@ -672,15 +671,14 @@ begin
             begin
               fPGParamFormats[i] := 1; // binary
               fPGParamLengths[i] := 4;
-              p^.VInt64 := htonl(p^.VInt64);
+              p^.VInt64 := bswap32(p^.VInt64);
               fPGParams[i] := @p^.VInt64;
             end
             else if p^.VDBType = INT8OID then
             begin
               fPGParamFormats[i] := 1; // binary
               fPGParamLengths[i] := 8;
-              Int64Rec(p^.VInt64).Hi := htonl(Int64Rec(p^.VInt64).Hi);
-              Int64Rec(p^.VInt64).Lo := htonl(Int64Rec(p^.VInt64).Lo);
+              p^.VInt64 := bswap64(p^.VInt64);
               fPGParams[i] := @p^.VInt64;
             end
             else

--- a/src/db/mormot.db.sql.postgres.pas
+++ b/src/db/mormot.db.sql.postgres.pas
@@ -232,6 +232,7 @@ type
 implementation
 
 uses
+  sockets, // htonl
   mormot.db.raw.postgres; // raw libpq library API access
 
 
@@ -666,7 +667,25 @@ begin
         ftNull:
           p^.VData := '';
         ftInt64:
-          Int64ToUtf8(p^.VInt64, RawUtf8(p^.VData));
+          begin
+            if p^.VDBType = INT4OID then
+            begin
+              fPGParamFormats[i] := 1; // binary
+              fPGParamLengths[i] := 4;
+              p^.VInt64 := htonl(p^.VInt64);
+              fPGParams[i] := @p^.VInt64;
+            end
+            else if p^.VDBType = INT8OID then
+            begin
+              fPGParamFormats[i] := 1; // binary
+              fPGParamLengths[i] := 8;
+              Int64Rec(p^.VInt64).Hi := htonl(Int64Rec(p^.VInt64).Hi);
+              Int64Rec(p^.VInt64).Lo := htonl(Int64Rec(p^.VInt64).Lo);
+              fPGParams[i] := @p^.VInt64;
+            end
+            else
+              Int64ToUtf8(p^.VInt64, RawUtf8(p^.VData));
+          end;
         ftCurrency:
           Curr64ToStr(p^.VInt64, RawUtf8(p^.VData));
         ftDouble:
@@ -687,7 +706,8 @@ begin
           'parameter #% of type %', [self, i, ToText(p^.VType)^]);
       end;
     end;
-    fPGParams[i] := pointer(p^.VData);
+    if (fPGParamFormats[i] <> 1) or (p^.VType = ftBlob) then
+      fPGParams[i] := pointer(p^.VData);
     inc(p);
   end;
 end;
@@ -714,6 +734,10 @@ end;
 
 procedure TSqlDBPostgresStatement.Prepare(
   const aSql: RawUtf8; ExpectResults: boolean);
+var
+  i: integer;
+  res: PPGresult;
+  c: TSqlDBPostgresConnection;
 begin
   // it is called once: already cached in TSqlDBConnection.NewStatementPrepared
   SqlLogBegin(sllDB);
@@ -725,8 +749,21 @@ begin
   begin
     // preparable statements will be cached server-side by index hexa as name
     include(fCache, scOnServer);
-    TSqlDBPostgresConnection(fConnection).PrepareCached(
-      fSqlPrepared, fPreparedParamsCount, fPreparedStmtName);
+    c := TSqlDBPostgresConnection(fConnection);
+    c.PrepareCached(fSqlPrepared, fPreparedParamsCount, fPreparedStmtName);
+    // get param types for possible binary binding
+    if fPreparedParamsCount > 0 then
+    begin
+      // allocate params in dynamic array
+      fParam.Count := fPreparedParamsCount;
+      res := PQ.DescribePrepared(c.fPGConn, pointer(fPreparedStmtName));
+      PQ.Check(c.fPGConn, 'DescribePrepared', res, nil, {forceClean=}false);
+      for i := 0 to fPreparedParamsCount - 1 do
+      begin
+        fParams[i].VDBType := PQ.ParamType(res, i);
+      end;
+      PQ.Clear(res);
+    end;
     SqlLogEnd(' c=%', [fPreparedStmtName]);
   end
   else


### PR DESCRIPTION
This MR break parameters logging, since I rewrite a p^.VInt64 value to be in htonl byte order as required by PG binary protocol. 
Can we extend a TSqlDBParam by adding VInt64BE, because comment below say don't to extend....  
```
// - don't change this structure, since it will be serialized as binary
  // for TSqlDBProxyConnectionCommandExecute
  TSqlDBParam = packed record
```   