### PR TITLE
ldap: Fixed delete children in non-leaf objects

### DIFF
--- a/src/net/mormot.net.ldap.pas
+++ b/src/net/mormot.net.ldap.pas
@@ -7062,7 +7062,7 @@ begin
     // Obj had children and DeleteChildren is True
     try
       SearchScope := lssSingleLevel;
-      Search([], Obj);
+      Search([], '', Obj);
       children := fSearchResult.ObjectNames;
       for i := 0 to high(children) do
         if not Delete(children[i], {DeleteChildren=}true) then


### PR DESCRIPTION
This Pull Requests contains modification to mormot.net.ldap. It fixes the delete method of TLdapClient. With the deleteChildren parameter to true, children of an object wasn't retrieved due to missplaced argument in search method (placed in filter parameter instead of baseDN). Fixed by adding an empty filter, then the baseDN.