### PR TITLE
Fixed "Error parsing certificate request"

### DIFF
--- a/src/net/mormot.net.acme.pas
+++ b/src/net/mormot.net.acme.pas
@@ -868,8 +868,8 @@ var
 begin
   try
     // Generate a new PKCS#10 Certificate Signing Request
-    csr := fHttpClient.fCert.CertAlgo.CreateSelfSignedCsr(
-      fSubjects, aPrivateKeyPassword, pk);
+    csr := PemToDer(fHttpClient.fCert.CertAlgo.CreateSelfSignedCsr(
+      fSubjects, aPrivateKeyPassword, pk));
     // Before sending a POST request to the server, an ACME client needs to
     // have a fresh anti-replay nonce to put in the "nonce" header of the JWS
     fHttpClient.Head(fNewNonce);


### PR DESCRIPTION
After latest changes TCryptCertAlgo.CreateSelfSignedCsr returns CSR in PEM encoding:
TCryptCertAlgoOpenSsl.CreateSelfSignedCsr returns `result := req^.ToPem;`

But in previous version EVP_PKEY.CreateSelfSignedCsr returns `result := req^.ToBinary();`

So we need to add  PemToDer conversion.