### PR TITLE
core: Delphi 2010 corrupted memory fix

### DIFF
--- a/src/core/mormot.core.os.windows.inc
+++ b/src/core/mormot.core.os.windows.inc
@@ -4773,15 +4773,20 @@ type
   end;
   TSystemLogicalProcessorInformation = record
     ProcessorMask: PtrUInt;
-    case Relationship: TSystemLogicalProcessorRelation of
-      RelationProcessorCore: (
+    // explicit field (not a variant discriminant) so {$Z4} is always honored
+    // - Delphi 2010 otherwise stores the discriminant as 1 byte, making the
+    //   record smaller than Windows' SYSTEM_LOGICAL_PROCESSOR_INFORMATION and
+    //   causing GetLogicalProcessorInformation() to overrun the dynamic array
+    Relationship: TSystemLogicalProcessorRelation;
+    case integer of
+      0: ( // RelationProcessorCore
         ProcessorCoreFlags: byte);
-      RelationNumaNode: (
+      1: ( // RelationNumaNode
         NumaNodeNumber: DWord);
-      RelationCache: (
+      2: ( // RelationCache
         Cache: TSystemCacheDescriptor);
-      RelationGroup: (
-        Reserved: array[0..1] of QWord); // to define the actual struct size
+      3: ( // RelationGroup - defines the actual struct size
+        Reserved: array[0..1] of QWord);
   end;
 
 {$ifndef UNICODE}
@@ -4837,6 +4842,10 @@ var
   i, n: PtrInt;
   siz: DWord;
 begin
+  // guard against compiler layout drift (D2010 used to under-size this record,
+  // leading to heap corruption from GetLogicalProcessorInformation overruns)
+  Assert(SizeOf(TSystemLogicalProcessorInformation) =
+    {$ifdef CPU64} 32 {$else} 24 {$endif});
   // 1. minimal fallback to support of very old 32-bit CPU without SSE2
   {$ifdef ASMX86}
   {$ifndef HASNOSSE2}


### PR DESCRIPTION
So this one is beyond my skill set, so I had to lean on Claude Code to figure out what to do.
Feel free to discard the PR and implement a better fix :)

In Delphi 2010, I would get this during initialization:
```
--------------------------------2026/4/20 14:20:29--------------------------------
FastMM has detected an error during a FreeMem operation. The block footer has been corrupted. 

The block size is: 840

This block was allocated by thread 0x2E98, and the stack trace (return addresses) at the time was:
00404CBD [System.pas][System][@ReallocMem][3121]
0040B094 [System.pas][System][DynArraySetLength][20708]
0040B16A [System.pas][System][@DynArraySetLength][20756]
017E65A7 [mormot.core.os.windows.inc][mormot.core.os][InitializeSpecificUnit][5072]
017EEE05 [mormot.core.os.pas][mormot.core.os][InitializeUnit][12076]
02174B6B 
004079E4 [System.pas][System][InitUnits][12773]
00407A50 [System.pas][System][@StartExe][12838]
0040D607 [SysInit.pas][SysInit][@InitExe][673]
022CC498 
75695D49 [BaseThreadInitThunk]

The block is currently used for an object of class: Unknown

The allocation number is: 154221

The current thread ID is 0x2E98, and the stack trace (return addresses) leading to this error is:
00404C6A [System.pas][System][@FreeMem][3030]
0040B2B8 [System.pas][System][@DynArrayClear][20868]
017E68E8 [mormot.core.os.windows.inc][mormot.core.os][InitializeSpecificUnit][5133]
017EEE05 [mormot.core.os.pas][mormot.core.os][InitializeUnit][12076]
02174B6B 
004079E4 [System.pas][System][InitUnits][12773]
00407A50 [System.pas][System][@StartExe][12838]
0040D607 [SysInit.pas][SysInit][@InitExe][673]
022CC498 
75695D49 [BaseThreadInitThunk]
771FD83B [Unknown function at RtlInitializeExceptionChain]
```