### PR TITLE
Added JSON:API media type to allow compression

### DIFF
--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -1041,10 +1041,11 @@ const
     'SVG',
     'X-ICO',
     nil);
-  _CONTENTAPP: array[0..3] of PUtf8Char = (
+  _CONTENTAPP: array[0..4] of PUtf8Char = (
     'JSON',
     'XML',
     'JAVASCRIPT',
+    'VND.API+JSON',
     nil);
 
 procedure CompressContent(Accepted: THttpSocketCompressSet;


### PR DESCRIPTION
As discussed in #203, here's the change to add the JSON:API media type "application/vnd.api+json" to the _CONTENTAPP array to allow compression