### PR TITLE
sqlite3: fix Delphi 64-bit compilation error

### DIFF
--- a/src/db/mormot.db.raw.sqlite3.static.pas
+++ b/src/db/mormot.db.raw.sqlite3.static.pas
@@ -393,6 +393,8 @@ begin // needed since 3.46.1
   result := p;
 end;
 
+{$endif CPU32}
+
 function memchr(p: pointer; chr: byte; n: PtrInt): PAnsiChar; cdecl;
 var
   i: PtrInt;
@@ -407,7 +409,6 @@ begin // needed since 3.46.1
     result := nil; // not found
 end;
 
-{$endif CPU32}
 
 {$endif OSWINDOWS}
 


### PR DESCRIPTION
The `memchr` function directive was misaligned with the 64-bit configuration, leading to an unsatisfied forward or external declaration error. (temporary fix #306)