### PR TITLE
Fix t service container server.remove fake callback on connection close av exception

### DIFF
--- a/src/soa/mormot.soa.server.pas
+++ b/src/soa/mormot.soa.server.pas
@@ -2001,7 +2001,7 @@ begin
       fake := pointer(fFakeCallbacks.List);
       for i := 1 to fFakeCallbacks.Count do
       begin
-        if (fake^ <> nil) and (fake^.fLowLevelConnectionID = aConnectionID) and
+        if (fake^.fLowLevelConnectionID = aConnectionID) and
            not fake^.fReleasedOnClientSide then
           RemoveFakeCallback(fake^, ctxt);
         inc(fake);

--- a/src/soa/mormot.soa.server.pas
+++ b/src/soa/mormot.soa.server.pas
@@ -2001,7 +2001,7 @@ begin
       fake := pointer(fFakeCallbacks.List);
       for i := 1 to fFakeCallbacks.Count do
       begin
-        if (fake^.fLowLevelConnectionID = aConnectionID) and
+        if (fake^<>nil) and (fake^.fLowLevelConnectionID = aConnectionID) and
            not fake^.fReleasedOnClientSide then
           RemoveFakeCallback(fake^, ctxt);
         inc(fake);

--- a/src/soa/mormot.soa.server.pas
+++ b/src/soa/mormot.soa.server.pas
@@ -2001,7 +2001,7 @@ begin
       fake := pointer(fFakeCallbacks.List);
       for i := 1 to fFakeCallbacks.Count do
       begin
-        if (fake^.fLowLevelConnectionID = aConnectionID) and
+        if (fake^ <> nil) and (fake^.fLowLevelConnectionID = aConnectionID) and
            not fake^.fReleasedOnClientSide then
           RemoveFakeCallback(fake^, ctxt);
         inc(fake);


### PR DESCRIPTION
Avoid fake^ = nil causing AV exceptions when the Client is interrupted abnormally, such as the Client process being killed.

How to reproduce:

Using Project31ChatServer and Client to test.

1. Start the Server
2. Start 4 Clients
3. Enter their respective Names, such as 1, 2, 3, 4
4. Close Client 2 and 3, directly click the X in the upper right corner of console windows, or directly press Ctrl-C
5. An exception will occur on the server side, fake^=nil