### PR TITLE
Fix declaration of GetJpegSize() which is called in a wrong parameter order

### DIFF
--- a/src/core/mormot.core.buffers.pas
+++ b/src/core/mormot.core.buffers.pas
@@ -1871,7 +1871,7 @@ function IsContentTypeJsonU(const ContentType: RawUtf8): boolean;
 // positive recognition, and no waranty that the memory buffer is a valid JPEG
 // - returns FALSE if the buffer does not have any expected SOI/SOF markers
 function GetJpegSize(jpeg: PAnsiChar; len: PtrInt;
-  out Height, Width, Bits: integer): boolean; overload;
+  out Width, Height, Bits: integer): boolean; overload;
 
 
 { ************* Text Memory Buffers and Files }
@@ -9026,7 +9026,7 @@ begin
 end;
 
 function GetJpegSize(jpeg: PAnsiChar; len: PtrInt;
-  out Height, Width, Bits: integer): boolean;
+  out Width, Height, Bits: integer): boolean;
 var
   je: PAnsiChar;
 begin


### PR DESCRIPTION
This fix restores the PDF image embedding which is currently called in a wrong parameter order where `width` and `height` are switched.

In `TPdfImage.CreateJpegDirect()`:
```pas
if not GetJpegSize(aJpegFile.Memory, len, fPixelWidth, fPixelHeight, bits) then
```

but the function is declared as:
```pas
function GetJpegSize(jpeg: PAnsiChar; len: PtrInt; out Height, Width, Bits: integer)
```

The function declaration should be fixed as the order in the old mormot `SynPDF` unit was also `width` before `height` which also is the typical order of those parameters.