### PR TITLE
Fix TDynArray find with external index on small array

### DIFF
--- a/src/core/mormot.core.data.pas
+++ b/src/core/mormot.core.data.pas
@@ -7799,12 +7799,12 @@ begin
   if Assigned(aCompare) and
      (n > 0) then
   begin
-    dec(n);
     P := fValue^;
     if (n > 10) and
-       (length(aIndex) >= n) then
+       (length(aIndex) = n) then
     begin
       // fast O(log(n)) binary search over aIndex[]
+      dec(n);
       L := 0;
       repeat
         result := (L + n) shr 1;


### PR DESCRIPTION
Sorry, if I misunderstood something (just at the beginning with this beautiful framework),
but I believe there is an error in TDynArray.Find(with external index) on a small array. For brute force branch array length decremented incorrectly, so last item never compared and can not be found (unless only 1 item in array, then any searched item in array)

Test:

var
  A, Aidx: TIntegerDynArray;
  DA: TDynArray;
  i: integer;
begin
  DA.Init(TypeInfo(TIntegerDynArray), A);
  i := 1;
  DA.Add(i);
  DA.CreateOrderedIndex(Aidx,SortDynArrayInteger);
  i := 2;
  Check(DA.Find(i, Aidx, SortDynArrayInteger)=-1);  // fail, 2 in [1,]
  DA.Add(i);
  DA.CreateOrderedIndexAfterAdd(Aidx, SortDynArrayInteger);
  Check(DA.Find(i, Aidx, SortDynArrayInteger)>=0);  // fail, 2 not in [1,2,]
end;         