### PR TITLE
Fix compile errors if NOLIBCSTATIC is defined

### DIFF
--- a/src/lib/mormot.lib.quickjs.pas
+++ b/src/lib/mormot.lib.quickjs.pas
@@ -3623,7 +3623,9 @@ end;
 
 
 initialization
+  {$IfNDef NOLIBCSTATIC}
   SetLibcNumericLocale; // required for quickjs parsing :(
+  {$EndIf}
   assert(SizeOf(JSValueRaw) = SizeOf(JSValue));
   {$ifdef JS_ANY_NAN_BOXING}
   assert(SizeOf(JSValueRaw) = SizeOf(double));

--- a/src/lib/mormot.lib.static.pas
+++ b/src/lib/mormot.lib.static.pas
@@ -2112,6 +2112,7 @@ end;
 initialization
 {$ifdef FPC}
 {$ifdef OSWINDOWS}
+{$IfNDef NOLIBCSTATIC}
   // manual fill of our raw mingw import table
   beginthreadex := @libc_beginthreadex;
   endthreadex := @libc_endthreadex;
@@ -2120,6 +2121,7 @@ initialization
   {$else}
   imp_localtime64 := @localtime64;
   {$endif CPU32}
+{$EndIf}
 {$endif OSWINDOWS}
 {$ifdef OSLINUXX64}
   _pthread_load;


### PR DESCRIPTION
After some testing related to https://synopse.info/forum/viewtopic.php?id=6767

I decided to use `NOLIBCSTATIC,` and some code needed to be wrapped with `NOLIBCSTATIC`.