### PR TITLE
Changed TServiceCustomStatus to record.

### DIFF
--- a/src/core/mormot.core.interfaces.pas
+++ b/src/core/mormot.core.interfaces.pas
@@ -503,7 +503,7 @@ type
     // - will handle vtPointer/vtClass/vtObject/vtVariant kind of arguments,
     // appending class name for any class or object, the hexa value for a
     // pointer, or the JSON representation of any supplied TDocVariant
-    constructor CreateUtf8WithStatus(const Format: RawUtf8; const Args: array of const; const Status: cardinal);
+    constructor CreateUWithStatus(const msg: RawUtf8; const Status: cardinal);
     /// the CustomStatus to return
     property Status: Cardinal read fStatus;
   end;
@@ -2634,10 +2634,10 @@ implementation
 
 { EInterfaceCustomStatus }
 
-constructor EInterfaceCustomStatus.CreateUtf8WithStatus(const Format: RawUtf8; const Args: array of const; const Status: cardinal);
+constructor EInterfaceCustomStatus.CreateUWithStatus(const msg: RawUtf8; const Status: cardinal);
 begin
   fStatus := Status;
-  inherited CreateUtf8(Format, Args);
+  inherited CreateU(msg);
 end;
 
 { ************ IInvokable Interface Methods and Parameters RTTI Extraction }
@@ -7589,7 +7589,7 @@ begin
         cs := fValues[fMethod^.ArgsResultIndex];
         fServiceCustomAnswerStatus := cs^.Status;
         if (fServiceCustomAnswerStatus >= HTTP_NOTFOUND) then
-          raise EInterfaceCustomStatus.CreateUtf8WithStatus(cs^.ErrorMessage, [], fServiceCustomAnswerStatus);
+          raise EInterfaceCustomStatus.CreateUWithStatus(ToUtf8(cs^.ErrorMessage), fServiceCustomAnswerStatus);
       end;
       // write the '{"result":[...' array or object
       opt[{smdVar=}false] := DEFAULT_WRITEOPTIONS[optDontStoreVoidJson in Options];

--- a/src/rest/mormot.rest.server.pas
+++ b/src/rest/mormot.rest.server.pas
@@ -7567,7 +7567,9 @@ begin
       on E: Exception do
         if (not Assigned(OnErrorUri)) or
            OnErrorUri(ctxt, E) then
-          if E.ClassType = EInterfaceFactory then
+          if E.ClassType = EInterfaceCustomStatus then
+            ctxt.Error(E, '', [], EInterfaceCustomStatus(e).Status)
+          else if E.ClassType = EInterfaceFactory then
             ctxt.Error(E, '', [], HTTP_NOTACCEPTABLE)
           else
             ctxt.Error(E, '', [], HTTP_SERVERERROR);


### PR DESCRIPTION
Now to clients no mormot we can receive HttpStatus code as return and body with
out parameters, case status code < HTTP_NOTFOUND
or Exception with custom message when status code >= HTTP_NOTFOUND

This changes fix problem of json return with last array item with statuscode too. some clients cannot recognize this json result

{
    "result": [
        {
            "RowID": 1,
            "Nome": "projeto ab",
            "DataCriacao": 1678706574,
            "UltimaAlteracao": 1678796824,
            "IdCriador": 5,
            "Paineis": []
        },
        0  <<<<<<<<<<<<<<<<<<<<
    ]
}
