### PR TITLE
Fix undefined Win32DotNetExceptions when using NOEXCEPTIONINTERCEPT

### DIFF
--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -4007,8 +4007,10 @@ function Utf8ToWin32PWideChar(const u: RawUtf8; var d: TSynTempBuffer): PWideCha
 // - as used internally by Utf8ToConsole()
 function Win32Utf8ToAnsi(P: pointer; L, CP: integer; var A: RawByteString): boolean;
 
+{$IfNDef NOEXCEPTIONINTERCEPT}
 /// get DotNet exception class names from HRESULT - published for testing purpose
 procedure Win32DotNetExceptions(code: cardinal; var names: TPShortStringDynArray);
+{$EndIf}
 
 /// ask the Operating System to convert a file URL to a local file path
 // - only Windows has a such a PathCreateFromUrlW() API


### PR DESCRIPTION
Fix for undefined declaration for 'Win32DotNetExceptions' when using "NOEXCEPTIONINTERCEPT"