### PR TITLE
Fix: H2443 Inline function 'TJsonWriter.AddAnsiString' has not been e…

### DIFF
--- a/src/db/mormot.db.rad.ui.pas
+++ b/src/db/mormot.db.rad.ui.pas
@@ -30,6 +30,7 @@ uses
   mormot.core.rtti,
   mormot.core.data,
   mormot.core.variants,
+  mormot.core.json,
   mormot.db.core,
   mormot.db.rad,
   {$ifdef ISDELPHIXE2}


### PR DESCRIPTION
…xpanded because unit 'mormot.core.json' is not specified in USES list