### PR TITLE
Fix TZipRead unzip when DestDir has no end path delimiter

### DIFF
--- a/src/core/mormot.core.zip.pas
+++ b/src/core/mormot.core.zip.pas
@@ -2813,7 +2813,7 @@ begin
     if not SafeFileName(LocalZipName) then
       raise ESynZip.CreateUtf8('%.UnZip(%): unsafe file name ''%''',
         [self, fFileName, LocalZipName]);
-    Dest := EnsureDirectoryExists(DestDir + ExtractFilePath(LocalZipName));
+    Dest := EnsureDirectoryExists(EnsureDirectoryExists(DestDir) + ExtractFilePath(LocalZipName));
     if Dest = '' then
       exit;
     Dest := Dest + ExtractFileName(LocalZipName);


### PR DESCRIPTION
- Unzip('dir/file.txt', 'outdir') was extracting the file at 'outdirdir/file.txt' instead of 'outdir/dir/file.txt'