### PR TITLE
Fix: TWrapperContext.ContextNestedProperties crashes when being used with `packed record` with an array of AnsiChar

### DIFF
--- a/src/soa/mormot.soa.codegen.pas
+++ b/src/soa/mormot.soa.codegen.pas
@@ -661,9 +661,22 @@ begin
     exit; // no nested properties
   end;
   TDocVariant.NewFast(result);
-  for i := 0 to rtti.Props.Count - 1 do
-    TDocVariantData(result).AddItem(
-      ContextOneProperty(rtti.Props.List[i], parentName));
+
+  { rtti may be nil, if "rtti := rtti.ArrayRtti" was executed above
+    for an array inside a record defined like this:
+
+    type
+      TMyRecord =
+        packed record
+          SomeUnimportantData1: Integer;
+          SomeUnimportantData2: Integer;
+          Res          : array [1..66] of AnsiChar;
+        end;
+  }
+  if rtti <> nil then
+    for i := 0 to rtti.Props.Count - 1 do
+      TDocVariantData(result).AddItem(
+        ContextOneProperty(rtti.Props.List[i], parentName));
 end;
 
 function ClassToWrapperType(c: TClass): TWrapperType;


### PR DESCRIPTION
Using a record like this:

```delphi
type
  TMyRecord =
    packed record
      SomeUnimportantData1: Integer;
      SomeUnimportantData2: Integer;
      Res: array [1..66] of AnsiChar;
    end;
```

... crashes in `TWrapperContext.ContextNestedProperties`, when it's called from `TRestServerUriContext.ExecuteSoaByMethod`.

Looking at the code,

- the `rtti := rtti.ArrayRtti` is executed for  `TMyRecord.Res` field,
- but the `rtti.ArrayRtti` given (by Delphi 12.1) is `nil`.
- So the code crashes when it tries to access `rtti.Props.Count`, since `rtti` is `nil`.

I made a simple fix that does solve the issue in our case.

It seems it's a regression caused by https://github.com/synopse/mORMot2/commit/8047afbf24d57ce20ee9143811045f2687c62f31 , which added using `ArrayRtti`? Old versions of mORMot (from ~2 years ago) don't have this issue.

We don't have a simple testcase to reproduce the crash at this point -- let me know if this enough for you to go on :)
