### PR TITLE
ldap: clear `TLdapClient.fNetbiosDN` on reset connection

### DIFF
--- a/src/net/mormot.net.ldap.pas
+++ b/src/net/mormot.net.ldap.pas
@@ -6668,6 +6668,7 @@ begin
     fRootDN := '';
     fDefaultDN := '';
     fConfigDN := '';
+    fNetbiosDN := '';
   end;
 end;
 


### PR DESCRIPTION
On changing the TLdapClient instance connection, the fNetBiosDN from the first instance is keeped in TLdapClient instance. It should be removed to ensure the correct fNetBiosDN is retrieve in the Active Directory