### PR TITLE
Fixed critical rtti cache bug

### DIFF
--- a/src/core/mormot.core.rtti.pas
+++ b/src/core/mormot.core.rtti.pas
@@ -786,7 +786,7 @@ type
     procedure Copy(Dest, Source: pointer);
       {$ifdef HASSAFEINLINE}inline;{$endif}
     /// compute extended information about this RTTI type
-    procedure ComputeCache(out Cache: TRttiCache);
+    procedure ComputeCache(var Cache: TRttiCache);
     /// for ordinal types, get the storage size and sign
     function RttiOrd: TRttiOrd;
       {$ifdef HASSAFEINLINE}inline;{$endif}
@@ -3571,7 +3571,7 @@ var
   // - rkChar,rkWChar,rkSString converted into temporary RawUtf8 as varUnknown
   RTTI_TO_VARTYPE: array[TRttiKind] of word;
 
-procedure TRttiInfo.ComputeCache(out Cache: TRttiCache);
+procedure TRttiInfo.ComputeCache(var Cache: TRttiCache);
 var
   enum: PRttiEnumType;
   siz, cnt: PtrInt;


### PR DESCRIPTION
bug present in stable, trunk.

TRttiInfo.ComputeCache method assumes Cache parameter will be zeroed out by caller but this is not true because of usage of out prefix which discards initial value. The method does not correctly initialize Cache structure therefor it contains whatever garbage is currently on the stack. The only time out parameter would "work" is if Cache would contain another managed type field which would force the compiler to initialize the structure on method entry.

Fix by using var prefix so that Cache is passed as reference. To be honest because of importance of this method in RTTI generation I would not leave it up to the caller to correctly initialize the Cache record. I would still use out parameter but the first line should be `Default(Cache);` so that it zeroes out the structure.

See following example

```
program test;

{$I mormot.defines.inc}
uses // >
 {$I mormot.uses.inc}
  mormot.core.base,
  mormot.core.os,
  mormot.core.log,
  mormot.core.Text,
  mormot.orm.core,
  mormot.rest.sqlite3,
  mormot.DB.raw.sqlite3.static;

type
  TOrmTest = class(TOrm)
  private
    FName: RawUTF8;
  published
    property Name: RawUTF8 read FName write FName stored False;
  end;

var
  LModel: TOrmModel;
  FDB: TRestServerDB;
  LTest: TOrmTest;
begin
  LModel := TOrmModel.Create([TOrmTest], 'test');
  FDB := TRestServerDB.Create(LModel, 'test.db');
  LModel.Owner := FDB;
  FDB.Server.CreateMissingTables;
  try
    LTest := TOrmTest.Create;
    try
      LTest.Name := 'test';
      while FDB.Orm.Add(LTest, True) <> 0 do ;
    finally
      LTest.Free;
    end;
  finally
    FDB.Free;
  end;

end.
```
Because of Unique constraint on property "Name", Sqlite returns error if already exists in table.
This kicks off the following events
```
  raise DB exception
     serialize exception into json
        generate first time rtti for exception
           > incorrectly initializes property Cache flags with stack garbage
               causes json serialization EAccessViolation because of wrong assumption
               (for example Cache flag can contain rttiHasOrd flag despite being a string property,
               causes incorrect assignment of DEFAULT parameter (0 but should be NO_DEFAULT),
               the code then trips itself on invalid function call because it assumes ordinal get&setter)
```
