### PR TITLE
mormot: reintroduced dropped DrawAntiAliased() for mormot2

### DIFF
--- a/src/lib/mormot.lib.gdiplus.pas
+++ b/src/lib/mormot.lib.gdiplus.pas
@@ -605,11 +605,16 @@ function ConvertToEmfPlus(Source: HENHMETAFILE; Width, Height: integer;
 
 /// draw an EMF metafile handle using GDI+ anti-aliased rendering
 // - will fallback to plain GDI drawing if GDI+ is not available
-// - this procedure is thread-safe (protected by Gdip.Lock/UnLock)
+// - these procedures are thread-safe (protected by Gdip.Lock/UnLock)
 procedure DrawAntiAliased(Source: HENHMETAFILE; Width, Height: integer;
   Dest: HDC; DestRect: TRect; ConvertOptions: TEmfConvertOptions = [];
   Smoothing: TSmoothingMode = smAntiAlias;
   TextRendering: TTextRenderingHint = trhClearTypeGridFit); overload;
+procedure DrawAntiAliased(Source: HENHMETAFILE; SourceRect: TRect;
+  Dest: HDC; DestRect: TRect; ConvertOptions: TEmfConvertOptions = [];
+  Smoothing: TSmoothingMode = smAntiAlias;
+  TextRendering: TTextRenderingHint = trhClearTypeGridFit;
+  u: TUnit=uPixel; attributes: TImageAttributes=nil); overload;
 
 /// low-level internal function used e.g. by ConvertToEmfPlus()
 function MetaFileToIStream(Source: HENHMETAFILE): IStream;
@@ -2100,6 +2105,49 @@ begin
       try
         with DestRect do
           _Gdip.DrawImageRect(gr, img, Left, Top, Right - Left, Bottom - Top);
+      finally
+        _Gdip.DeleteGraphics(gr);
+      end;
+    finally
+      _Gdip.DisposeImage(img);
+      _Gdip.UnLock;
+    end;
+end;
+
+procedure DrawAntiAliased(Source: HENHMETAFILE; SourceRect: TRect;
+  Dest: HDC; DestRect: TRect; ConvertOptions: TEmfConvertOptions;
+  Smoothing: TSmoothingMode; TextRendering: TTextRenderingHint;
+  u: TUnit; attributes: TImageAttributes);
+var
+  img, gr: THandle;
+  ia: TGpipImageAttributes;
+begin
+  with SourceRect do
+    img := ConvertToEmfPlus(
+        Source, Right - Left, Bottom - Top, Dest, ConvertOptions, Smoothing, TextRendering);
+  if img = 0 then
+  begin
+    // GDI Metafile rect includes right and bottom coords
+    dec(DestRect.Right);
+    dec(DestRect.Bottom);
+    // fallback to regular GDI drawing if GDI+ is not available
+    PlayEnhMetaFile(Dest, Source, DestRect);
+  end
+  else
+    if Assigned(attributes) then
+      ia:= attributes.Attr
+    else
+      ia:= nil;
+    try
+      // use GDI+ 1.0/1.1 anti-aliased rendering
+      _Gdip.Lock;
+      _Gdip.CreateFromHDC(Dest, gr);
+      try
+        with DestRect do
+          _Gdip.DrawImageRectRect(gr, img,
+             DestRect.Left, DestRect.Top, DestRect.Right - DestRect.Left, DestRect.Bottom - DestRect.Top,
+             SourceRect.Left, SourceRect.Top, SourceRect.Right - SourceRect.Left, SourceRect.Bottom - SourceRect.Top,
+             u, ia);
       finally
         _Gdip.DeleteGraphics(gr);
       end;

--- a/src/ui/mormot.ui.gdiplus.pas
+++ b/src/ui/mormot.ui.gdiplus.pas
@@ -212,10 +212,15 @@ procedure RegisterSynPictures;
 
 /// draw an EMF TMetaFile using GDI+ anti-aliased rendering
 // - will fallback to plain GDI drawing if GDI+ is not available
-// - this procedure is thread-safe (protected by Gdip.Lock/UnLock)
+// - these procedures are thread-safe (protected by Gdip.Lock/UnLock)
 procedure DrawAntiAliased(Source: TMetafile; Dest: HDC; const DestRect: TRect;
   ConvertOptions: TEmfConvertOptions = []; Smoothing: TSmoothingMode = smAntiAlias;
   TextRendering: TTextRenderingHint = trhClearTypeGridFit); overload;
+procedure DrawAntiAliased(Source: TMetafile; const SourceRect: TRect;
+  Dest: HDC; const DestRect: TRect;
+  ConvertOptions: TEmfConvertOptions = []; Smoothing: TSmoothingMode = smAntiAlias;
+  TextRendering: TTextRenderingHint = trhClearTypeGridFit;
+  u: TUnit=uPixel; attributes: TImageAttributes=nil); overload;
 
 /// draw the corresponding EMF metafile into a bitmap created by the method
 // - this default TGdiplus implementation uses GDI drawing only
@@ -994,6 +999,16 @@ procedure DrawAntiAliased(Source: TMetafile; Dest: HDC; const DestRect: TRect;
 begin
   DrawAntiAliased(Source.Handle, Source.Width, Source.Height, Dest, DestRect,
     ConvertOptions, Smoothing, TextRendering);
+end;
+
+procedure DrawAntiAliased(Source: TMetafile; const SourceRect: TRect;
+  Dest: HDC; const DestRect: TRect;
+  ConvertOptions: TEmfConvertOptions; Smoothing: TSmoothingMode;
+  TextRendering: TTextRenderingHint;
+  u: TUnit; attributes: TImageAttributes);
+begin
+  DrawAntiAliased(Source.Handle, SourceRect, Dest, DestRect,
+    ConvertOptions, Smoothing, TextRendering, u, attributes);
 end;
 
 function DrawAntiAliased(Source: TMetafile; ScaleX, ScaleY: integer;


### PR DESCRIPTION
See a455fd3e "SynGdiPlus: add support for image attributes" on the v1 repo.