### PR TITLE
CPU pinning with limited CPUs support 

### DIFF
--- a/ex/techempower-bench/README.md
+++ b/ex/techempower-bench/README.md
@@ -37,15 +37,28 @@ Those two `.sql` scripts are located in this folder for convenience.
 
 ## Command line  parameters
 
-Working threads (per server), used CPU cores, and servers count can be specified in command line as such:
+Working threads (per server), servers count and CPU pinning can be specified in command line as such:
 ```
-$ raw threads cores servers
+$ raw [-s serversCount] [-t threadsPerServer] [-p] 
 ```
-Default values are computed at startup depending on the available CPU cores on the running system - trying to leverage the framework potential.
+Default values are computed at startup depending on the accessible (can be limited using `taskset`) CPU cores
+on the running system - trying to leverage the framework potential.
 
-Note that currently, the `cores` number is ignored.
+Example (consider total CPU count > 12):
+```shell
+# use all CPUs and default parameters
+./raw
 
-Depending on the hardware you have, you may consider using our [x86_64 Memory Manager](https://github.com/synopse/mORMot2/blob/master/src/core/mormot.core.fpcx64mm.pas) if your CPU has less than 8/16 cores, but would rather switch to [the libc Memory Manager](https://github.com/synopse/mORMot2/blob/master/src/core/mormot.core.fpclibcmm.pas) for high-end harware. On the TFB hardware, we enable the libc heap, which has lower performance with a few cores, but scales better when allocating small blocks with a high number of cores.
+# limit to first 6 CPUs and use default parameters
+taskset -c 0-5 ./raw
+
+# limit to first 6 CPUs, launch 6 servers with 4 threads for each without pinning servers to CPUs
+taskset -c 0-5 ./raw -s 6 -t 4
+```
+Depending on the hardware you have, you may consider using our [x86_64 Memory Manager](https://github.com/synopse/mORMot2/blob/master/src/core/mormot.core.fpcx64mm.pas)
+if your CPU has less than 8/16 cores, but would rather switch to [the libc Memory Manager](https://github.com/synopse/mORMot2/blob/master/src/core/mormot.core.fpclibcmm.pas)
+for high-end harware. On the TFB hardware, we enable the libc heap, which has lower performance with a few cores,
+but scales better when allocating small blocks with a high number of cores.
 
 ## Some Numbers
 

--- a/packages/lazarus/mormot2.pas
+++ b/packages/lazarus/mormot2.pas
@@ -8,7 +8,7 @@ unit mormot2;
 interface
 
 uses
-  mormot.app.console, mormot.app.daemon, mormot.app.agl, mormot.core.base, 
+  mormot.app.console, mormot.app.daemon, mormot.core.base, 
   mormot.core.buffers, mormot.core.collections, mormot.core.data, 
   mormot.core.datetime, mormot.core.fpcx64mm, mormot.core.interfaces, 
   mormot.core.json, mormot.core.log, mormot.core.mustache, mormot.core.os, 
@@ -28,7 +28,7 @@ uses
   mormot.lib.static, mormot.lib.winhttp, mormot.lib.z, mormot.net.async, 
   mormot.net.client, mormot.net.http, mormot.net.relay, mormot.net.rtsphttp, 
   mormot.net.server, mormot.net.sock, mormot.net.tunnel, mormot.net.ws.client, 
-  mormot.net.ws.core, mormot.net.ws.server, mormot.net.acme, mormot.orm.base, 
+  mormot.net.ws.core, mormot.net.ws.server, mormot.orm.base, 
   mormot.orm.client, mormot.orm.core, mormot.orm.mongodb, mormot.orm.rest, 
   mormot.orm.server, mormot.orm.sql, mormot.orm.sqlite3, mormot.orm.storage, 
   mormot.rest.client, mormot.rest.core, mormot.rest.http.client, 
@@ -36,10 +36,10 @@ uses
   mormot.rest.server, mormot.rest.sqlite3, mormot.script.core, 
   mormot.script.quickjs, mormot.soa.client, mormot.soa.codegen, 
   mormot.soa.core, mormot.soa.server, mormot.db.rad.ui, mormot.db.rad.ui.orm, 
-  mormot.db.rad.ui.sql, mormot.net.tftp.client, mormot.net.tftp.server,
-  mormot.lib.gdiplus, mormot.db.rad.ui.cds, mormot.core.os.mac,
-  mormot.misc.pecoff, mormot.lib.pkcs11, mormot.net.ldap, mormot.core.fpclibcmm,
-  mormot.net.dns, mormot.lib.win7zip;
+  mormot.db.rad.ui.sql, mormot.net.tftp.client, mormot.net.tftp.server, 
+  mormot.lib.gdiplus, mormot.net.acme, mormot.db.rad.ui.cds, 
+  mormot.core.os.mac, mormot.app.agl, mormot.misc.pecoff, mormot.lib.pkcs11, 
+  mormot.net.ldap, mormot.core.fpclibcmm, mormot.net.dns, mormot.lib.win7zip;
 
 implementation
 


### PR DESCRIPTION
- use accessible CPUs (can be limited by taskset) instead of available
- added named command line parameters for servers (-s), threads )-t) and CPU pinning (-p)
- added pinning servers to CPUs
- change rawupdates to use `update table set .. from values (), (), ... where id = id`