### PR TITLE
TAsyncConnections: allow direct access to the internal threads

### DIFF
--- a/src/net/mormot.net.async.pas
+++ b/src/net/mormot.net.async.pas
@@ -495,6 +495,8 @@ type
     Items: TAsyncConnectionDynArray;
   end;
 
+  TAsyncConnectionsThreads = array of TAsyncConnectionsThread;
+
   /// implements an abstract thread-pooled high-performance TCP clients or server
   // - internal TAsyncConnectionsSockets will handle high-performance process
   // of a high number of long-living simultaneous connections
@@ -509,7 +511,7 @@ type
     fConnectionClass: TAsyncConnectionClass;
     fConnection: TAsyncConnectionDynArray; // sorted by TAsyncConnection.Handle
     fClients: TAsyncConnectionsSockets;
-    fThreads: array of TAsyncConnectionsThread;
+    fThreads: TAsyncConnectionsThreads;
     fThreadReadPoll: TAsyncConnectionsThread;
     fConnectionCount: integer; // only subscribed - not just after accept()
     fConnectionHigh: integer;
@@ -650,6 +652,8 @@ type
     // - will WriteLock/block only on connection add/remove
     property ConnectionLock: TRWLock
       read fConnectionLock;
+    /// direct access to the internal AsyncConnectionsThread`s
+    property Threads: TAsyncConnectionsThreads read fThreads;
   published
     /// how many read threads there are in this thread pool
     property ThreadPoolCount: integer


### PR DESCRIPTION
This allow direct access to the internal AsyncConnectionsThread's.

I need it to verify idea for TFB test about set all threads of each server instance to the same CPU
So we will have 28 servers each with 8 threads, all 8 threads of server 0 is binds to the 0, all 8 threads for server 1 - to 1 core and so on

From my tests (on my server hardware) it's improve all tests a little, but json - for +15%! 