### PR TITLE
THttpAsyncServer: fix HTTPS responses >64KB hanging on Windows IOCP+TLS

### DIFF
--- a/src/lib/mormot.lib.openssl11.pas
+++ b/src/lib/mormot.lib.openssl11.pas
@@ -11322,6 +11322,12 @@ begin
     if BoundContext.AcceptCert = nil then
       raise EOpenSslNetTls.Create('AfterAccept: missing AfterBind');
     fSsl := SSL_new(BoundContext.AcceptCert);
+    // SSL_MODE_ENABLE_PARTIAL_WRITE ($01): SSL_write returns partial count on
+    // partial send, so mORMot can advance the buffer pointer correctly and
+    // issue a fresh SSL_write for the remainder (no retry-same-buffer constraint)
+    // SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER ($02): allow retry with different
+    // buffer pointer after WANT_WRITE (mORMot copies pending data to fWr)
+    SSL_set_mode(fSsl, $00000003); // ENABLE_PARTIAL_WRITE | ACCEPT_MOVING_WRITE_BUFFER
     Check('AfterAccept set_fd', SSL_set_fd(fSsl, Socket.Socket));
     // server TLS negotiation with server
     Check('AfterAccept accept', SSL_accept(fSsl));


### PR DESCRIPTION
  Three bugs compound to prevent large TLS responses from being delivered:

  - Add ifSeparateWLock to THttpAsyncServerConnection.AfterCreate and Recycle to use separate R/W locks and avoid deadlock between ProcessRead and Write()
  - Add ifWriteWait (USE_WINIOCP) to bypass WaitFor(0) check in ProcessWrite so pending fWr data is retried when wieSend IOCP event fires
  - Set SSL_MODE_ENABLE_PARTIAL_WRITE|SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER in TOpenSslNetTls.AfterAccept so SSL_write returns partial byte count instead of -1 on WANT_WRITE, allowing mORMot to correctly advance the buffer pointer for the next SSL_write call

  Without these fixes, SSL_write sends 4 TLS records (~65KB) then returns
  WANT_WRITE. mORMot retries with a different buffer pointer (fWr.Buffer),
  violating OpenSSL contract. The remaining data is never delivered and
  the connection hangs indefinitely.

  Tested on Windows with a 103KB HTTPS JSON response. Not reproduced on
  Linux (epoll path unaffected).