### PR TITLE
Update mormot.crypt.core.pas

### DIFF
--- a/src/crypt/mormot.crypt.core.pas
+++ b/src/crypt/mormot.crypt.core.pas
@@ -4286,6 +4286,7 @@ function TAes.DecryptInitFrom(const Encryption: TAes;
 var
   ctx: TAesContext absolute Context;
 begin
+  ctx.Flags := [];
   if not (aesInitialized in TAesContext(Encryption).Flags) then
     // e.g. called from DecryptInit()
     EncryptInit(Key, KeySize)
@@ -11530,3 +11531,4 @@ finalization
   FinalizeUnit;
 
 end.
+


### PR DESCRIPTION
under Win64/Delphi 10.4 with current mORMot2 AESSHA256Full (decrypt) results in av
  by call of MoveFast(Encryption, self, SizeOf(TAes)); //line 4294 in mormon.crypt.core.pas
  in mormot.core.base.asmx64.inc (MoveFast line 395).
With revision 9f99b38beac50b425f46420aec27a93f5d109f42 from 2025-05-13 it was still working.