### PR TITLE
Can cause exception when setting the counter

### DIFF
--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -7395,7 +7395,9 @@ begin
   // fast cross-platform implementation
   folder := GetSystemPath(spTemp);
   if _TmpCounter = 0 then
-    _TmpCounter := Random32;
+    repeat
+      _TmpCounter := integer(Random32);
+    until _TmpCounter>0;
   retry := 10;
   repeat
     // thread-safe unique file name generation

--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -7395,9 +7395,7 @@ begin
   // fast cross-platform implementation
   folder := GetSystemPath(spTemp);
   if _TmpCounter = 0 then
-    repeat
-      _TmpCounter := integer(Random32);
-    until _TmpCounter>0;
+      _TmpCounter := Random31;
   retry := 10;
   repeat
     // thread-safe unique file name generation


### PR DESCRIPTION
Random32 returns cardinal and this can cause overflow to a 32bit integer _TmpCounter.