### PR TITLE
mormot: fix off-by-one in FindNameValue()

### DIFF
--- a/src/core/mormot.core.unicode.pas
+++ b/src/core/mormot.core.unicode.pas
@@ -8217,7 +8217,10 @@ eol:      if P^ <= #13 then
           break; // handle next line
         end
         else if P^ <> #0 then
+        begin
+          inc(p);
           continue; // e.g. #9
+        end;
 eof:    result := nil; // reached P^=#0 -> not found
         exit;
       until false


### PR DESCRIPTION
This patch is a bit dated and I forgot the details how I ran into the issue :\
It probably was a tab?
Hopefully the fix is obvious to the reviewer ;)