### PR TITLE
Preallocation for text output parameters for Oracle SQL statements.

### DIFF
--- a/src/core/mormot.core.base.pas
+++ b/src/core/mormot.core.base.pas
@@ -110,6 +110,9 @@ const
   /// use rather CP_LATIN1 with mORMot 2
   CODEPAGE_LATIN1 = CP_LATIN1;
 
+  /// Maximum bytes for single UTF-8 char.
+  UTF8_CHAR_MAX_BYTES = 4;
+
 {$ifdef FPC} { make cross-compiler and cross-CPU types available to Delphi }
 
 type

--- a/src/db/mormot.db.raw.oracle.pas
+++ b/src/db/mormot.db.raw.oracle.pas
@@ -897,6 +897,8 @@ type
   public
     // the client verion numbers
     major_version, minor_version, update_num, patch_num, port_update_num: sword;
+    /// Maximum supported varchar string length
+    MaxVarCharLength: Integer;
     /// if OCI handles directly Int64 bound parameters (revision >= 11.2)
     SupportsInt64Params: boolean;
     /// OCI will call OCILobGetChunkSize when retrieving BLOB/CLOB content
@@ -1693,6 +1695,10 @@ begin
   SupportsInt64Params := (major_version > 11) or
                          ((major_version = 11) and
                           (minor_version > 1));
+  if major_version > 7 then
+    MaxVarCharLength := 4000
+  else
+    MaxVarCharLength := 2000;
   UseLobChunks := true; // by default
 end;
 

--- a/src/db/mormot.db.sql.oracle.pas
+++ b/src/db/mormot.db.sql.oracle.pas
@@ -1637,11 +1637,19 @@ begin
                       begin
 txt:                    VDBType := SQLT_STR; // use STR external data type (SQLT_LVC fails)
                         oLength := Length(VData) + 1; // include #0
+                        L := OCI.MaxVarCharLength * UTF8_CHAR_MAX_BYTES;
+                          // input text pre-allocation for OUT param
+                        if (VInOut in [paramOut, paramInOut]) and (oLength < L) then
+                        begin
+                          SetLength(VData, L);
+                          if VInOut = paramInOut then
+                            VData[oLength] := #0;
+                          oLength := L + 1;
+                        end;
                         if oLength = 1 then // '' will just map one #0
                           oData := @VData
                         else
                           oData := pointer(VData);
-                        // for OUT param, input text shall be pre-allocated
                       end;
                     ftBlob:
                       if VInOut <> paramIn then


### PR DESCRIPTION
Changes according to the mORMot forums topic: https://synopse.info/forum/viewtopic.php?id=6402 for mORMot 2.