### PR TITLE
Fix infinite loop when using multiple times the same parameter

### DIFF
--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -7688,6 +7688,7 @@ begin
           @fNames[k][f], pointer(v[i]), length(v[i]), length(fNames[k]) - f);
         if result >= 0 then
         begin
+          Inc(Result, f);
           fRetrieved[k][result] := true;
           exit;
         end;


### PR DESCRIPTION
With a command line like this:
```sh
binary --parameter 0 --parameter 1
```

A call to `Get(['parameter'], utf8DynArray)` was creating an infinite loop