### PR TITLE
RFC 9239

### DIFF
--- a/src/core/mormot.core.buffers.pas
+++ b/src/core/mormot.core.buffers.pas
@@ -8681,20 +8681,20 @@ begin
 end;
 
 const
-  MIME_EXT: array[0..45] of PUtf8Char = ( // for IdemPPChar() start check
+  MIME_EXT: array[0..46] of PUtf8Char = ( // for IdemPPChar() start check
     'PNG',  'GIF',  'TIF',  'JP',  'BMP', 'DOC',  'HTM',  'CSS',
     'JSON', 'ICO',  'WOF', 'TXT', 'SVG',  'ATOM', 'RDF', 'RSS',
-    'WEBP', 'APPC', 'MANI', 'XML', 'JS',  'WOFF', 'OGG',
+    'WEBP', 'APPC', 'MANI', 'XML', 'JS',  'MJS',  'WOFF', 'OGG',
     'OGV',  'MP4',  'M2V',  'M2P', 'MP3', 'H264', 'TEXT', 'LOG',
     'GZ',  'WEBM', 'MKV',  'RAR',  '7Z',  'BZ2', 'WMA',  'WMV',
     'AVI', 'PPT',  'XLS',  'PDF',  'SQLITE', 'DB3', nil);
   MIME_EXT_TYPE: array[0 .. high(MIME_EXT) - 1] of TMimeType = (
     mtPng,  mtGif,  mtTiff,  mtJpg,  mtBmp,  mtDoc,  mtHtml, mtCss,
     mtJson, mtXIcon, mtFont, mtText, mtSvg,  mtXml,  mtXml,  mtXml,
-    mtWebp, mtManifest, mtManifest,  mtXml,  mtJS,   mtFont, mtOgg,
-    mtOgg,  mtMp4,  mtMp2,   mtMp2,  mtMpeg, mtH264, mtText, mtText,
-    mtGzip, mtWebm, mtWebm,  mtRar,  mt7z,   mtBz2,  mtWma,  mtWmv,
-    mtAvi,  mtPpt,  mtXls,  mtPdf,   mtSQlite3, mtSQlite3);
+    mtWebp, mtManifest, mtManifest,  mtXml,  mtJS,   mtJS,   mtFont,
+    mtOgg,  mtOgg,  mtMp4,  mtMp2,   mtMp2,  mtMpeg, mtH264, mtText,
+    mtText, mtGzip, mtWebm, mtWebm,  mtRar,  mt7z,   mtBz2,  mtWma,
+    mtWmv,  mtAvi,  mtPpt,  mtXls,  mtPdf,   mtSQlite3, mtSQlite3);
 
 function GetMimeTypeFromExt(const Ext: RawUtf8): TMimeType;
 var

--- a/src/core/mormot.core.buffers.pas
+++ b/src/core/mormot.core.buffers.pas
@@ -1739,7 +1739,7 @@ const
     'text/css',                      // mtCss
     'application/javascript',        // mtJS
     'image/x-icon',                  // mtXIcon
-    'application/font-woff',         // mtFont
+    'text/font-woff',         // mtFont
     TEXT_CONTENT_TYPE,               // mtText
     'image/svg+xml',                 // mtSvg
     XML_CONTENT_TYPE,                // mtXml


### PR DESCRIPTION
Two changes according to RFC 9239

* "text/javascript" as mime content type for JS-files, "application/javascript" is defined as obsolete
* MJS-filetype to be handled like JS-filetype

https://datatracker.ietf.org/doc/html/rfc9239
https://www.rfc-editor.org/rfc/rfc9239
