### PR TITLE
doc: add DeepWiki badge for AI-powered documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Thanks to all [Contributors](CONTRIBUTORS.md)!
 
 **NOTICE: This version 2 replaces [*mORMot 1.18*](https://github.com/synopse/mORMot) which is now in maintainance-only mode. Consider using *mORMot 2* for any new or maintainable project.**
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/synopse/mORMot2)
+
 ## Resources
 
 You can find more about *mORMot 2* in:


### PR DESCRIPTION
## Summary
- Add DeepWiki badge to README.md for AI-assisted documentation lookup

## Why
DeepWiki provides AI-powered documentation search, helping developers quickly find relevant information about mORMot2. This embraces modern AI tools to improve developer experience.

## Changes
- Added DeepWiki badge linking to https://deepwiki.com/synopse/mORMot2