### PR TITLE
Fix UrlDecodeInt64

### DIFF
--- a/src/core/mormot.core.buffers.pas
+++ b/src/core/mormot.core.buffers.pas
@@ -8508,11 +8508,11 @@ begin
     inc(U, length(Upper));
     if U^ = '-' then
     begin
-      sign := 1;
+      sign := -1;
       inc(U);
     end
     else
-      sign := -1;
+      sign := 1;
     if U^ in ['0'..'9'] then
     begin
       v := 0;


### PR DESCRIPTION
The changes in this commit https://github.com/synopse/mORMot2/commit/c27ec5dc547f9ef0b48e3b24aeaa285051f5afd1

Introduced a bug in UrlDecodeInt64, which returns the opposite sign of a value.