### PR TITLE
Bugfix: lacking a begin..end block

### DIFF
--- a/src/db/mormot.db.sql.odbc.pas
+++ b/src/db/mormot.db.sql.odbc.pas
@@ -6,7 +6,7 @@ unit mormot.db.sql.odbc;
 {
   *****************************************************************************
 
-   Efficient SQL Database Connection via ODBC 
+   Efficient SQL Database Connection via ODBC
     -  TSqlDBOdbcConnection* and TSqlDBOdbcStatement Classes
 
   *****************************************************************************
@@ -29,6 +29,7 @@ uses
   mormot.core.json,
   mormot.core.perf,
   mormot.core.log,
+  {$ifdef HASINLINE} mormot.core.rtti, {$endif}
   mormot.db.core,
   mormot.db.sql;
 

--- a/src/lib/mormot.lib.gdiplus.pas
+++ b/src/lib/mormot.lib.gdiplus.pas
@@ -2138,17 +2138,18 @@ begin
     PlayEnhMetaFile(Dest, Source, DestRect);
   end
   else
-    if Assigned(attributes) then
-      ia := attributes.Attr
-    else
-      ia := nil;
+  begin
     try
+      if Assigned(attributes) then
+        ia := attributes.Attr
+      else
+        ia := nil;
       // use GDI+ 1.0/1.1 anti-aliased rendering
       _Gdip.Lock;
       _Gdip.CreateFromHDC(Dest, gr);
       try
         with DestRect do
-          _Gdip.DrawImageRectRect(gr, img, DestRect.Left, DestRect.Top, 
+          _Gdip.DrawImageRectRect(gr, img, DestRect.Left, DestRect.Top,
              DestRect.Right - DestRect.Left, DestRect.Bottom - DestRect.Top,
              SourceRect.Left, SourceRect.Top, SourceRect.Right - SourceRect.Left,
              SourceRect.Bottom - SourceRect.Top, u, ia);
@@ -2159,6 +2160,7 @@ begin
       _Gdip.DisposeImage(img);
       _Gdip.UnLock;
     end;
+  end;
 end;
 
 {$endif OSPOSIX}


### PR DESCRIPTION
The indentation hints the else block should be one statement, but there are two. Compiling in Delphi 12 it shows a hint there