### PR TITLE
Fix compiling error when NOEXCEPTIONINTERCEPT is used

### DIFF
--- a/src/core/mormot.core.log.pas
+++ b/src/core/mormot.core.log.pas
@@ -4616,7 +4616,9 @@ begin
       exit;
     // reset the current thread context
     nfo^.Index := 0;
+    {$ifndef NOEXCEPTIONINTERCEPT}
     nfo^.ExceptionIgnore := false;
+    {$endif NOEXCEPTIONINTERCEPT}
     ctx := @fThreadContexts[ndx - 1];
     Finalize(ctx^);
     FillcharFast(ctx^, SizeOf(ctx^), 0);
@@ -7941,7 +7943,9 @@ procedure FinalizeUnit;
 var
   files: TSynLogDynArray; // thread-safe local copy
 begin
+  {$ifndef NOEXCEPTIONINTERCEPT}
   HandleExceptionFamily := nil; // disable exception interception
+  {$endif NOEXCEPTIONINTERCEPT}
   SynLogFileFreeing := true;    // to avoid GPF at shutdown
   mormot.core.os.EnterCriticalSection(GlobalThreadLock);
   files := SynLogFile;


### PR DESCRIPTION
Hello @synopse 

The latest update to the core.log has some forgotten unwrapped code for NOEXC

like

https://github.com/synopse/mORMot2/blob/dd4376c74344820c20567a2acfa2b8a6f07407e3/src/core/mormot.core.log.pas#L4161

https://github.com/synopse/mORMot2/blob/dd4376c74344820c20567a2acfa2b8a6f07407e3/src/core/mormot.core.log.pas#L4619