### PR TITLE
Pass optional UserName&Password params to Service Install

### DIFF
--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -4892,7 +4892,8 @@ type
     /// wrapper around CreateNewService() to install the current executable as service
     class function Install(const Name, DisplayName, Description: RawUtf8;
       AutoStart: boolean; ExeName: TFileName = '';
-      const Dependencies: RawUtf8 = ''): TServiceState;
+      const Dependencies: RawUtf8 = ''; const UserName: RawUtf8 = '';
+      const Password: RawUtf8 = ''): TServiceState;
     /// wrapper around CreateOpenService(SERVICE_QUERY_STATUS) and GetState
     class function CurrentState(const Name: RawUtf8): TServiceState;
     /// open an existing service, in order to control it or its configuration

--- a/src/core/mormot.core.os.windows.inc
+++ b/src/core/mormot.core.os.windows.inc
@@ -4003,7 +4003,7 @@ end;
 
 class function TServiceController.Install(
   const Name, DisplayName, Description: RawUtf8; AutoStart: boolean;
-  ExeName: TFileName; const Dependencies: RawUtf8): TServiceState;
+  ExeName: TFileName; const Dependencies: RawUtf8;const Username: RawUtf8; const Password: RawUtf8): TServiceState;
 var
   ctrl: TServiceController;
   start: cardinal;
@@ -4015,7 +4015,7 @@ begin
   if ExeName = '' then
     ExeName := Executable.ProgramFileName;
   ctrl := TServiceController.CreateNewService(
-    '', '', Name, DisplayName, ExeName, '', Dependencies, '', '',
+    '', '', Name, DisplayName, ExeName, '', Dependencies, UserName, Password,
     SERVICE_ALL_ACCESS, SERVICE_WIN32_OWN_PROCESS, start);
   try
     result := ctrl.State;


### PR DESCRIPTION
Small change, default const params for Username and Password provide full backward-compatibility.