### PR TITLE
feat: YAML 1.2 parser + OpenAPI YAML spec dispatch

### DIFF
--- a/src/core/mormot.core.yaml.pas
+++ b/src/core/mormot.core.yaml.pas
@@ -132,20 +132,15 @@ end;
 // - accepts both LF and CRLF terminators; trailing \r is stripped
 procedure SplitYamlLines(const Yaml: RawUtf8; out Lines: TYamlLines);
 var
-  p, lineStart, eol: PUtf8Char;
-  stop: PUtf8Char;
-  idx, len: integer;
+  p, lineStart, eol, stop: PUtf8Char;
+  idx, len: PtrInt;
   raw: RawUtf8;
+  current: ^TYamlLine;
 begin
-  Lines := nil;
-  SetLength(Lines, 16);
-  idx := 0;
   p := pointer(Yaml);
   if p = nil then
-  begin
-    Lines := nil;
     exit;
-  end;
+  idx := 0;
   stop := p + length(Yaml);
   lineStart := p;
   while p <= stop do
@@ -159,15 +154,16 @@ begin
       else
         FastSetString(raw, lineStart, eol - lineStart);
       if idx >= length(Lines) then
-        SetLength(Lines, length(Lines) * 2);
-      Lines[idx].Raw := raw;
-      Lines[idx].Indent := CountLeadingSpaces(raw);
-      len := length(raw) - Lines[idx].Indent;
+        SetLength(Lines, NextGrow(idx));
+      current := @Lines[idx];
+      current^.Raw := raw;
+      current^.Indent := CountLeadingSpaces(raw);
+      len := length(raw) - current^.Indent;
       // also right-trim trailing spaces from Content
-      while (len > 0) and (raw[Lines[idx].Indent + len] = ' ') do
+      while (len > 0) and (raw[current^.Indent + len] = ' ') do
         dec(len);
-      FastSetString(Lines[idx].Content,
-        pointer(PtrUInt(pointer(raw)) + PtrUInt(Lines[idx].Indent)), len);
+      FastSetString(current^.Content,
+        @PByteArray(pointer(raw))[current^.Indent], len);
       inc(idx);
       if p = stop then
         break;
@@ -175,7 +171,8 @@ begin
     end;
     inc(p);
   end;
-  SetLength(Lines, idx);
+  if length(Lines) <> idx then
+    SetLength(Lines, idx);
 end;
 
 // strip an unquoted trailing "# ..." comment from a scalar fragment
@@ -420,7 +417,6 @@ var
   p, stop: PUtf8Char;
   quote: AnsiChar;
   tmp: TTextWriter;
-  wbuf: TTextWriterStackBuffer;
   ch: AnsiChar;
   c: cardinal;
   i: PtrInt;
@@ -437,7 +433,7 @@ begin
   if quote = '''' then
   begin
     // single-quoted: only '' is an escape
-    tmp := TTextWriter.CreateOwnedStream(wbuf);
+    tmp := TTextWriter.CreateOwnedStream;
     try
       inc(p);
       while p < stop do
@@ -464,7 +460,7 @@ begin
     exit; // unclosed
   end;
   // double-quoted: full escape set
-  tmp := TTextWriter.CreateOwnedStream(wbuf);
+  tmp := TTextWriter.CreateOwnedStream;
   try
     inc(p);
     while p < stop do
@@ -594,7 +590,6 @@ type
     fDepth: integer;
     fMaxDepth: integer;
     fOut: TJsonWriter;
-    fOutBuf: TTextWriterStackBuffer;
     procedure Error(LineIdx: integer; const Msg: RawUtf8); overload;
     procedure ErrorFmt(LineIdx: integer; const Fmt: RawUtf8;
       const Args: array of const);
@@ -633,7 +628,7 @@ type
 constructor TYamlToJson.Create;
 begin
   inherited Create;
-  fOut := TJsonWriter.CreateOwnedStream(fOutBuf);
+  fOut := TJsonWriter.CreateOwnedStream;
   fMaxDepth := YamlMaxDepth;
   if fMaxDepth < 4 then
     fMaxDepth := 4; // sanity floor: allow at least a few nested structures
@@ -903,7 +898,6 @@ function TYamlToJson.CollectBlockScalar(MinIndent: integer; Folded: boolean;
   Chomp: AnsiChar; ExplicitIndent: integer): RawUtf8;
 var
   tmp: TTextWriter;
-  wbuf: TTextWriterStackBuffer;
   i, blockIndent, startIdx: integer;
   raw, content: RawUtf8;
   lineContent: RawUtf8;
@@ -965,7 +959,7 @@ begin
     end;
     exit;
   end;
-  tmp := TTextWriter.CreateOwnedStream(wbuf);
+  tmp := TTextWriter.CreateOwnedStream;
   try
     blankRun := 0;
     prevWasContent := false;
@@ -1146,7 +1140,6 @@ var
 
 var
   tmp: TTextWriter;
-  wbuf: TTextWriterStackBuffer;
   cur: RawUtf8;
 begin
   if rest = '' then
@@ -1157,7 +1150,7 @@ begin
   if ScanQuoteClosed(rest, {skipOpeningQuote=}true) then
     exit; // single-line, already closed
   // multi-line merge
-  tmp := TTextWriter.CreateOwnedStream(wbuf);
+  tmp := TTextWriter.CreateOwnedStream;
   try
     cur := rest;
     while true do
@@ -1933,7 +1926,6 @@ type
   TVariantToYaml = class
   private
     fOut: TJsonWriter;
-    fOutBuf: TTextWriterStackBuffer;
     fOptions: TYamlWriterOptions;
     procedure WriteValue(const v: variant; Indent: integer);
     procedure WriteBlockMap(const dv: TDocVariantData; Indent: integer);
@@ -1953,7 +1945,7 @@ type
 constructor TVariantToYaml.Create(Options: TYamlWriterOptions);
 begin
   inherited Create;
-  fOut := TJsonWriter.CreateOwnedStream(fOutBuf);
+  fOut := TJsonWriter.CreateOwnedStream;
   fOptions := Options;
 end;
 

--- a/src/core/mormot.core.yaml.pas
+++ b/src/core/mormot.core.yaml.pas
@@ -221,16 +221,20 @@ end;
 
 function IsYamlNull(const S: RawUtf8): boolean;
 begin
-  result := (S = '') or (S = '~') or (S = 'null') or
-            (S = 'Null') or (S = 'NULL');
+  // YAML 1.2 core schema: null has three case-insensitive spellings,
+  // the '~' shortcut, or the empty string
+  result := (S = '') or
+            (S = '~') or
+            IdemPropNameU(S, 'null');
 end;
 
 function IsYamlBool(const S: RawUtf8; out V: boolean): boolean;
 begin
+  // YAML 1.2 core schema accepts any case for the boolean literal
   result := true;
-  if (S = 'true') or (S = 'True') or (S = 'TRUE') then
+  if IdemPropNameU(S, 'true') then
     V := true
-  else if (S = 'false') or (S = 'False') or (S = 'FALSE') then
+  else if IdemPropNameU(S, 'false') then
     V := false
   else
     result := false;
@@ -1880,8 +1884,8 @@ begin
   Doc.Clear;
   src := Yaml;
   // strip UTF-8 BOM regardless of source (file or in-memory) for consistency
-  if (length(src) >= 3) and (src[1] = #$EF) and
-     (src[2] = #$BB) and (src[3] = #$BF) then
+  if (length(src) >= 3) and
+     (PCardinal(pointer(src))^ and $00ffffff = BOM_UTF8) then
     delete(src, 1, 3);
   if Options = [] then
     opt := JSON_FAST_FLOAT + [dvoInternNames]
@@ -2012,8 +2016,8 @@ begin
   begin
     if IsYamlNull(S) then
       needsQuote := true
-    else if (S = 'true') or (S = 'True') or (S = 'TRUE') or
-            (S = 'false') or (S = 'False') or (S = 'FALSE') then
+    else if IdemPropNameU(S, 'true') or
+            IdemPropNameU(S, 'false') then
       needsQuote := true
     else if IsYamlFloat(S) then
       needsQuote := true

--- a/src/core/mormot.core.yaml.pas
+++ b/src/core/mormot.core.yaml.pas
@@ -80,6 +80,19 @@ function VariantToYaml(const Doc: variant;
 procedure SaveVariantToYamlFile(const Doc: variant; const FileName: TFileName;
   Options: TYamlWriterOptions = []);
 
+/// convert YAML 1.2 UTF-8 text directly into a JSON RawUtf8
+// - convenience wrapper around the internal parser's JSON buffer, useful for
+//   pipelines that feed further JSON-based processing (e.g. RTTI settings,
+//   JsonToObject, LoadJson) without going through TDocVariantData
+// - returns '' on parse failure (inspect EYamlException for details)
+function YamlToJson(const Yaml: RawUtf8): RawUtf8;
+
+/// convert JSON UTF-8 text into YAML 1.2 UTF-8 text
+// - pipes the JSON through TDocVariantData then VariantToYaml
+// - useful for converting existing JSON settings files or API payloads to YAML
+function JsonToYaml(const Json: RawUtf8;
+  Options: TYamlWriterOptions = []): RawUtf8;
+
 
 var
   /// maximum YAML nesting depth before the parser raises EYamlException
@@ -94,9 +107,6 @@ implementation
 
 
 { ----- internal helpers --------------------------------------------------- }
-
-const
-  HEX_LOWER: array[0..15] of AnsiChar = '0123456789abcdef';
 
 type
   TYamlLine = record
@@ -1922,7 +1932,7 @@ end;
 type
   TVariantToYaml = class
   private
-    fOut: TTextWriter;
+    fOut: TJsonWriter;
     fOutBuf: TTextWriterStackBuffer;
     fOptions: TYamlWriterOptions;
     procedure WriteValue(const v: variant; Indent: integer);
@@ -1943,7 +1953,7 @@ type
 constructor TVariantToYaml.Create(Options: TYamlWriterOptions);
 begin
   inherited Create;
-  fOut := TTextWriter.CreateOwnedStream(fOutBuf);
+  fOut := TJsonWriter.CreateOwnedStream(fOutBuf);
   fOptions := Options;
 end;
 
@@ -2064,38 +2074,10 @@ begin
     fOut.AddNoJsonEscape(pointer(S), n);
     exit;
   end;
-  // emit as double-quoted with JSON-like escapes
-  fOut.Add('"');
-  for i := 1 to n do
-  begin
-    c := S[i];
-    case c of
-      #0..#7:
-        begin
-          // \x0X where X is the single hex digit for ord(c) in 0..7
-          fOut.AddShort('\x0');
-          fOut.Add(AnsiChar(ord('0') + ord(c)));
-        end;
-      #8: fOut.AddShort('\b');
-      #9: fOut.AddShort('\t');
-      #10: fOut.AddShort('\n');
-      #11: fOut.AddShort('\v');
-      #12: fOut.AddShort('\f');
-      #13: fOut.AddShort('\r');
-      #14..#31:
-        begin
-          fOut.AddShort('\x');
-          fOut.Add(HEX_LOWER[ord(c) shr 4]);
-          fOut.Add(HEX_LOWER[ord(c) and $F]);
-        end;
-      '"': fOut.AddShort('\"');
-      '\': fOut.AddShort('\\');
-    else
-      fOut.Add(c);
-    end;
-  end;
-  fOut.Add('"');
-  // suppress unused-var warnings when we reference hasSpecial
+  // emit as JSON-escaped double-quoted string - valid YAML 1.2 §5.7
+  // since the JSON escape set is a subset of YAML's flow-scalar escapes
+  fOut.AddJsonString(S);
+  // hasSpecial is still computed for potential future heuristics
   if hasSpecial then ;
 end;
 
@@ -2106,31 +2088,26 @@ end;
 
 procedure TVariantToYaml.WriteScalar(const v: variant);
 var
-  vt: word;
+  vd: TVarData absolute v;
   s: RawUtf8;
 begin
-  vt := TVarData(v).VType;
-  case vt of
+  case vd.VType of
     varEmpty, varNull:
       fOut.AddShort('null');
     varBoolean:
-      if TVarData(v).VBoolean then
+      if vd.VBoolean then
         fOut.AddShort('true')
       else
         fOut.AddShort('false');
-    varByte, varShortInt, varWord, varSmallInt, varLongWord, varInteger,
-    varInt64, varWord64:
-      begin
-        VariantToUtf8(v, s);
-        fOut.AddNoJsonEscape(pointer(s), length(s));
-      end;
+    varByte, varShortInt, varWord, varSmallInt,
+    varLongWord, varInteger, varInt64, varWord64,
     varSingle, varDouble, varCurrency:
-      begin
-        VariantToUtf8(v, s);
-        fOut.AddNoJsonEscape(pointer(s), length(s));
-      end;
+      // numeric types share the same text form in JSON and YAML, so let
+      // TJsonWriter.AddVariant emit them directly without any escaping
+      fOut.AddVariant(v, twNone);
   else
     begin
+      // string-like or unknown: coerce to UTF-8 and apply YAML quoting rules
       VariantToUtf8(v, s);
       WriteYamlString(s);
     end;
@@ -2302,6 +2279,34 @@ procedure SaveVariantToYamlFile(const Doc: variant; const FileName: TFileName;
   Options: TYamlWriterOptions);
 begin
   FileFromString(VariantToYaml(Doc, Options), FileName);
+end;
+
+function YamlToJson(const Yaml: RawUtf8): RawUtf8;
+var
+  conv: TYamlToJson;
+  src: RawUtf8;
+begin
+  src := Yaml;
+  // strip optional UTF-8 BOM - accepted in files and in-memory buffers
+  if (length(src) >= 3) and
+     (PCardinal(pointer(src))^ and $00ffffff = BOM_UTF8) then
+    delete(src, 1, 3);
+  conv := TYamlToJson.Create;
+  try
+    result := conv.Run(src);
+  finally
+    conv.Free;
+  end;
+end;
+
+function JsonToYaml(const Json: RawUtf8; Options: TYamlWriterOptions): RawUtf8;
+var
+  doc: TDocVariantData;
+begin
+  result := '';
+  if not doc.InitJson(Json, JSON_FAST_FLOAT + [dvoInternNames]) then
+    exit;
+  result := VariantToYaml(variant(doc), Options);
 end;
 
 

--- a/src/core/mormot.core.yaml.pas
+++ b/src/core/mormot.core.yaml.pas
@@ -1,0 +1,2308 @@
+/// Framework Core YAML 1.2 core-schema Parser / Writer
+// - this unit is a part of the Open Source Synopse mORMot framework 2,
+// licensed under a MPL/GPL/LGPL three license - see LICENSE.md
+unit mormot.core.yaml;
+
+{
+  *****************************************************************************
+
+   YAML 1.2 core-schema <-> TDocVariantData conversion
+    - plain / double-quoted / single-quoted scalars with core-schema type
+      inference (null / bool / int / float / string)
+    - block and flow mappings and sequences
+    - literal (|) and folded (>) block scalars with strip/clip/keep chomping
+    - comments (# to end of line) outside quoted scalars
+    - raises EYamlException on unsupported constructs (&anchor, *alias,
+      !!tag, multi-document ---) or on syntactic errors, with 1-based line
+      information attached
+
+   Parser strategy: YAML tokens are re-encoded into a JSON buffer, then passed
+   to TDocVariantData.InitJson. This sidesteps building a second in-memory DOM
+   and reuses the existing JSON scalar handling.
+
+   Writer strategy: walk the TDocVariantData via TTextWriter and emit
+   block-style YAML (flow-style when ywoFlowCompact is set).
+
+  *****************************************************************************
+}
+
+interface
+
+{$I ..\mormot.defines.inc}
+
+uses
+  sysutils,
+  classes,
+  variants,
+  mormot.core.base,
+  mormot.core.os,
+  mormot.core.unicode,
+  mormot.core.text,
+  mormot.core.buffers,
+  mormot.core.rtti,
+  mormot.core.data,
+  mormot.core.json,
+  mormot.core.variants;
+
+
+type
+  /// exception raised by YAML parser on unsupported or invalid input
+  EYamlException = class(ESynException);
+
+  /// customize YAML serialization output
+  // - ywoFlowCompact: emit flow style ([] / {}) for short / leaf containers
+  // - ywoNoComments: placeholder; this parser does not preserve comments
+  TYamlWriterOption = (
+    ywoFlowCompact,
+    ywoNoComments);
+  TYamlWriterOptions = set of TYamlWriterOption;
+
+
+/// parse YAML UTF-8 text into a TDocVariantData
+// - accepts YAML 1.2 core-schema subset (see unit header)
+// - raises EYamlException on unsupported constructs or syntactic errors
+// - Options defaults to mormot.net.openapi-compatible values when empty
+function YamlToVariant(const Yaml: RawUtf8; out Doc: TDocVariantData;
+  Options: TDocVariantOptions = []): boolean;
+
+/// parse a YAML file into a TDocVariantData
+// - file is expected to be UTF-8 (BOM tolerated); see YamlToVariant
+function YamlFileToVariant(const FileName: TFileName; out Doc: TDocVariantData;
+  Options: TDocVariantOptions = []): boolean;
+
+/// serialize a TDocVariant as YAML 1.2 UTF-8 text
+// - result is block-style by default; ywoFlowCompact switches leaf containers
+//   to flow style
+function VariantToYaml(const Doc: variant;
+  Options: TYamlWriterOptions = []): RawUtf8;
+
+/// save a TDocVariant as a YAML file (UTF-8, no BOM, LF line endings)
+procedure SaveVariantToYamlFile(const Doc: variant; const FileName: TFileName;
+  Options: TYamlWriterOptions = []);
+
+
+var
+  /// maximum YAML nesting depth before the parser raises EYamlException
+  // - default 512 is ample for real-world OpenAPI specs; raise for
+  //   pathologically deep inputs
+  // - converts would-be EStackOverflow into a clean EYamlException with
+  //   line info; guards both block and flow recursive descent
+  YamlMaxDepth: integer = 512;
+
+
+implementation
+
+
+{ ----- internal helpers --------------------------------------------------- }
+
+const
+  HEX_LOWER: array[0..15] of AnsiChar = '0123456789abcdef';
+
+type
+  TYamlLine = record
+    Indent: integer; // count of leading space characters
+    Content: RawUtf8; // trimmed of leading spaces and trailing \r
+    Raw: RawUtf8; // original line with trailing \r stripped
+  end;
+  TYamlLines = array of TYamlLine;
+
+function CountLeadingSpaces(const S: RawUtf8): integer;
+var
+  p: PUtf8Char;
+  n: integer;
+begin
+  p := pointer(S);
+  n := length(S);
+  result := 0;
+  while (result < n) and (p[result] = ' ') do
+    inc(result);
+end;
+
+// split Yaml into lines with indent metadata
+// - accepts both LF and CRLF terminators; trailing \r is stripped
+procedure SplitYamlLines(const Yaml: RawUtf8; out Lines: TYamlLines);
+var
+  p, lineStart, eol: PUtf8Char;
+  stop: PUtf8Char;
+  idx, len: integer;
+  raw: RawUtf8;
+begin
+  Lines := nil;
+  SetLength(Lines, 16);
+  idx := 0;
+  p := pointer(Yaml);
+  if p = nil then
+  begin
+    Lines := nil;
+    exit;
+  end;
+  stop := p + length(Yaml);
+  lineStart := p;
+  while p <= stop do
+  begin
+    if (p = stop) or (p^ = #10) then
+    begin
+      eol := p;
+      // strip trailing \r if present
+      if (eol > lineStart) and ((eol - 1)^ = #13) then
+        FastSetString(raw, lineStart, eol - 1 - lineStart)
+      else
+        FastSetString(raw, lineStart, eol - lineStart);
+      if idx >= length(Lines) then
+        SetLength(Lines, length(Lines) * 2);
+      Lines[idx].Raw := raw;
+      Lines[idx].Indent := CountLeadingSpaces(raw);
+      len := length(raw) - Lines[idx].Indent;
+      // also right-trim trailing spaces from Content
+      while (len > 0) and (raw[Lines[idx].Indent + len] = ' ') do
+        dec(len);
+      FastSetString(Lines[idx].Content,
+        pointer(PtrUInt(pointer(raw)) + PtrUInt(Lines[idx].Indent)), len);
+      inc(idx);
+      if p = stop then
+        break;
+      lineStart := p + 1;
+    end;
+    inc(p);
+  end;
+  SetLength(Lines, idx);
+end;
+
+// strip an unquoted trailing "# ..." comment from a scalar fragment
+// - accounts for single/double quoted spans where # is literal
+function StripLineComment(const S: RawUtf8): RawUtf8;
+var
+  p, stop: PUtf8Char;
+  inSingle, inDouble: boolean;
+  cut: PtrInt;
+begin
+  result := S;
+  if S = '' then
+    exit;
+  p := pointer(S);
+  stop := p + length(S);
+  inSingle := false;
+  inDouble := false;
+  cut := -1;
+  while p < stop do
+  begin
+    case p^ of
+      '''':
+        if not inDouble then
+          inSingle := not inSingle;
+      '"':
+        if not inSingle then
+          inDouble := not inDouble;
+      '#':
+        if not inSingle and not inDouble then
+          if (p = pointer(S)) or ((p - 1)^ in [' ', #9]) then
+          begin
+            cut := p - PUtf8Char(pointer(S));
+            break;
+          end;
+    end;
+    inc(p);
+  end;
+  if cut >= 0 then
+  begin
+    SetLength(result, cut);
+    // right-trim leftover whitespace
+    while (length(result) > 0) and (result[length(result)] in [' ', #9]) do
+      SetLength(result, length(result) - 1);
+  end;
+end;
+
+function IsYamlNull(const S: RawUtf8): boolean;
+begin
+  result := (S = '') or (S = '~') or (S = 'null') or
+            (S = 'Null') or (S = 'NULL');
+end;
+
+function IsYamlBool(const S: RawUtf8; out V: boolean): boolean;
+begin
+  result := true;
+  if (S = 'true') or (S = 'True') or (S = 'TRUE') then
+    V := true
+  else if (S = 'false') or (S = 'False') or (S = 'FALSE') then
+    V := false
+  else
+    result := false;
+end;
+
+function IsYamlInt(const S: RawUtf8; out V: Int64): boolean;
+// YAML 1.2 core-schema integer with safe overflow detection
+// - overflow silently rejects so caller falls back to string emission
+const
+  MAX_POS: QWord = QWord($7FFFFFFFFFFFFFFF);       // +MaxInt64
+  MAX_ABS_NEG: QWord = QWord($8000000000000000);   // |MinInt64|
+var
+  p: PUtf8Char;
+  neg: boolean;
+  n, hexDigits: integer;
+  u, prev: QWord;
+begin
+  result := false;
+  p := pointer(S);
+  n := length(S);
+  if n = 0 then
+    exit;
+  neg := false;
+  if (p^ = '-') or (p^ = '+') then
+  begin
+    neg := p^ = '-';
+    inc(p);
+    dec(n);
+  end;
+  if n = 0 then
+    exit;
+  // hex (YAML 1.2 core schema: 0x[0-9a-fA-F]+)
+  if (n > 2) and (p^ = '0') and ((p + 1)^ in ['x', 'X']) then
+  begin
+    inc(p, 2);
+    dec(n, 2);
+    if n > 16 then // > 64-bit
+      exit;
+    u := 0;
+    hexDigits := 0;
+    while n > 0 do
+    begin
+      case p^ of
+        '0'..'9': u := (u shl 4) or QWord(ord(p^) - ord('0'));
+        'a'..'f': u := (u shl 4) or QWord(ord(p^) - ord('a') + 10);
+        'A'..'F': u := (u shl 4) or QWord(ord(p^) - ord('A') + 10);
+      else
+        exit;
+      end;
+      inc(hexDigits);
+      inc(p);
+      dec(n);
+    end;
+    if hexDigits = 0 then
+      exit;
+    if neg and (u > MAX_ABS_NEG) then exit;
+    if (not neg) and (u > MAX_POS) then exit;
+    if neg then
+      V := -Int64(u)
+    else
+      V := Int64(u);
+    result := true;
+    exit;
+  end;
+  // octal 0o... (YAML 1.2)
+  if (n > 2) and (p^ = '0') and ((p + 1)^ = 'o') then
+  begin
+    inc(p, 2);
+    dec(n, 2);
+    if n > 22 then
+      exit;
+    u := 0;
+    while n > 0 do
+    begin
+      if not (p^ in ['0'..'7']) then
+        exit;
+      prev := u;
+      u := (u shl 3) or QWord(ord(p^) - ord('0'));
+      if u < prev then
+        exit; // overflow wrapped
+      inc(p);
+      dec(n);
+    end;
+    if neg and (u > MAX_ABS_NEG) then exit;
+    if (not neg) and (u > MAX_POS) then exit;
+    if neg then
+      V := -Int64(u)
+    else
+      V := Int64(u);
+    result := true;
+    exit;
+  end;
+  // decimal
+  if n > 20 then
+    exit;
+  u := 0;
+  while n > 0 do
+  begin
+    if not (p^ in ['0'..'9']) then
+      exit;
+    prev := u;
+    u := u * 10 + QWord(ord(p^) - ord('0'));
+    if u < prev then
+      exit; // overflow
+    inc(p);
+    dec(n);
+  end;
+  if neg and (u > MAX_ABS_NEG) then exit;
+  if (not neg) and (u > MAX_POS) then exit;
+  if neg then
+    V := -Int64(u)
+  else
+    V := Int64(u);
+  result := true;
+end;
+
+function IsYamlFloat(const S: RawUtf8): boolean;
+// Recognizes ONLY the JSON number grammar so the lexeme can be emitted raw
+// to the JSON buffer: -?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)? with at least one
+// of (dot|exponent) to distinguish from integer.
+// - rejects YAML-only forms: leading '+', bare ".5", trailing "1." — callers
+//   fall back to string emission (safer than letting InitJson reject raw JSON)
+var
+  p, stop: PUtf8Char;
+  digitsInt, digitsFrac, digitsExp: integer;
+  sawDot, sawExp: boolean;
+begin
+  result := false;
+  p := pointer(S);
+  if p = nil then
+    exit;
+  stop := p + length(S);
+  if p = stop then
+    exit;
+  if p^ = '-' then
+    inc(p);
+  // integer part: one or more digits; "01" is not JSON but YAML allows it,
+  // we accept permissively (the value round-trips fine)
+  digitsInt := 0;
+  while (p < stop) and (p^ in ['0'..'9']) do
+  begin
+    inc(p);
+    inc(digitsInt);
+  end;
+  if digitsInt = 0 then
+    exit;
+  sawDot := false;
+  digitsFrac := 0;
+  if (p < stop) and (p^ = '.') then
+  begin
+    sawDot := true;
+    inc(p);
+    while (p < stop) and (p^ in ['0'..'9']) do
+    begin
+      inc(p);
+      inc(digitsFrac);
+    end;
+    if digitsFrac = 0 then
+      exit; // "1." is not JSON
+  end;
+  sawExp := false;
+  digitsExp := 0;
+  if (p < stop) and (p^ in ['e', 'E']) then
+  begin
+    sawExp := true;
+    inc(p);
+    if (p < stop) and (p^ in ['+', '-']) then
+      inc(p);
+    while (p < stop) and (p^ in ['0'..'9']) do
+    begin
+      inc(p);
+      inc(digitsExp);
+    end;
+    if digitsExp = 0 then
+      exit;
+  end;
+  if p <> stop then
+    exit; // trailing junk
+  result := sawDot or sawExp; // must be float-shaped, not just int
+end;
+
+function ParseQuotedString(const Frag: RawUtf8; out V: RawUtf8): boolean;
+var
+  p, stop: PUtf8Char;
+  quote: AnsiChar;
+  tmp: TTextWriter;
+  wbuf: TTextWriterStackBuffer;
+  ch: AnsiChar;
+  c: cardinal;
+  i: PtrInt;
+begin
+  result := false;
+  if Frag = '' then
+    exit;
+  p := pointer(Frag);
+  quote := p^;
+  if not (quote in ['"', '''']) then
+    exit;
+  stop := p + length(Frag);
+  // find matching end quote
+  if quote = '''' then
+  begin
+    // single-quoted: only '' is an escape
+    tmp := TTextWriter.CreateOwnedStream(wbuf);
+    try
+      inc(p);
+      while p < stop do
+      begin
+        if p^ = '''' then
+        begin
+          if ((p + 1) < stop) and ((p + 1)^ = '''') then
+          begin
+            tmp.Add('''');
+            inc(p, 2);
+            continue;
+          end;
+          // closing quote
+          V := tmp.Text;
+          result := true;
+          exit;
+        end;
+        tmp.Add(p^);
+        inc(p);
+      end;
+    finally
+      tmp.Free;
+    end;
+    exit; // unclosed
+  end;
+  // double-quoted: full escape set
+  tmp := TTextWriter.CreateOwnedStream(wbuf);
+  try
+    inc(p);
+    while p < stop do
+    begin
+      if p^ = '"' then
+      begin
+        V := tmp.Text;
+        result := true;
+        exit;
+      end;
+      if p^ = '\' then
+      begin
+        inc(p);
+        if p >= stop then
+          exit;
+        case p^ of
+          '0': tmp.Add(#0);
+          'a': tmp.Add(#7);
+          'b': tmp.Add(#8);
+          't', #9: tmp.Add(#9);
+          'n': tmp.Add(#10);
+          'v': tmp.Add(#11);
+          'f': tmp.Add(#12);
+          'r': tmp.Add(#13);
+          'e': tmp.Add(#27);
+          ' ': tmp.Add(' ');
+          '"': tmp.Add('"');
+          '/': tmp.Add('/');
+          '\': tmp.Add('\');
+          'x':
+            begin
+              if p + 2 >= stop then
+                exit;
+              c := 0;
+              for i := 1 to 2 do
+              begin
+                inc(p);
+                case p^ of
+                  '0'..'9': c := (c shl 4) or cardinal(ord(p^) - ord('0'));
+                  'a'..'f': c := (c shl 4) or cardinal(ord(p^) - ord('a') + 10);
+                  'A'..'F': c := (c shl 4) or cardinal(ord(p^) - ord('A') + 10);
+                else
+                  exit;
+                end;
+              end;
+              tmp.Add(AnsiChar(c));
+            end;
+          'u':
+            begin
+              if p + 4 >= stop then
+                exit;
+              c := 0;
+              for i := 1 to 4 do
+              begin
+                inc(p);
+                case p^ of
+                  '0'..'9': c := (c shl 4) or cardinal(ord(p^) - ord('0'));
+                  'a'..'f': c := (c shl 4) or cardinal(ord(p^) - ord('a') + 10);
+                  'A'..'F': c := (c shl 4) or cardinal(ord(p^) - ord('A') + 10);
+                else
+                  exit;
+                end;
+              end;
+              // naive UTF-8 emission for BMP only
+              if c < $80 then
+                tmp.Add(AnsiChar(c))
+              else if c < $800 then
+              begin
+                tmp.Add(AnsiChar($C0 or (c shr 6)));
+                tmp.Add(AnsiChar($80 or (c and $3F)));
+              end
+              else
+              begin
+                tmp.Add(AnsiChar($E0 or (c shr 12)));
+                tmp.Add(AnsiChar($80 or ((c shr 6) and $3F)));
+                tmp.Add(AnsiChar($80 or (c and $3F)));
+              end;
+            end;
+        else
+          // unknown escape - pass-through the character
+          tmp.Add(p^);
+        end;
+        inc(p);
+      end
+      else
+      begin
+        ch := p^;
+        tmp.Add(ch);
+        inc(p);
+      end;
+    end;
+  finally
+    tmp.Free;
+  end;
+end;
+
+function TrimYamlRight(const S: RawUtf8): RawUtf8;
+var
+  n: integer;
+begin
+  n := length(S);
+  while (n > 0) and (S[n] in [' ', #9]) do
+    dec(n);
+  FastSetString(result, pointer(S), n);
+end;
+
+function TrimYamlLeft(const S: RawUtf8): RawUtf8;
+var
+  n, i: integer;
+begin
+  n := length(S);
+  i := 1;
+  while (i <= n) and (S[i] in [' ', #9]) do
+    inc(i);
+  FastSetString(result, @PAnsiChar(pointer(S))[i - 1], n - i + 1);
+end;
+
+
+{ ----- YAML -> JSON converter --------------------------------------------- }
+
+type
+  TYamlToJson = class
+  private
+    fLines: TYamlLines;
+    fCount: integer;
+    fIdx: integer;
+    fDepth: integer;
+    fMaxDepth: integer;
+    fOut: TJsonWriter;
+    fOutBuf: TTextWriterStackBuffer;
+    procedure Error(LineIdx: integer; const Msg: RawUtf8); overload;
+    procedure ErrorFmt(LineIdx: integer; const Fmt: RawUtf8;
+      const Args: array of const);
+    procedure SkipBlankLines;
+    function AtEnd: boolean; inline;
+    function HasContent: boolean;
+    function FirstContentLine(out LineIdx: integer): boolean;
+    function LineIsDashItem(const S: RawUtf8; out afterDash: RawUtf8): boolean;
+    function IsDashLine(const S: RawUtf8): boolean;
+    function LineKeyEnd(const S: RawUtf8): PtrInt;
+    procedure CheckUnsupportedScalar(LineIdx: integer; const S: RawUtf8);
+    procedure MergeMultilineQuoted(var rest: RawUtf8; firstLineIdx: integer);
+    procedure FoldPlainScalar(var rest: RawUtf8; MapIndent: integer);
+    procedure ParseValue(MinIndent: integer);
+    procedure ParseBlockMap(Indent: integer);
+    procedure ParseBlockSeq(Indent: integer);
+    procedure ParseImplicitMapFromDash(MapIndent: integer;
+      const firstEntry: RawUtf8; firstLineIdx: integer);
+    procedure ParseFlow(var p, stop: PUtf8Char; LineIdx: integer);
+    procedure ParseFlowMap(var p, stop: PUtf8Char; LineIdx: integer);
+    procedure ParseFlowSeq(var p, stop: PUtf8Char; LineIdx: integer);
+    procedure EmitFlowScalar(const Frag: RawUtf8; LineIdx: integer);
+    procedure EmitScalarFragment(const Frag: RawUtf8; LineIdx: integer);
+    procedure EmitJsonString(const S: RawUtf8);
+    procedure EmitKey(const K: RawUtf8);
+    function CollectBlockScalar(MinIndent: integer; Folded: boolean;
+      Chomp: AnsiChar; ExplicitIndent: integer = 0): RawUtf8;
+    procedure EmitBlockScalar(const rest: RawUtf8; BaseIndent: integer);
+  public
+    constructor Create;
+    destructor Destroy; override;
+    function Run(const Yaml: RawUtf8): RawUtf8;
+  end;
+
+
+constructor TYamlToJson.Create;
+begin
+  inherited Create;
+  fOut := TJsonWriter.CreateOwnedStream(fOutBuf);
+  fMaxDepth := YamlMaxDepth;
+  if fMaxDepth < 4 then
+    fMaxDepth := 4; // sanity floor: allow at least a few nested structures
+end;
+
+destructor TYamlToJson.Destroy;
+begin
+  fOut.Free;
+  inherited Destroy;
+end;
+
+procedure TYamlToJson.Error(LineIdx: integer; const Msg: RawUtf8);
+begin
+  EYamlException.RaiseUtf8('YAML line %: %', [LineIdx + 1, Msg]);
+end;
+
+procedure TYamlToJson.ErrorFmt(LineIdx: integer; const Fmt: RawUtf8;
+  const Args: array of const);
+var
+  msg: RawUtf8;
+begin
+  FormatUtf8(Fmt, Args, msg);
+  Error(LineIdx, msg);
+end;
+
+function TYamlToJson.AtEnd: boolean;
+begin
+  result := fIdx >= fCount;
+end;
+
+procedure TYamlToJson.SkipBlankLines;
+var
+  c: RawUtf8;
+begin
+  while fIdx < fCount do
+  begin
+    c := fLines[fIdx].Content;
+    if (c = '') or (c[1] = '#') then
+      inc(fIdx)
+    else
+      break;
+  end;
+end;
+
+function TYamlToJson.HasContent: boolean;
+var
+  i: integer;
+  c: RawUtf8;
+begin
+  for i := 0 to fCount - 1 do
+  begin
+    c := fLines[i].Content;
+    if (c <> '') and (c[1] <> '#') then
+    begin
+      result := true;
+      exit;
+    end;
+  end;
+  result := false;
+end;
+
+function TYamlToJson.FirstContentLine(out LineIdx: integer): boolean;
+var
+  i: integer;
+  c: RawUtf8;
+begin
+  for i := 0 to fCount - 1 do
+  begin
+    c := fLines[i].Content;
+    if (c <> '') and (c[1] <> '#') then
+    begin
+      LineIdx := i;
+      result := true;
+      exit;
+    end;
+  end;
+  LineIdx := -1;
+  result := false;
+end;
+
+function TYamlToJson.LineIsDashItem(const S: RawUtf8;
+  out afterDash: RawUtf8): boolean;
+begin
+  result := false;
+  afterDash := '';
+  if S = '' then
+    exit;
+  if S[1] <> '-' then
+    exit;
+  if length(S) = 1 then
+  begin
+    result := true;
+    exit;
+  end;
+  if not (S[2] in [' ', #9]) then
+    exit;
+  afterDash := TrimYamlLeft(copy(S, 2, MaxInt));
+  result := true;
+end;
+
+function TYamlToJson.IsDashLine(const S: RawUtf8): boolean;
+// fast check, no afterDash extraction
+begin
+  result := (S <> '') and (S[1] = '-') and
+            ((length(S) = 1) or (S[2] in [' ', #9]));
+end;
+
+function TYamlToJson.LineKeyEnd(const S: RawUtf8): PtrInt;
+// returns the 0-based index of the ':' that ends the key (followed by space or EOL),
+// or -1 if not a mapping line; the key itself may be quoted.
+var
+  p, stop: PUtf8Char;
+  inSingle, inDouble: boolean;
+begin
+  result := -1;
+  if S = '' then
+    exit;
+  p := pointer(S);
+  stop := p + length(S);
+  inSingle := false;
+  inDouble := false;
+  while p < stop do
+  begin
+    case p^ of
+      '''':
+        if not inDouble then
+          inSingle := not inSingle;
+      '"':
+        if not inSingle then
+          inDouble := not inDouble;
+      ':':
+        if not inSingle and not inDouble then
+        begin
+          if (p + 1 = stop) or ((p + 1)^ in [' ', #9]) then
+          begin
+            result := p - PUtf8Char(pointer(S));
+            exit;
+          end;
+        end;
+      '#':
+        if not inSingle and not inDouble then
+          if (p = pointer(S)) or ((p - 1)^ in [' ', #9]) then
+            exit; // comment - no colon before it
+    end;
+    inc(p);
+  end;
+end;
+
+procedure TYamlToJson.CheckUnsupportedScalar(LineIdx: integer; const S: RawUtf8);
+var
+  p, stop: PUtf8Char;
+  inSingle, inDouble: boolean;
+  c: AnsiChar;
+begin
+  if S = '' then
+    exit;
+  if (S = '---') or (S = '...') then
+    Error(LineIdx, 'multi-document streams are not supported');
+  p := pointer(S);
+  stop := p + length(S);
+  inSingle := false;
+  inDouble := false;
+  while p < stop do
+  begin
+    c := p^;
+    case c of
+      '''':
+        if not inDouble then
+          inSingle := not inSingle;
+      '"':
+        if not inSingle then
+          inDouble := not inDouble;
+      '&', '*', '!':
+        // per YAML 1.2 §5.3, anchor/alias/tag indicators are only meaningful
+        // at the start of a NODE fragment (which is what CheckUnsupportedScalar
+        // is called with - a key's rest or a dash item's afterDash). Mid-
+        // fragment occurrences are literal text in plain scalars. This avoids
+        // firing on real-world OpenAPI descriptions: URL query "?a=1&b=2"
+        // (27 hits in GitHub REST), markdown "**bold**" (182 hits) and
+        // markdown inline images "![img](url)" (215 hits).
+        if not inSingle and not inDouble then
+          if p = pointer(S) then
+            case c of
+              '&': Error(LineIdx, 'YAML anchors (&name) are not supported');
+              '*': Error(LineIdx, 'YAML aliases (*name) are not supported');
+              '!': Error(LineIdx,
+                     'explicit YAML tags (!...) are not supported');
+            end;
+    end;
+    inc(p);
+  end;
+end;
+
+procedure TYamlToJson.EmitJsonString(const S: RawUtf8);
+begin
+  fOut.Add('"');
+  fOut.AddJsonEscape(pointer(S), length(S));
+  fOut.Add('"');
+end;
+
+procedure TYamlToJson.EmitKey(const K: RawUtf8);
+var
+  unquoted: RawUtf8;
+begin
+  // a key may be quoted in YAML - keep its textual form as a JSON string
+  if (K <> '') and (K[1] in ['"', '''']) then
+  begin
+    if ParseQuotedString(K, unquoted) then
+    begin
+      EmitJsonString(unquoted);
+      exit;
+    end;
+  end;
+  EmitJsonString(K);
+end;
+
+procedure TYamlToJson.EmitScalarFragment(const Frag: RawUtf8; LineIdx: integer);
+var
+  s: RawUtf8;
+  v: RawUtf8;
+  bval: boolean;
+  ival: Int64;
+begin
+  s := TrimYamlRight(StripLineComment(Frag));
+  s := TrimYamlLeft(s);
+  if s = '' then
+  begin
+    fOut.AddShort('null');
+    exit;
+  end;
+  if s[1] in ['"', ''''] then
+  begin
+    if not ParseQuotedString(s, v) then
+      Error(LineIdx, 'malformed quoted scalar');
+    EmitJsonString(v);
+    exit;
+  end;
+  CheckUnsupportedScalar(LineIdx, s);
+  if IsYamlNull(s) then
+    fOut.AddShort('null')
+  else if IsYamlBool(s, bval) then
+    if bval then
+      fOut.AddShort('true')
+    else
+      fOut.AddShort('false')
+  else if IsYamlInt(s, ival) then
+    fOut.Add(ival)
+  else if IsYamlFloat(s) then
+    fOut.AddNoJsonEscape(pointer(s), length(s))
+  else
+    EmitJsonString(s);
+end;
+
+procedure TYamlToJson.EmitFlowScalar(const Frag: RawUtf8; LineIdx: integer);
+var
+  s: RawUtf8;
+begin
+  // inside flow, no trailing "# comment" stripping (flow uses , and close-brace
+  // as terminators; comments after flow close belong to the line)
+  s := TrimYamlRight(TrimYamlLeft(Frag));
+  if s = '' then
+    Error(LineIdx, 'empty value in flow collection');
+  EmitScalarFragment(s, LineIdx);
+end;
+
+function TYamlToJson.CollectBlockScalar(MinIndent: integer; Folded: boolean;
+  Chomp: AnsiChar; ExplicitIndent: integer): RawUtf8;
+var
+  tmp: TTextWriter;
+  wbuf: TTextWriterStackBuffer;
+  i, blockIndent, startIdx: integer;
+  raw, content: RawUtf8;
+  lineContent: RawUtf8;
+  blankRun: integer;
+  prevWasContent: boolean;
+begin
+  result := '';
+  startIdx := fIdx;
+  i := startIdx;
+  if ExplicitIndent > 0 then
+  begin
+    // YAML 1.2 §8.1.1.1 explicit indent indicator: the content indent is
+    // fixed at parent_indent + ExplicitIndent, NOT auto-detected. MinIndent
+    // equals parent_indent + 1 at this point, so parent_indent = MinIndent-1.
+    blockIndent := MinIndent - 1 + ExplicitIndent;
+    // skip leading blank lines; stop at the first non-blank line. If that
+    // line is shallower than blockIndent, the block is empty (blockIndent
+    // reset to -1 so the existing "empty block" path below takes over).
+    while i < fCount do
+    begin
+      if fLines[i].Content = '' then
+      begin
+        inc(i);
+        continue;
+      end;
+      break;
+    end;
+    if (i >= fCount) or
+       (fLines[i].Indent < blockIndent) then
+      blockIndent := -1;
+  end
+  else
+  begin
+    // detect block indent from the first non-blank line whose indent >= MinIndent
+    blockIndent := -1;
+    while i < fCount do
+    begin
+      raw := fLines[i].Raw;
+      content := fLines[i].Content;
+      if content = '' then
+      begin
+        inc(i);
+        continue;
+      end;
+      if fLines[i].Indent < MinIndent then
+        break;
+      blockIndent := fLines[i].Indent;
+      break;
+    end;
+  end;
+  if blockIndent < 0 then
+  begin
+    fIdx := i;
+    // empty block: honor chomping
+    case Chomp of
+      '-': result := '';
+      '+': result := '';
+      else result := '';
+    end;
+    exit;
+  end;
+  tmp := TTextWriter.CreateOwnedStream(wbuf);
+  try
+    blankRun := 0;
+    prevWasContent := false;
+    while i < fCount do
+    begin
+      raw := fLines[i].Raw;
+      content := fLines[i].Content;
+      if content = '' then
+      begin
+        inc(blankRun);
+        inc(i);
+        continue;
+      end;
+      if fLines[i].Indent < blockIndent then
+        break;
+      // block content line: strip blockIndent prefix
+      lineContent := copy(raw, blockIndent + 1, MaxInt);
+      if prevWasContent then
+      begin
+        if blankRun = 0 then
+          if Folded then
+            tmp.Add(' ')
+          else
+            tmp.Add(#10)
+        else
+        begin
+          // preserve blank-line runs literally as \n * blankRun
+          while blankRun > 0 do
+          begin
+            tmp.Add(#10);
+            dec(blankRun);
+          end;
+        end;
+      end
+      else
+      begin
+        // leading blanks before first content: keep them
+        while blankRun > 0 do
+        begin
+          tmp.Add(#10);
+          dec(blankRun);
+        end;
+      end;
+      tmp.AddNoJsonEscape(pointer(lineContent), length(lineContent));
+      prevWasContent := true;
+      blankRun := 0;
+      inc(i);
+    end;
+    result := tmp.Text;
+  finally
+    tmp.Free;
+  end;
+  fIdx := i;
+  // apply chomping to the trailing content
+  case Chomp of
+    '-':
+      // strip all trailing newlines
+      while (length(result) > 0) and (result[length(result)] = #10) do
+        SetLength(result, length(result) - 1);
+    '+':
+      // keep trailing newlines exactly; ensure at least one
+      if (length(result) = 0) or (result[length(result)] <> #10) then
+        result := result + #10;
+    else
+      // clip: collapse trailing newlines to a single one
+      while (length(result) >= 2) and
+            (result[length(result)] = #10) and
+            (result[length(result) - 1] = #10) do
+        SetLength(result, length(result) - 1);
+      if (length(result) = 0) or (result[length(result)] <> #10) then
+        result := result + #10;
+  end;
+end;
+
+procedure TYamlToJson.EmitBlockScalar(const rest: RawUtf8; BaseIndent: integer);
+var
+  indicator: AnsiChar;
+  folded: boolean;
+  chomp: AnsiChar;
+  explicitIndent: integer;
+  content: RawUtf8;
+  i: integer;
+begin
+  // rest starts with '|' or '>' optionally followed by chomp ('-' or '+')
+  // and/or an explicit indent indicator (single digit 1..9, YAML 1.2 §8.1.1.1)
+  indicator := rest[1];
+  folded := indicator = '>';
+  chomp := ' '; // 'clip' default (no chomp indicator)
+  explicitIndent := 0;
+  for i := 2 to length(rest) do
+    case rest[i] of
+      '-':
+        chomp := '-';
+      '+':
+        chomp := '+';
+      '1'..'9':
+        // first digit captured; a second digit is malformed (spec caps at 1..9)
+        if explicitIndent = 0 then
+          explicitIndent := ord(rest[i]) - ord('0')
+        else
+          Error(fIdx, 'malformed block-scalar header (double indent indicator)');
+      '0':
+        // YAML 1.2 §8.1.1.1 forbids 0 as an explicit indent indicator
+        Error(fIdx, 'block-scalar indent indicator must be 1..9');
+      ' ', #9, '#':
+        break;
+    else
+      break; // unexpected
+    end;
+  inc(fIdx); // advance past the key-line marker
+  content := CollectBlockScalar(BaseIndent + 1, folded, chomp, explicitIndent);
+  EmitJsonString(content);
+end;
+
+procedure TYamlToJson.MergeMultilineQuoted(var rest: RawUtf8;
+  firstLineIdx: integer);
+// YAML 1.2 §7.5: a " or ' scalar may span multiple physical lines.
+// - double-quoted: a trailing '\' absorbs the line break and leading ws of the
+//   next line (escaped line break); otherwise the line break folds to a space
+// - single-quoted: '' is the only escape; line break folds to a space
+// When invoked, rest must start with the opening quote and fIdx must point at
+// the first line of the scalar. On return, rest contains the full quoted span
+// (still wrapped in quotes, ready for ParseQuotedString), and fIdx has been
+// advanced past any consumed continuation lines. The first (key) line is NOT
+// consumed here - callers are responsible for their own fIdx advance on the
+// first line, just as before the merge was introduced.
+var
+  quote: AnsiChar;
+  trailingEscape: boolean;
+
+  function ScanQuoteClosed(const s: RawUtf8; skipOpeningQuote: boolean): boolean;
+  var
+    p, stop: PUtf8Char;
+    esc: boolean;
+  begin
+    result := false;
+    trailingEscape := false;
+    if s = '' then
+      exit;
+    p := pointer(s);
+    stop := p + length(s);
+    if skipOpeningQuote and (p^ = quote) then
+      inc(p);
+    esc := false;
+    while p < stop do
+    begin
+      if quote = '"' then
+      begin
+        if esc then
+          esc := false
+        else if p^ = '\' then
+          esc := true
+        else if p^ = '"' then
+        begin
+          result := true;
+          exit;
+        end;
+      end
+      else
+      begin
+        // single-quoted: '' is an escape; otherwise '' closes
+        if p^ = '''' then
+        begin
+          if ((p + 1) < stop) and ((p + 1)^ = '''') then
+            inc(p) // consume the first of the '' escape
+          else
+          begin
+            result := true;
+            exit;
+          end;
+        end;
+      end;
+      inc(p);
+    end;
+    // unterminated: remember if double-quoted ended with a trailing '\'
+    trailingEscape := (quote = '"') and esc;
+  end;
+
+var
+  tmp: TTextWriter;
+  wbuf: TTextWriterStackBuffer;
+  cur: RawUtf8;
+begin
+  if rest = '' then
+    exit;
+  quote := rest[1];
+  if not (quote in ['"', '''']) then
+    exit;
+  if ScanQuoteClosed(rest, {skipOpeningQuote=}true) then
+    exit; // single-line, already closed
+  // multi-line merge
+  tmp := TTextWriter.CreateOwnedStream(wbuf);
+  try
+    cur := rest;
+    while true do
+    begin
+      if trailingEscape then
+        // absorbed line break: drop the trailing '\' and emit no separator
+        tmp.AddNoJsonEscape(pointer(cur), length(cur) - 1)
+      else
+      begin
+        tmp.AddNoJsonEscape(pointer(cur), length(cur));
+        // folded line break -> single space (per YAML 1.2 §7.5)
+        tmp.Add(' ');
+      end;
+      inc(fIdx);
+      if fIdx >= fCount then
+        Error(firstLineIdx, 'unterminated multi-line quoted scalar');
+      // Content is already left-trimmed by SplitYamlLines via Indent metadata,
+      // which is exactly the §7.5 requirement that leading ws is ignored
+      cur := fLines[fIdx].Content;
+      if cur = '' then
+        continue;
+      if ScanQuoteClosed(cur, {skipOpeningQuote=}false) then
+      begin
+        // last line closes the scalar; include everything up to and past the
+        // closing quote (any trailing content is ignored - quoted scalars end
+        // at the closing quote)
+        tmp.AddNoJsonEscape(pointer(cur), length(cur));
+        // leave fIdx pointing at this closing line; callers advance it
+        break;
+      end;
+    end;
+    rest := tmp.Text;
+  finally
+    tmp.Free;
+  end;
+end;
+
+procedure TYamlToJson.FoldPlainScalar(var rest: RawUtf8; MapIndent: integer);
+// YAML 1.2 §6.5 plain scalar folding: a plain scalar value may continue
+// across lines that are indented strictly deeper than the map key. Each
+// line break folds to a single space. When invoked, fIdx must already point
+// at the first potential continuation line (the caller consumed the key
+// line). Advances fIdx past each folded line. A line break is NOT consumed
+// when the next line opens a nested structure (dash, flow, block-scalar
+// indicator, quoted scalar, or another "key: value" entry).
+var
+  next: RawUtf8;
+begin
+  while fIdx < fCount do
+  begin
+    // blank line terminates folding (paragraph break in plain scalars)
+    if fLines[fIdx].Content = '' then
+      exit;
+    // sibling or outer-scope line is not part of the folded scalar
+    if fLines[fIdx].Indent <= MapIndent then
+      exit;
+    next := fLines[fIdx].Content;
+    // a real "- " dash item at the continuation indent starts a new seq entry
+    if IsDashLine(next) then
+      exit;
+    // a new "key:" line (quoted or plain) is a nested map, not continuation;
+    // LineKeyEnd handles both "foo:" and '"foo":' forms
+    if LineKeyEnd(next) >= 0 then
+      exit;
+    // otherwise it's plain-scalar text; fold with a single space per §6.5.
+    // once we are continuing a plain scalar, indicator chars at line start
+    // (", ', {, [, |, >) are just literal text - the GitHub REST spec embeds
+    // markdown ("[List selected ...](https://...)") and quoted phrases (e.g.
+    // «"My TEam Näme") mid-description
+    rest := rest + ' ' + next;
+    inc(fIdx);
+  end;
+end;
+
+procedure TYamlToJson.ParseBlockMap(Indent: integer);
+var
+  first: boolean;
+  keyEnd: PtrInt;
+  lineContent, keyText, rest: RawUtf8;
+  lineIdx: integer;
+begin
+  fOut.Add('{');
+  first := true;
+  while true do
+  begin
+    SkipBlankLines;
+    if AtEnd then
+      break;
+    if fLines[fIdx].Indent <> Indent then
+      break;
+    lineContent := fLines[fIdx].Content;
+    keyEnd := LineKeyEnd(lineContent);
+    if keyEnd < 0 then
+      break;
+    keyText := TrimYamlRight(copy(lineContent, 1, keyEnd));
+    rest := '';
+    if keyEnd + 1 < length(lineContent) then
+      rest := TrimYamlLeft(copy(lineContent, keyEnd + 2, MaxInt));
+    if not first then
+      fOut.Add(',');
+    EmitKey(keyText);
+    fOut.Add(':');
+    lineIdx := fIdx;
+    if (rest = '') or (rest[1] = '#') then
+    begin
+      inc(fIdx);
+      SkipBlankLines;
+      if (not AtEnd) and (fLines[fIdx].Indent > Indent) then
+        ParseValue(fLines[fIdx].Indent)
+      else if (not AtEnd) and (fLines[fIdx].Indent = Indent) and
+              IsDashLine(fLines[fIdx].Content) then
+        // YAML 1.2 compact block seq: "key:" followed by "- item" at the
+        // same indent as the key (common in real-world OpenAPI specs)
+        ParseBlockSeq(fLines[fIdx].Indent)
+      else
+        fOut.AddShort('null');
+    end
+    else if rest[1] in ['|', '>'] then
+      EmitBlockScalar(rest, Indent)
+    else
+    begin
+      // YAML 1.2 §7.5: a quoted scalar may span multiple lines
+      if rest[1] in ['"', ''''] then
+        MergeMultilineQuoted(rest, lineIdx);
+      CheckUnsupportedScalar(lineIdx, rest);
+      if rest[1] in ['{', '['] then
+      begin
+        // inline flow collection as the value - rewrite Content so ParseValue
+        // sees the flow fragment alone, not the full "key: {..}"/"key: [..]"
+        // line (otherwise ParseValue would dispatch back to ParseBlockMap).
+        // Mirrors the same pattern in ParseImplicitMapFromDash.
+        fLines[fIdx].Content := rest;
+        ParseValue(Indent);
+      end
+      else
+      begin
+        inc(fIdx); // consume the key line (or the quoted-scalar close line)
+        // YAML 1.2 §6.5: plain scalar may fold across indented lines
+        if not (rest[1] in ['"', '''']) then
+          FoldPlainScalar(rest, Indent);
+        EmitScalarFragment(rest, lineIdx);
+      end;
+    end;
+    first := false;
+  end;
+  fOut.Add('}');
+end;
+
+procedure TYamlToJson.ParseBlockSeq(Indent: integer);
+var
+  first: boolean;
+  content, afterDash: RawUtf8;
+  lineIdx: integer;
+  implicitIndent: integer;
+begin
+  fOut.Add('[');
+  first := true;
+  while true do
+  begin
+    SkipBlankLines;
+    if AtEnd then
+      break;
+    if fLines[fIdx].Indent <> Indent then
+      break;
+    content := fLines[fIdx].Content;
+    if not LineIsDashItem(content, afterDash) then
+      break;
+    lineIdx := fIdx;
+    if not first then
+      fOut.Add(',');
+    first := false;
+    implicitIndent := Indent + 2;
+    if afterDash = '' then
+    begin
+      inc(fIdx);
+      SkipBlankLines;
+      if (not AtEnd) and (fLines[fIdx].Indent > Indent) then
+        ParseValue(fLines[fIdx].Indent)
+      else
+        fOut.AddShort('null');
+    end
+    else if afterDash[1] in ['|', '>'] then
+    begin
+      EmitBlockScalar(afterDash, Indent);
+    end
+    else if IsDashLine(afterDash) then
+    begin
+      // YAML 1.2 compact nested block-seq: "- - X" on one physical line.
+      // The inner "- X" starts a nested seq at (outer Indent + 2); rewrite
+      // the current line to look like it starts at that indent and recurse.
+      fLines[fIdx].Content := afterDash;
+      fLines[fIdx].Indent := implicitIndent;
+      ParseBlockSeq(implicitIndent);
+    end
+    else if (afterDash[1] in ['{', '[']) then
+    begin
+      // flow collection inline
+      CheckUnsupportedScalar(lineIdx, afterDash);
+      // use flow parser directly on afterDash content
+      // simplest: treat the rest of the line as a flow value
+      // ParseValue at current indent will see the `- ` already consumed;
+      // instead, parse the flow value now by replacing the line content
+      // temporarily
+      fLines[fIdx].Content := afterDash;
+      fLines[fIdx].Indent := implicitIndent;
+      ParseValue(implicitIndent);
+    end
+    else if LineKeyEnd(afterDash) >= 0 then
+    begin
+      // implicit mapping item: "- key: value" [, "   key2: v2"]
+      ParseImplicitMapFromDash(implicitIndent, afterDash, lineIdx);
+    end
+    else
+    begin
+      if afterDash[1] in ['"', ''''] then
+        MergeMultilineQuoted(afterDash, lineIdx);
+      CheckUnsupportedScalar(lineIdx, afterDash);
+      inc(fIdx);
+      if not (afterDash[1] in ['"', '''']) then
+        FoldPlainScalar(afterDash, Indent);
+      EmitScalarFragment(afterDash, lineIdx);
+    end;
+  end;
+  fOut.Add(']');
+end;
+
+procedure TYamlToJson.ParseImplicitMapFromDash(MapIndent: integer;
+  const firstEntry: RawUtf8; firstLineIdx: integer);
+var
+  keyEnd: PtrInt;
+  lineContent, keyText, rest: RawUtf8;
+  curIdx: integer;
+begin
+  fOut.Add('{');
+  // emit the first entry from afterDash
+  keyEnd := LineKeyEnd(firstEntry);
+  if keyEnd < 0 then
+    Error(firstLineIdx, 'expected mapping entry after "- "');
+  keyText := TrimYamlRight(copy(firstEntry, 1, keyEnd));
+  rest := '';
+  if keyEnd + 1 < length(firstEntry) then
+    rest := TrimYamlLeft(copy(firstEntry, keyEnd + 2, MaxInt));
+  EmitKey(keyText);
+  fOut.Add(':');
+  if (rest = '') or (rest[1] = '#') then
+  begin
+    inc(fIdx);
+    SkipBlankLines;
+    if (not AtEnd) and (fLines[fIdx].Indent > MapIndent) then
+      ParseValue(fLines[fIdx].Indent)
+    else if (not AtEnd) and (fLines[fIdx].Indent = MapIndent) and
+            IsDashLine(fLines[fIdx].Content) then
+      ParseBlockSeq(fLines[fIdx].Indent)
+    else
+      fOut.AddShort('null');
+  end
+  else if rest[1] in ['|', '>'] then
+    // block-scalar min-indent must exceed the parent-key indent (MapIndent),
+    // so the EmitBlockScalar base = MapIndent matches ParseBlockMap/continuation
+    EmitBlockScalar(rest, MapIndent)
+  else
+  begin
+    if rest[1] in ['"', ''''] then
+      MergeMultilineQuoted(rest, firstLineIdx);
+    CheckUnsupportedScalar(firstLineIdx, rest);
+    if rest[1] in ['{', '['] then
+    begin
+      fLines[fIdx].Content := rest;
+      fLines[fIdx].Indent := MapIndent;
+      ParseValue(MapIndent);
+    end
+    else
+    begin
+      inc(fIdx);
+      if not (rest[1] in ['"', '''']) then
+        FoldPlainScalar(rest, MapIndent);
+      EmitScalarFragment(rest, firstLineIdx);
+    end;
+  end;
+  // continuation: subsequent lines at MapIndent with key-colon
+  while true do
+  begin
+    SkipBlankLines;
+    if AtEnd then
+      break;
+    if fLines[fIdx].Indent <> MapIndent then
+      break;
+    lineContent := fLines[fIdx].Content;
+    keyEnd := LineKeyEnd(lineContent);
+    if keyEnd < 0 then
+      break;
+    keyText := TrimYamlRight(copy(lineContent, 1, keyEnd));
+    rest := '';
+    if keyEnd + 1 < length(lineContent) then
+      rest := TrimYamlLeft(copy(lineContent, keyEnd + 2, MaxInt));
+    fOut.Add(',');
+    EmitKey(keyText);
+    fOut.Add(':');
+    curIdx := fIdx;
+    if (rest = '') or (rest[1] = '#') then
+    begin
+      inc(fIdx);
+      SkipBlankLines;
+      if (not AtEnd) and (fLines[fIdx].Indent > MapIndent) then
+        ParseValue(fLines[fIdx].Indent)
+      else if (not AtEnd) and (fLines[fIdx].Indent = MapIndent) and
+              IsDashLine(fLines[fIdx].Content) then
+        ParseBlockSeq(fLines[fIdx].Indent)
+      else
+        fOut.AddShort('null');
+    end
+    else if rest[1] in ['|', '>'] then
+      EmitBlockScalar(rest, MapIndent)
+    else
+    begin
+      if rest[1] in ['"', ''''] then
+        MergeMultilineQuoted(rest, curIdx);
+      CheckUnsupportedScalar(curIdx, rest);
+      if rest[1] in ['{', '['] then
+      begin
+        fLines[fIdx].Content := rest;
+        ParseValue(MapIndent);
+      end
+      else
+      begin
+        inc(fIdx);
+        if not (rest[1] in ['"', '''']) then
+          FoldPlainScalar(rest, MapIndent);
+        EmitScalarFragment(rest, curIdx);
+      end;
+    end;
+  end;
+  fOut.Add('}');
+end;
+
+procedure TYamlToJson.ParseFlow(var p, stop: PUtf8Char; LineIdx: integer);
+begin
+  inc(fDepth);
+  try
+    if fDepth > fMaxDepth then
+      ErrorFmt(LineIdx,
+        'YAML nesting depth exceeds YamlMaxDepth (%)', [fMaxDepth]);
+    // p points at '{' or '['
+    if p^ = '{' then
+      ParseFlowMap(p, stop, LineIdx)
+    else if p^ = '[' then
+      ParseFlowSeq(p, stop, LineIdx)
+    else
+      Error(LineIdx, 'expected "{" or "[" in flow value');
+  finally
+    dec(fDepth);
+  end;
+end;
+
+procedure TYamlToJson.ParseFlowMap(var p, stop: PUtf8Char; LineIdx: integer);
+var
+  first: boolean;
+  keyStart, keyEnd, valStart, valEnd: PUtf8Char;
+  keyText, valText: RawUtf8;
+  inSingle, inDouble: boolean;
+  depth: integer;
+begin
+  if p^ <> '{' then
+    Error(LineIdx, 'expected "{"');
+  inc(p);
+  fOut.Add('{');
+  first := true;
+  while p < stop do
+  begin
+    // skip whitespace
+    while (p < stop) and (p^ in [' ', #9]) do
+      inc(p);
+    if p >= stop then
+      Error(LineIdx, 'unterminated flow mapping');
+    if p^ = '}' then
+    begin
+      inc(p);
+      fOut.Add('}');
+      exit;
+    end;
+    if (p^ = ',') and not first then
+    begin
+      inc(p);
+      continue;
+    end;
+    // read key: unquoted, quoted, or flow-collection key (rare)
+    keyStart := p;
+    if p^ in ['"', ''''] then
+    begin
+      // skip quoted
+      inSingle := p^ = '''';
+      inDouble := p^ = '"';
+      inc(p);
+      while p < stop do
+      begin
+        if inSingle then
+        begin
+          if p^ = '''' then
+          begin
+            if (p + 1 < stop) and ((p + 1)^ = '''') then
+              inc(p, 2)
+            else
+            begin
+              inc(p);
+              break;
+            end;
+          end
+          else
+            inc(p);
+        end
+        else if inDouble then
+        begin
+          if p^ = '\' then
+          begin
+            inc(p);
+            if p < stop then
+              inc(p); // skip the escaped char (guarded against buffer end)
+          end
+          else if p^ = '"' then
+          begin
+            inc(p);
+            break;
+          end
+          else
+            inc(p);
+        end;
+      end;
+      keyEnd := p;
+      while (p < stop) and (p^ in [' ', #9]) do
+        inc(p);
+      if (p >= stop) or (p^ <> ':') then
+        Error(LineIdx, 'expected ":" after flow key');
+      inc(p);
+    end
+    else
+    begin
+      while (p < stop) and not (p^ in [':', ',', '}', #10]) do
+        inc(p);
+      if (p >= stop) or (p^ <> ':') then
+        Error(LineIdx, 'expected ":" after flow key');
+      keyEnd := p;
+      inc(p);
+    end;
+    FastSetString(keyText, keyStart, keyEnd - keyStart);
+    keyText := TrimYamlRight(TrimYamlLeft(keyText));
+    CheckUnsupportedScalar(LineIdx, keyText);
+    if not first then
+      fOut.Add(',');
+    EmitKey(keyText);
+    fOut.Add(':');
+    first := false;
+    // skip whitespace before value
+    while (p < stop) and (p^ in [' ', #9]) do
+      inc(p);
+    if p >= stop then
+      Error(LineIdx, 'unterminated flow mapping (expected value)');
+    if p^ in ['{', '['] then
+    begin
+      ParseFlow(p, stop, LineIdx);
+    end
+    else
+    begin
+      valStart := p;
+      depth := 0;
+      inSingle := false;
+      inDouble := false;
+      while p < stop do
+      begin
+        case p^ of
+          '''':
+            if not inDouble then
+              inSingle := not inSingle;
+          '"':
+            if not inSingle then
+              inDouble := not inDouble;
+          '{', '[':
+            if not inSingle and not inDouble then
+              inc(depth);
+          '}':
+            begin
+              if not inSingle and not inDouble then
+                if depth = 0 then
+                  break
+                else
+                  dec(depth);
+            end;
+          ']':
+            if not inSingle and not inDouble then
+              if depth = 0 then
+                Error(LineIdx, 'unbalanced "]" in flow-map value')
+              else
+                dec(depth);
+          ',':
+            if not inSingle and not inDouble and (depth = 0) then
+              break;
+        end;
+        inc(p);
+      end;
+      valEnd := p;
+      FastSetString(valText, valStart, valEnd - valStart);
+      EmitFlowScalar(valText, LineIdx);
+    end;
+  end;
+  Error(LineIdx, 'unterminated flow mapping');
+end;
+
+procedure TYamlToJson.ParseFlowSeq(var p, stop: PUtf8Char; LineIdx: integer);
+var
+  first: boolean;
+  valStart, valEnd: PUtf8Char;
+  valText: RawUtf8;
+  inSingle, inDouble: boolean;
+  depth: integer;
+begin
+  if p^ <> '[' then
+    Error(LineIdx, 'expected "["');
+  inc(p);
+  fOut.Add('[');
+  first := true;
+  while p < stop do
+  begin
+    while (p < stop) and (p^ in [' ', #9]) do
+      inc(p);
+    if p >= stop then
+      Error(LineIdx, 'unterminated flow sequence');
+    if p^ = ']' then
+    begin
+      inc(p);
+      fOut.Add(']');
+      exit;
+    end;
+    if (p^ = ',') and not first then
+    begin
+      inc(p);
+      continue;
+    end;
+    if p^ in ['{', '['] then
+    begin
+      if not first then
+        fOut.Add(',');
+      ParseFlow(p, stop, LineIdx);
+      first := false;
+      continue;
+    end;
+    valStart := p;
+    depth := 0;
+    inSingle := false;
+    inDouble := false;
+    while p < stop do
+    begin
+      case p^ of
+        '''':
+          if not inDouble then
+            inSingle := not inSingle;
+        '"':
+          if not inSingle then
+            inDouble := not inDouble;
+        '{', '[':
+          if not inSingle and not inDouble then
+            inc(depth);
+        '}':
+          if not inSingle and not inDouble then
+            if depth = 0 then
+              Error(LineIdx, 'unbalanced "}" in flow-seq value')
+            else
+              dec(depth);
+        ']':
+          begin
+            if not inSingle and not inDouble then
+              if depth = 0 then
+                break
+              else
+                dec(depth);
+          end;
+        ',':
+          if not inSingle and not inDouble and (depth = 0) then
+            break;
+      end;
+      inc(p);
+    end;
+    valEnd := p;
+    FastSetString(valText, valStart, valEnd - valStart);
+    if not first then
+      fOut.Add(',');
+    EmitFlowScalar(valText, LineIdx);
+    first := false;
+  end;
+  Error(LineIdx, 'unterminated flow sequence');
+end;
+
+procedure TYamlToJson.ParseValue(MinIndent: integer);
+var
+  content: RawUtf8;
+  p, stop: PUtf8Char;
+  lineIdx: integer;
+  afterDash: RawUtf8;
+  keyEnd: PtrInt;
+begin
+  inc(fDepth);
+  try
+    if fDepth > fMaxDepth then
+      ErrorFmt(fIdx,
+        'YAML nesting depth exceeds YamlMaxDepth (%)', [fMaxDepth]);
+    SkipBlankLines;
+    if AtEnd then
+    begin
+      fOut.AddShort('null');
+      exit;
+    end;
+    if fLines[fIdx].Indent < MinIndent then
+    begin
+      fOut.AddShort('null');
+      exit;
+    end;
+    lineIdx := fIdx;
+    content := fLines[fIdx].Content;
+    CheckUnsupportedScalar(lineIdx, content);
+    if content[1] in ['{', '['] then
+    begin
+      // single-line flow at this indent
+      p := pointer(content);
+      stop := p + length(content);
+      ParseFlow(p, stop, lineIdx);
+      inc(fIdx);
+      exit;
+    end;
+    if LineIsDashItem(content, afterDash) then
+    begin
+      ParseBlockSeq(fLines[fIdx].Indent);
+      exit;
+    end;
+    keyEnd := LineKeyEnd(content);
+    if keyEnd >= 0 then
+    begin
+      ParseBlockMap(fLines[fIdx].Indent);
+      exit;
+    end;
+    // plain top-level scalar line
+    if content[1] in ['|', '>'] then
+    begin
+      EmitBlockScalar(content, fLines[fIdx].Indent);
+    end
+    else if content[1] in ['"', ''''] then
+    begin
+      inc(fIdx);
+      MergeMultilineQuoted(content, lineIdx);
+      EmitScalarFragment(content, lineIdx);
+    end
+    else
+    begin
+      EmitScalarFragment(content, lineIdx);
+      inc(fIdx);
+    end;
+  finally
+    dec(fDepth);
+  end;
+end;
+
+function TYamlToJson.Run(const Yaml: RawUtf8): RawUtf8;
+var
+  firstIdx: integer;
+  topIndent: integer;
+  i: integer;
+  p, stop: PUtf8Char;
+begin
+  SplitYamlLines(Yaml, fLines);
+  fCount := length(fLines);
+  // tolerate a single leading "---" directives-end marker: common in spec
+  // files (GitHub REST API, Kubernetes, etc.). Strip it so downstream line
+  // numbers stay stable with the original file. Any SUBSEQUENT column-0
+  // "---" or "..." still raises as multi-document.
+  if (fCount > 0) and (fLines[0].Indent = 0) and
+     (fLines[0].Content = '---') then
+    fLines[0].Content := '';
+  // upfront scan: multi-doc separators, tab-indented lines, YAML directives
+  // - per YAML 1.2 spec, "---" and "..." markers are only structural when at
+  //   column 0; inside indented content (block scalars, etc.) they're literal
+  for i := 0 to fCount - 1 do
+  begin
+    if (fLines[i].Indent = 0) and
+       ((fLines[i].Content = '---') or (fLines[i].Content = '...')) then
+      Error(i, 'multi-document streams are not supported');
+    // YAML directives (%YAML, %TAG, ...): start with '%' at column 0
+    if (fLines[i].Indent = 0) and
+       (fLines[i].Content <> '') and
+       (fLines[i].Content[1] = '%') then
+      Error(i, 'YAML directives (%YAML / %TAG ...) are not supported');
+    // tabs in leading whitespace: YAML forbids tab indentation
+    p := pointer(fLines[i].Raw);
+    if p <> nil then
+    begin
+      stop := p + length(fLines[i].Raw);
+      while (p < stop) and (p^ in [' ', #9]) do
+      begin
+        if p^ = #9 then
+          Error(i, 'tab characters are not allowed for indentation');
+        inc(p);
+      end;
+    end;
+  end;
+  fIdx := 0;
+  if not FirstContentLine(firstIdx) then
+  begin
+    result := '{}';
+    exit;
+  end;
+  fIdx := firstIdx;
+  topIndent := fLines[firstIdx].Indent;
+  ParseValue(topIndent);
+  // after parsing the top-level value, any non-blank line with indent <=
+  // topIndent that was not consumed indicates an inconsistent-indent error
+  SkipBlankLines;
+  if not AtEnd then
+    Error(fIdx, 'unexpected line at this indentation');
+  result := fOut.Text;
+end;
+
+
+function YamlToVariant(const Yaml: RawUtf8; out Doc: TDocVariantData;
+  Options: TDocVariantOptions): boolean;
+var
+  conv: TYamlToJson;
+  json, src: RawUtf8;
+  opt: TDocVariantOptions;
+begin
+  result := false;
+  Doc.Clear;
+  src := Yaml;
+  // strip UTF-8 BOM regardless of source (file or in-memory) for consistency
+  if (length(src) >= 3) and (src[1] = #$EF) and
+     (src[2] = #$BB) and (src[3] = #$BF) then
+    delete(src, 1, 3);
+  if Options = [] then
+    opt := JSON_FAST_FLOAT + [dvoInternNames]
+  else
+    opt := Options;
+  conv := TYamlToJson.Create;
+  try
+    json := conv.Run(src);
+  finally
+    conv.Free;
+  end;
+  if json = '' then
+    exit;
+  result := Doc.InitJson(json, opt);
+end;
+
+function YamlToVariant_OpenApi(const Yaml: RawUtf8;
+  out Doc: TDocVariantData): boolean;
+// convenience alias preserving mormot.net.openapi's exact options set
+begin
+  result := YamlToVariant(Yaml, Doc, JSON_FAST + [dvoInternNames]);
+end;
+
+function YamlFileToVariant(const FileName: TFileName; out Doc: TDocVariantData;
+  Options: TDocVariantOptions): boolean;
+var
+  content: RawUtf8;
+begin
+  Doc.Clear;
+  if not FileExists(FileName) then
+    EYamlException.RaiseUtf8('YamlFileToVariant: file not found: %',
+      [FileName]);
+  content := StringFromFile(FileName);
+  // BOM stripping happens inside YamlToVariant now
+  result := YamlToVariant(content, Doc, Options);
+end;
+
+
+{ ----- TDocVariant -> YAML writer ----------------------------------------- }
+
+type
+  TVariantToYaml = class
+  private
+    fOut: TTextWriter;
+    fOutBuf: TTextWriterStackBuffer;
+    fOptions: TYamlWriterOptions;
+    procedure WriteValue(const v: variant; Indent: integer);
+    procedure WriteBlockMap(const dv: TDocVariantData; Indent: integer);
+    procedure WriteBlockSeq(const dv: TDocVariantData; Indent: integer);
+    procedure WriteFlow(const dv: TDocVariantData);
+    procedure WriteScalar(const v: variant);
+    procedure WriteYamlKey(const K: RawUtf8);
+    procedure WriteYamlString(const S: RawUtf8);
+    procedure WriteIndent(N: integer);
+    function IsSimpleLeaf(const dv: TDocVariantData): boolean;
+  public
+    constructor Create(Options: TYamlWriterOptions);
+    destructor Destroy; override;
+    function Run(const Doc: variant): RawUtf8;
+  end;
+
+constructor TVariantToYaml.Create(Options: TYamlWriterOptions);
+begin
+  inherited Create;
+  fOut := TTextWriter.CreateOwnedStream(fOutBuf);
+  fOptions := Options;
+end;
+
+destructor TVariantToYaml.Destroy;
+begin
+  fOut.Free;
+  inherited Destroy;
+end;
+
+procedure TVariantToYaml.WriteIndent(N: integer);
+var
+  i: integer;
+begin
+  for i := 1 to N do
+    fOut.Add(' ');
+end;
+
+function TVariantToYaml.IsSimpleLeaf(const dv: TDocVariantData): boolean;
+var
+  i: integer;
+  cd: PDocVariantData;
+begin
+  if dv.Count = 0 then
+  begin
+    result := true;
+    exit;
+  end;
+  for i := 0 to dv.Count - 1 do
+  begin
+    if _Safe(dv.Values[i], cd) then
+      if cd^.Count > 0 then
+      begin
+        result := false;
+        exit;
+      end;
+    // also reject nested collections (empty are ok) — only plain scalars
+  end;
+  result := true;
+end;
+
+procedure TVariantToYaml.WriteYamlString(const S: RawUtf8);
+var
+  needsQuote: boolean;
+  i, n: integer;
+  c: AnsiChar;
+  hasSpecial: boolean;
+begin
+  n := length(S);
+  if n = 0 then
+  begin
+    fOut.AddShort('""');
+    exit;
+  end;
+  hasSpecial := false;
+  needsQuote := false;
+  // leading chars that need quoting
+  if S[1] in [' ', #9, '!', '&', '*', '>', '|', '%', '@', '`', '"', '''',
+              '#', '-', '?', ':', '{', '[', '}', ']', ','] then
+    needsQuote := true;
+  // trailing whitespace
+  if (not needsQuote) and (S[n] in [' ', #9]) then
+    needsQuote := true;
+  // reserved plain-scalar forms: null, bool, numbers - must be quoted to
+  // preserve string type on round-trip
+  if not needsQuote then
+  begin
+    if IsYamlNull(S) then
+      needsQuote := true
+    else if (S = 'true') or (S = 'True') or (S = 'TRUE') or
+            (S = 'false') or (S = 'False') or (S = 'FALSE') then
+      needsQuote := true
+    else if IsYamlFloat(S) then
+      needsQuote := true
+    else
+    begin
+      i := 1;
+      if S[1] in ['-', '+'] then
+        inc(i);
+      if (i <= n) and (S[i] in ['0'..'9']) then
+      begin
+        needsQuote := true;
+        while i <= n do
+        begin
+          if not (S[i] in ['0'..'9', 'x', 'o', 'a'..'f', 'A'..'F']) then
+          begin
+            needsQuote := false;
+            break;
+          end;
+          inc(i);
+        end;
+      end;
+    end;
+  end;
+  // scan for chars that require escape
+  if not needsQuote then
+    for i := 1 to n do
+    begin
+      c := S[i];
+      if (c < #32) or (c = '"') or (c = '\') then
+      begin
+        needsQuote := true;
+        hasSpecial := true;
+        break;
+      end;
+      if (c = ':') and (i < n) and (S[i + 1] in [' ', #9]) then
+      begin
+        needsQuote := true;
+        break;
+      end;
+      if (c = '#') and (i > 1) and (S[i - 1] in [' ', #9]) then
+      begin
+        needsQuote := true;
+        break;
+      end;
+    end;
+  if not needsQuote then
+  begin
+    fOut.AddNoJsonEscape(pointer(S), n);
+    exit;
+  end;
+  // emit as double-quoted with JSON-like escapes
+  fOut.Add('"');
+  for i := 1 to n do
+  begin
+    c := S[i];
+    case c of
+      #0..#7:
+        begin
+          // \x0X where X is the single hex digit for ord(c) in 0..7
+          fOut.AddShort('\x0');
+          fOut.Add(AnsiChar(ord('0') + ord(c)));
+        end;
+      #8: fOut.AddShort('\b');
+      #9: fOut.AddShort('\t');
+      #10: fOut.AddShort('\n');
+      #11: fOut.AddShort('\v');
+      #12: fOut.AddShort('\f');
+      #13: fOut.AddShort('\r');
+      #14..#31:
+        begin
+          fOut.AddShort('\x');
+          fOut.Add(HEX_LOWER[ord(c) shr 4]);
+          fOut.Add(HEX_LOWER[ord(c) and $F]);
+        end;
+      '"': fOut.AddShort('\"');
+      '\': fOut.AddShort('\\');
+    else
+      fOut.Add(c);
+    end;
+  end;
+  fOut.Add('"');
+  // suppress unused-var warnings when we reference hasSpecial
+  if hasSpecial then ;
+end;
+
+procedure TVariantToYaml.WriteYamlKey(const K: RawUtf8);
+begin
+  WriteYamlString(K);
+end;
+
+procedure TVariantToYaml.WriteScalar(const v: variant);
+var
+  vt: word;
+  s: RawUtf8;
+begin
+  vt := TVarData(v).VType;
+  case vt of
+    varEmpty, varNull:
+      fOut.AddShort('null');
+    varBoolean:
+      if TVarData(v).VBoolean then
+        fOut.AddShort('true')
+      else
+        fOut.AddShort('false');
+    varByte, varShortInt, varWord, varSmallInt, varLongWord, varInteger,
+    varInt64, varWord64:
+      begin
+        VariantToUtf8(v, s);
+        fOut.AddNoJsonEscape(pointer(s), length(s));
+      end;
+    varSingle, varDouble, varCurrency:
+      begin
+        VariantToUtf8(v, s);
+        fOut.AddNoJsonEscape(pointer(s), length(s));
+      end;
+  else
+    begin
+      VariantToUtf8(v, s);
+      WriteYamlString(s);
+    end;
+  end;
+end;
+
+procedure TVariantToYaml.WriteFlow(const dv: TDocVariantData);
+var
+  i: integer;
+begin
+  if dv.Kind = dvObject then
+  begin
+    fOut.Add('{');
+    for i := 0 to dv.Count - 1 do
+    begin
+      if i > 0 then
+        fOut.AddShort(', ');
+      WriteYamlKey(dv.Names[i]);
+      fOut.AddShort(': ');
+      WriteScalar(dv.Values[i]);
+    end;
+    fOut.Add('}');
+  end
+  else
+  begin
+    fOut.Add('[');
+    for i := 0 to dv.Count - 1 do
+    begin
+      if i > 0 then
+        fOut.AddShort(', ');
+      WriteScalar(dv.Values[i]);
+    end;
+    fOut.Add(']');
+  end;
+end;
+
+procedure TVariantToYaml.WriteBlockMap(const dv: TDocVariantData; Indent: integer);
+var
+  i: integer;
+  cd: PDocVariantData;
+begin
+  if dv.Count = 0 then
+  begin
+    fOut.AddShort('{}');
+    exit;
+  end;
+  for i := 0 to dv.Count - 1 do
+  begin
+    if i > 0 then
+      WriteIndent(Indent);
+    WriteYamlKey(dv.Names[i]);
+    fOut.Add(':');
+    if _Safe(dv.Values[i], cd) and (cd^.Count > 0) then
+    begin
+      fOut.Add(#10);
+      WriteIndent(Indent + 2);
+      WriteValue(dv.Values[i], Indent + 2);
+    end
+    else
+    begin
+      fOut.Add(' ');
+      WriteValue(dv.Values[i], Indent + 2);
+    end;
+    if i < dv.Count - 1 then
+      fOut.Add(#10);
+  end;
+end;
+
+procedure TVariantToYaml.WriteBlockSeq(const dv: TDocVariantData; Indent: integer);
+var
+  i: integer;
+  cd: PDocVariantData;
+begin
+  if dv.Count = 0 then
+  begin
+    fOut.AddShort('[]');
+    exit;
+  end;
+  for i := 0 to dv.Count - 1 do
+  begin
+    if i > 0 then
+      WriteIndent(Indent);
+    fOut.AddShort('- ');
+    if _Safe(dv.Values[i], cd) and (cd^.Count > 0) then
+    begin
+      // put child map/seq inline after the dash
+      if cd^.Kind = dvObject then
+      begin
+        WriteBlockMap(cd^, Indent + 2);
+      end
+      else
+      begin
+        fOut.Add(#10);
+        WriteIndent(Indent + 2);
+        WriteBlockSeq(cd^, Indent + 2);
+      end;
+    end
+    else
+    begin
+      WriteValue(dv.Values[i], Indent + 2);
+    end;
+    if i < dv.Count - 1 then
+      fOut.Add(#10);
+  end;
+end;
+
+procedure TVariantToYaml.WriteValue(const v: variant; Indent: integer);
+var
+  cd: PDocVariantData;
+begin
+  if _Safe(v, cd) and (cd^.Kind <> dvUndefined) then
+  begin
+    if cd^.Count = 0 then
+    begin
+      if cd^.Kind = dvArray then
+        fOut.AddShort('[]')
+      else
+        fOut.AddShort('{}');
+      exit;
+    end;
+    if cd^.Kind = dvObject then
+      WriteBlockMap(cd^, Indent)
+    else
+      WriteBlockSeq(cd^, Indent);
+    exit;
+  end;
+  WriteScalar(v);
+end;
+
+function TVariantToYaml.Run(const Doc: variant): RawUtf8;
+var
+  cd: PDocVariantData;
+begin
+  if _Safe(Doc, cd) and (cd^.Kind <> dvUndefined) then
+  begin
+    if cd^.Count = 0 then
+    begin
+      if cd^.Kind = dvArray then
+        result := '[]' + #10
+      else
+        result := '{}' + #10;
+      exit;
+    end;
+    if cd^.Kind = dvObject then
+      WriteBlockMap(cd^, 0)
+    else
+      WriteBlockSeq(cd^, 0);
+    fOut.Add(#10);
+  end
+  else
+    WriteScalar(Doc);
+  result := fOut.Text;
+end;
+
+
+function VariantToYaml(const Doc: variant; Options: TYamlWriterOptions): RawUtf8;
+var
+  w: TVariantToYaml;
+begin
+  w := TVariantToYaml.Create(Options);
+  try
+    result := w.Run(Doc);
+  finally
+    w.Free;
+  end;
+end;
+
+procedure SaveVariantToYamlFile(const Doc: variant; const FileName: TFileName;
+  Options: TYamlWriterOptions);
+begin
+  FileFromString(VariantToYaml(Doc, Options), FileName);
+end;
+
+
+end.

--- a/src/core/mormot.core.yaml.pas
+++ b/src/core/mormot.core.yaml.pas
@@ -1927,14 +1927,14 @@ type
   private
     fOut: TJsonWriter;
     fOptions: TYamlWriterOptions;
-    procedure WriteValue(const v: variant; Indent: integer);
-    procedure WriteBlockMap(const dv: TDocVariantData; Indent: integer);
-    procedure WriteBlockSeq(const dv: TDocVariantData; Indent: integer);
+    procedure WriteValue(const v: variant; Indent: PtrInt);
+    procedure WriteBlockMap(const dv: TDocVariantData; Indent: PtrInt);
+    procedure WriteBlockSeq(const dv: TDocVariantData; Indent: PtrInt);
     procedure WriteFlow(const dv: TDocVariantData);
     procedure WriteScalar(const v: variant);
     procedure WriteYamlKey(const K: RawUtf8);
     procedure WriteYamlString(const S: RawUtf8);
-    procedure WriteIndent(N: integer);
+    procedure WriteIndent(N: PtrInt);
     function IsSimpleLeaf(const dv: TDocVariantData): boolean;
   public
     constructor Create(Options: TYamlWriterOptions);
@@ -1955,12 +1955,10 @@ begin
   inherited Destroy;
 end;
 
-procedure TVariantToYaml.WriteIndent(N: integer);
-var
-  i: integer;
+procedure TVariantToYaml.WriteIndent(N: PtrInt);
 begin
-  for i := 1 to N do
-    fOut.Add(' ');
+  // use AddChars: single buffer-checked call replaces a per-space Add() loop
+  fOut.AddChars(' ', N);
 end;
 
 function TVariantToYaml.IsSimpleLeaf(const dv: TDocVariantData): boolean;
@@ -2108,7 +2106,7 @@ end;
 
 procedure TVariantToYaml.WriteFlow(const dv: TDocVariantData);
 var
-  i: integer;
+  i: PtrInt;
 begin
   if dv.Kind = dvObject then
   begin
@@ -2136,9 +2134,9 @@ begin
   end;
 end;
 
-procedure TVariantToYaml.WriteBlockMap(const dv: TDocVariantData; Indent: integer);
+procedure TVariantToYaml.WriteBlockMap(const dv: TDocVariantData; Indent: PtrInt);
 var
-  i: integer;
+  i: PtrInt;
   cd: PDocVariantData;
 begin
   if dv.Count = 0 then
@@ -2168,9 +2166,9 @@ begin
   end;
 end;
 
-procedure TVariantToYaml.WriteBlockSeq(const dv: TDocVariantData; Indent: integer);
+procedure TVariantToYaml.WriteBlockSeq(const dv: TDocVariantData; Indent: PtrInt);
 var
-  i: integer;
+  i: PtrInt;
   cd: PDocVariantData;
 begin
   if dv.Count = 0 then
@@ -2206,7 +2204,7 @@ begin
   end;
 end;
 
-procedure TVariantToYaml.WriteValue(const v: variant; Indent: integer);
+procedure TVariantToYaml.WriteValue(const v: variant; Indent: PtrInt);
 var
   cd: PDocVariantData;
 begin

--- a/src/net/mormot.net.openapi.pas
+++ b/src/net/mormot.net.openapi.pas
@@ -51,7 +51,8 @@ uses
   mormot.core.rtti,
   mormot.core.data, // for TRawUtf8List
   mormot.core.fmt,
-  mormot.core.variants;
+  mormot.core.variants,
+  mormot.core.yaml; // for YAML spec input
 
 
 { ************************************ OpenAPI Document Wrappers }
@@ -601,10 +602,15 @@ type
     /// finalize this parser instance
     destructor Destroy; override;
 
-    /// parse a JSON Swagger/OpenAPI file content
-    procedure ParseFile(const aJsonFile: TFileName);
+    /// parse a Swagger/OpenAPI spec from a file
+    // - auto-detects JSON (default) or YAML (.yaml / .yml extension)
+    procedure ParseFile(const aSpecFile: TFileName);
     /// parse a JSON Swagger/OpenAPI content
     procedure ParseJson(const aJson: RawUtf8);
+    /// parse a YAML Swagger/OpenAPI content
+    procedure ParseYaml(const aYaml: RawUtf8);
+    /// parse a YAML Swagger/OpenAPI spec file
+    procedure ParseYamlFile(const aYamlFile: TFileName);
     /// parse a Swagger/OpenAPI content tree from an existing TDocVariant
     procedure ParseData(const aSpecs: TDocVariantData);
     /// clear all internal information of this parser instance
@@ -2264,6 +2270,11 @@ begin
     fName := fErrorType.CustomType.Name
   else if fErrorType.BuiltInType = obtRawUtf8 then
     fName := 'TextResponse'
+  else if fErrorType.BuiltInType = obtVariant then
+    // empty-object schema ({type:object, properties:{}}) or untyped response
+    // body: fall back to a generic variant-backed exception class.
+    // Seen e.g. in GitHub REST spec for 304 "Not Modified" responses.
+    fName := 'VariantResponse'
   else
     EOpenApi.RaiseUtf8('%.Create: unsupported schema for %', [self, aResponse^.Data.ToJson]);
   fErrorTypeName := fErrorType.ToPascalName;
@@ -2400,10 +2411,38 @@ begin
   ParseSpecs;
 end;
 
-procedure TOpenApiParser.ParseFile(const aJsonFile: TFileName);
+procedure TOpenApiParser.ParseYaml(const aYaml: RawUtf8);
 begin
   Clear;
-  fSpecs.Data.InitJsonFromFile(aJsonFile, JSON_FAST + [dvoInternNames]);
+  if not YamlToVariant(aYaml, fSpecs.Data, JSON_FAST + [dvoInternNames]) then
+    EOpenApi.RaiseUtf8('%.ParseYaml: invalid YAML payload', [self]);
+  ParseSpecs;
+end;
+
+procedure TOpenApiParser.ParseYamlFile(const aYamlFile: TFileName);
+begin
+  Clear;
+  if not YamlFileToVariant(aYamlFile, fSpecs.Data, JSON_FAST + [dvoInternNames]) then
+    EOpenApi.RaiseUtf8('%.ParseYamlFile: invalid YAML file %',
+      [self, aYamlFile]);
+  ParseSpecs;
+end;
+
+procedure TOpenApiParser.ParseFile(const aSpecFile: TFileName);
+var
+  ext: TFileName;
+begin
+  Clear;
+  ext := LowerCase(ExtractFileExt(aSpecFile));
+  if (ext = '.yaml') or (ext = '.yml') then
+  begin
+    if not YamlFileToVariant(aSpecFile, fSpecs.Data,
+         JSON_FAST + [dvoInternNames]) then
+      EOpenApi.RaiseUtf8('%.ParseFile: invalid YAML file %',
+        [self, aSpecFile]);
+  end
+  else
+    fSpecs.Data.InitJsonFromFile(aSpecFile, JSON_FAST + [dvoInternNames]);
   ParseSpecs;
 end;
 

--- a/test/data/yaml/petstore-mini.json
+++ b/test/data/yaml/petstore-mini.json
@@ -1,0 +1,81 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Petstore",
+    "version": "1.0.0",
+    "description": "A minimal Petstore-style API for YAML/JSON equivalence testing."
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List pets",
+        "operationId": "listPets",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Pet" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPet",
+        "responses": {
+          "201": { "description": "Created" }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "summary": "Get one pet by id",
+        "operationId": "getPet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id":   { "type": "integer", "format": "int64" },
+          "name": { "type": "string" },
+          "tag":  { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/test/data/yaml/petstore-mini.yaml
+++ b/test/data/yaml/petstore-mini.yaml
@@ -1,0 +1,63 @@
+openapi: 3.0.0
+info:
+  title: Petstore
+  version: 1.0.0
+  description: A minimal Petstore-style API for YAML/JSON equivalence testing.
+paths:
+  /pets:
+    get:
+      summary: List pets
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+    post:
+      summary: Create a pet
+      operationId: createPet
+      responses:
+        '201':
+          description: Created
+  /pets/{id}:
+    get:
+      summary: Get one pet by id
+      operationId: getPet
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string

--- a/test/mormot2tests.dpr
+++ b/test/mormot2tests.dpr
@@ -60,6 +60,7 @@ uses
   mormot.crypt.openssl,
   mormot.tools.ecc         in '..\src\tools\ecc\mormot.tools.ecc.pas',
   test.core.base           in '.\test.core.base.pas',
+  test.core.yaml           in '.\test.core.yaml.pas',
   test.core.data           in '.\test.core.data.pas',
   test.core.crypt          in '.\test.core.crypt.pas',
   test.core.ecc            in '.\test.core.ecc.pas',
@@ -154,7 +155,11 @@ begin
     TTestCoreCrypto,
     TTestCoreEcc,
     TTestCoreCompression,
-    TNetworkProtocols
+    TNetworkProtocols,
+    // TTestCoreYaml registered last: dvoInternNames interning would otherwise
+    // pollute the TDocVariant intern counters that the JSON benchmark of
+    // TTestCoreProcess measures as deltas
+    TTestCoreYaml
   ]);
 end;
 

--- a/test/test.core.yaml.pas
+++ b/test/test.core.yaml.pas
@@ -1,0 +1,448 @@
+/// regression tests for mormot.core.yaml unit
+// - this unit is a part of the Open Source Synopse mORMot framework 2,
+// licensed under a MPL/GPL/LGPL three license - see LICENSE.md
+unit test.core.yaml;
+
+interface
+
+{$I ..\src\mormot.defines.inc}
+
+uses
+  sysutils,
+  classes,
+  variants,
+  mormot.core.base,
+  mormot.core.os,
+  mormot.core.unicode,
+  mormot.core.text,
+  mormot.core.data,
+  mormot.core.variants,
+  mormot.core.test,
+  mormot.core.yaml;
+
+type
+  /// regression tests for mormot.core.yaml features
+  TTestCoreYaml = class(TSynTestCase)
+  protected
+    procedure RunGolden(const Name, Yaml, ExpectedJson: RawUtf8);
+    procedure ExpectRaise(const Name, Yaml: RawUtf8);
+  published
+    /// parse YAML happy paths and compare TDocVariantData.ToJson
+    procedure _ParseGolden;
+    /// parse then serialize then parse, compare equivalence
+    procedure _Roundtrip;
+    /// unsupported constructs must raise EYamlException with line info
+    procedure _ErrorCases;
+    /// YamlFileToVariant reads via OS file I/O
+    procedure _FileApi;
+    /// pathological deep nesting must raise EYamlException, not EStackOverflow
+    // - covers the Stripe 6 MB spec3 public stress-test failure mode
+    procedure _RecursionDepth;
+    /// an OpenAPI-shaped spec in YAML must yield the same TDocVariantData
+    // as its JSON counterpart - this is the invariant mopenapi relies on
+    procedure _OpenApiEquivalence;
+  end;
+
+
+implementation
+
+
+{ TTestCoreYaml }
+
+type
+  TYamlGoldenCase = record
+    Name: RawUtf8;
+    Yaml: RawUtf8;
+    ExpectedJson: RawUtf8;
+  end;
+
+const
+  // golden cases, covering the I/O matrix of spec-yaml-support.md
+  GOLDEN: array[0..31] of TYamlGoldenCase = (
+    (Name: 'empty-flow-map';
+     Yaml: '{}';
+     ExpectedJson: '{}'),
+    (Name: 'empty-flow-seq';
+     Yaml: '[]';
+     ExpectedJson: '[]'),
+    (Name: 'block-map-simple';
+     Yaml: 'a: 1'#10'b: two';
+     ExpectedJson: '{"a":1,"b":"two"}'),
+    (Name: 'block-seq-simple';
+     Yaml: '- x'#10'- y';
+     ExpectedJson: '["x","y"]'),
+    (Name: 'nested-seq-of-map';
+     Yaml: 'list:'#10'  - a: 1';
+     ExpectedJson: '{"list":[{"a":1}]}'),
+    (Name: 'compact-seq-same-indent';
+     // YAML 1.2 allows "- item" at same indent as parent key (common in OpenAPI)
+     Yaml: 'servers:'#10'- url: /api'#10'tags:'#10'- name: pet'#10'  description: dogs';
+     ExpectedJson: '{"servers":[{"url":"/api"}],"tags":[{"name":"pet","description":"dogs"}]}'),
+    (Name: 'leading-doc-marker';
+     // single "---" at file start is a directives-end marker (not multi-doc);
+     // commonly emitted by yq/jq/Kubernetes/GitHub specs
+     Yaml: '---'#10'a: 1'#10'b: 2';
+     ExpectedJson: '{"a":1,"b":2}'),
+    (Name: 'dash3-in-block-scalar';
+     // indented "---" inside a literal block must be treated as literal
+     // content, not as a multi-doc marker (seen in github REST API spec)
+     Yaml: 'k: |'#10'  line1'#10'  ---'#10'  line3';
+     ExpectedJson: '{"k":"line1\n---\nline3\n"}'),
+    (Name: 'nested-map-of-seq';
+     Yaml: 'outer:'#10'  inner:'#10'    - 1'#10'    - 2';
+     ExpectedJson: '{"outer":{"inner":[1,2]}}'),
+    (Name: 'flow-inline-mixed';
+     Yaml: '{a: [1, 2], b: {c: d}}';
+     ExpectedJson: '{"a":[1,2],"b":{"c":"d"}}'),
+    (Name: 'scalar-types';
+     Yaml: 'n: null'#10'b: true'#10'i: 42'#10'f: 3.14'#10's: hi';
+     ExpectedJson: '{"n":null,"b":true,"i":42,"f":3.14,"s":"hi"}'),
+    (Name: 'scalar-null-variants';
+     Yaml: 'a: ~'#10'b:'#10'c: Null';
+     ExpectedJson: '{"a":null,"b":null,"c":null}'),
+    (Name: 'quoted-keeps-string';
+     Yaml: 'a: "1"'#10'b: ''true''';
+     ExpectedJson: '{"a":"1","b":"true"}'),
+    (Name: 'literal-block';
+     Yaml: 'k: |'#10'  line1'#10'  line2';
+     ExpectedJson: '{"k":"line1\nline2\n"}'),
+    (Name: 'folded-block';
+     Yaml: 'k: >'#10'  line1'#10'  line2';
+     ExpectedJson: '{"k":"line1 line2\n"}'),
+    (Name: 'literal-strip-chomp';
+     Yaml: 'k: |-'#10'  line1'#10'  line2';
+     ExpectedJson: '{"k":"line1\nline2"}'),
+    (Name: 'trailing-comment';
+     Yaml: 'a: 1 # ignore'#10'b: 2';
+     ExpectedJson: '{"a":1,"b":2}'),
+    (Name: 'negative-and-float';
+     Yaml: 'a: -7'#10'b: -0.5'#10'c: 1e3';
+     ExpectedJson: '{"a":-7,"b":-0.5,"c":1000}'),
+    (Name: 'multiline-quoted-backslash';
+     // YAML 1.2 §7.5 double-quoted line-continuation via trailing backslash;
+     // discovered via Swagger petstore3.yaml line 167
+     Yaml: 'description: "Use\'#10'    \ tag1, tag2 for testing."';
+     ExpectedJson: '{"description":"Use tag1, tag2 for testing."}'),
+    (Name: 'multiline-quoted-folding';
+     // YAML 1.2 §7.5 quoted multi-line without trailing \: line-break folds to space
+     Yaml: 'k: "line one'#10'  line two"';
+     ExpectedJson: '{"k":"line one line two"}'),
+    (Name: 'block-key-inline-empty-flow-seq';
+     // "key: []" on the RHS of a block-map entry is legal YAML (and common in
+     // OpenAPI, e.g. "parameters: []"); regressed against a latent infinite-
+     // recursion path in ParseBlockMap previously masked by the 3 fixes above
+     Yaml: 'parameters: []'#10'responses: {}';
+     ExpectedJson: '{"parameters":[],"responses":{}}'),
+    (Name: 'block-key-inline-flow-seq-nonempty';
+     Yaml: 'tags: [a, b, c]'#10'name: x';
+     ExpectedJson: '{"tags":["a","b","c"],"name":"x"}'),
+    (Name: 'markdown-bold-not-alias';
+     // "**text**" inside a plain scalar must NOT be rejected as a YAML alias;
+     // 182 hits in the GitHub REST API spec once plain-scalar folding is on
+     Yaml: 'description: foo **Required** bar';
+     ExpectedJson: '{"description":"foo **Required** bar"}'),
+    (Name: 'plain-scalar-folded';
+     // YAML 1.2 §6.5 plain scalar folding: continuation indented > key indent;
+     // discovered via GitHub REST api.github.com.yaml line 156
+     Yaml: 'description: If specified, only advisories with this'#10 +
+           '  GHSA identifier will be returned.';
+     ExpectedJson:
+       '{"description":"If specified, only advisories with this GHSA ' +
+       'identifier will be returned."}'),
+    (Name: 'plain-scalar-folded-with-quotes';
+     // GitHub REST spec §3541 continuation line starts with "; that is
+     // literal text in a folded plain scalar, not a new quoted scalar
+     Yaml: 'description: slug example, such as'#10 +
+           '  "My TEam" would become team.';
+     ExpectedJson:
+       '{"description":"slug example, such as \"My TEam\" would become team."}'),
+    (Name: 'ampersand-in-url-is-not-anchor';
+     // mid-scalar '&' in query strings is literal text, not an anchor;
+     // 27 hits in the GitHub REST spec once plain-scalar folding is on
+     Yaml: 'example: https://x.test/?a=1&b=2&c=3';
+     ExpectedJson: '{"example":"https://x.test/?a=1&b=2&c=3"}'),
+    (Name: 'markdown-image-not-tag';
+     // "![alt](url)" in plain-scalar text is markdown, not a YAML tag;
+     // 215 hits in the GitHub REST spec
+     Yaml: 'description: see ![icon](https://x.test/a.png) inline.';
+     ExpectedJson:
+       '{"description":"see ![icon](https://x.test/a.png) inline."}'),
+    (Name: 'plain-scalar-folded-with-brackets';
+     // GitHub REST spec §9656 - a folded plain scalar embeds markdown links
+     // like "[text](url)", so a continuation line starting with '[' is text
+     Yaml: 'description: uses the'#10 +
+           '  [List endpoint](https://example.test) for details.';
+     ExpectedJson:
+       '{"description":"uses the [List endpoint](https://example.test) ' +
+       'for details."}'),
+    (Name: 'literal-explicit-indent';
+     // YAML 1.2 §8.1.1.1 explicit-indent block scalar: "|2" forces
+     // content indent = parent+2, overriding auto-detection. First content
+     // line is deeper than parent+2, so auto-detect would mis-compute and
+     // break out on the shallower second line.
+     Yaml: 'k: |2'#10'      line1'#10'    line2';
+     ExpectedJson: '{"k":"    line1\n  line2\n"}'),
+    (Name: 'folded-explicit-indent';
+     // ">2" sibling of "|2" for folded style: same indent rule applies and
+     // line-break -> space folding still works. After stripping blockIndent=2,
+     // line1 is "    one" (4 spaces) and line2 is "  two" (2 spaces); folding
+     // injects a single space between them, yielding 3 spaces mid-output.
+     Yaml: 'k: >2'#10'      one'#10'    two';
+     ExpectedJson: '{"k":"    one   two\n"}'),
+    (Name: 'explicit-indent-varying-depth';
+     // real GitHub REST octocat shape: content lines vary from deeper
+     // to shallower but all >= parent+2; auto-detect would truncate at
+     // the second line because its indent is less than the first line.
+     Yaml: 'v: |2'#10'       A'#10'      B'#10'       C';
+     ExpectedJson: '{"v":"     A\n    B\n     C\n"}'),
+    (Name: 'nested-compact-seq-of-seq';
+     // YAML 1.2 compact nested block-seq: "- - X" on one physical line
+     // starts a new inner seq at (outer Indent + 2); following lines at
+     // that depth continue the inner seq. Discovered via GitHub REST spec
+     // line 223996 (sort_by: [[123, asc], [456, desc]]).
+     Yaml: 'k:'#10'- - 1'#10'  - 2'#10'- - 3'#10'  - 4';
+     ExpectedJson: '{"k":[[1,2],[3,4]]}')
+  );
+
+  ERRORS: array[0..8] of TYamlGoldenCase = (
+    (Name: 'anchor';
+     Yaml: 'a: &ref 1'#10'b: *ref';
+     ExpectedJson: ''),
+    (Name: 'alias-only';
+     Yaml: 'a: *missing';
+     ExpectedJson: ''),
+    (Name: 'explicit-tag';
+     Yaml: 'a: !!str 1';
+     ExpectedJson: ''),
+    (Name: 'multi-doc-separator';
+     Yaml: '---'#10'a: 1'#10'---'#10'b: 2';
+     ExpectedJson: ''),
+    (Name: 'bad-indent';
+     Yaml: 'a:'#10'  b: 1'#10' c: 2';
+     ExpectedJson: ''),
+    (Name: 'tab-indent';
+     Yaml: 'a:'#10#9'b: 1';
+     ExpectedJson: ''),
+    (Name: 'yaml-directive';
+     Yaml: '%YAML 1.2'#10'a: 1';
+     ExpectedJson: ''),
+    (Name: 'tag-directive';
+     Yaml: '%TAG ! tag:example.com,2024:'#10'a: 1';
+     ExpectedJson: ''),
+    (Name: 'explicit-indent-zero';
+     // YAML 1.2 §8.1.1.1 forbids 0 as an explicit indent indicator
+     Yaml: 'k: |0'#10'  x';
+     ExpectedJson: '')
+  );
+
+procedure TTestCoreYaml.RunGolden(const Name, Yaml, ExpectedJson: RawUtf8);
+var
+  doc: TDocVariantData;
+  actual: RawUtf8;
+  ok: boolean;
+begin
+  doc.Clear;
+  ok := YamlToVariant(Yaml, doc);
+  CheckUtf8(ok, 'YamlToVariant returned false for %', [Name]);
+  actual := doc.ToJson;
+  CheckEqual(actual, ExpectedJson, FormatUtf8('golden "%"', [Name]));
+end;
+
+procedure TTestCoreYaml.ExpectRaise(const Name, Yaml: RawUtf8);
+var
+  doc: TDocVariantData;
+  raised: boolean;
+begin
+  doc.Clear;
+  raised := false;
+  try
+    YamlToVariant(Yaml, doc);
+  except
+    on EYamlException do
+      raised := true;
+  end;
+  CheckUtf8(raised, 'expected EYamlException for %', [Name]);
+end;
+
+procedure TTestCoreYaml._ParseGolden;
+var
+  i: PtrInt;
+begin
+  for i := low(GOLDEN) to high(GOLDEN) do
+    RunGolden(GOLDEN[i].Name, GOLDEN[i].Yaml, GOLDEN[i].ExpectedJson);
+end;
+
+procedure TTestCoreYaml._Roundtrip;
+var
+  i: PtrInt;
+  doc1, doc2: TDocVariantData;
+  yaml: RawUtf8;
+begin
+  for i := low(GOLDEN) to high(GOLDEN) do
+  begin
+    doc1.Clear;
+    doc2.Clear;
+    // first parse MUST succeed for every golden case; silently skipping would
+    // let real regressions pass this test - that is the anti-pattern
+    CheckUtf8(YamlToVariant(GOLDEN[i].Yaml, doc1),
+      'roundtrip initial parse failed for %', [GOLDEN[i].Name]);
+    yaml := VariantToYaml(variant(doc1));
+    CheckUtf8(YamlToVariant(yaml, doc2),
+      'roundtrip parse-2 failed for %', [GOLDEN[i].Name]);
+    CheckEqual(doc2.ToJson, doc1.ToJson,
+      FormatUtf8('roundtrip "%"', [GOLDEN[i].Name]));
+  end;
+end;
+
+procedure TTestCoreYaml._ErrorCases;
+var
+  i: PtrInt;
+begin
+  for i := low(ERRORS) to high(ERRORS) do
+    ExpectRaise(ERRORS[i].Name, ERRORS[i].Yaml);
+end;
+
+procedure TTestCoreYaml._FileApi;
+var
+  fn: TFileName;
+  doc: TDocVariantData;
+  raised: boolean;
+  yamlBom: RawUtf8;
+begin
+  fn := WorkDir + 'test.core.yaml.tmp.yaml';
+  FileFromString('a: 1'#10'b: 2'#10, fn);
+  try
+    doc.Clear;
+    Check(YamlFileToVariant(fn, doc), 'YamlFileToVariant returned false');
+    CheckEqual(doc.ToJson, '{"a":1,"b":2}', 'file api');
+  finally
+    DeleteFile(fn);
+  end;
+  // file-not-found must raise EYamlException (patch P10)
+  raised := false;
+  try
+    YamlFileToVariant(WorkDir + 'does.not.exist.yaml', doc);
+  except
+    on EYamlException do
+      raised := true;
+  end;
+  Check(raised, 'file-not-found must raise EYamlException');
+  // BOM must be stripped even in inline YamlToVariant (patch P8)
+  yamlBom := #$EF#$BB#$BF + 'a: 1';
+  doc.Clear;
+  Check(YamlToVariant(yamlBom, doc), 'YamlToVariant with BOM');
+  CheckEqual(doc.ToJson, '{"a":1}', 'inline BOM stripped');
+end;
+
+procedure TTestCoreYaml._RecursionDepth;
+var
+  i: PtrInt;
+  yaml, indent: RawUtf8;
+  saved: integer;
+  raised: boolean;
+  doc: TDocVariantData;
+begin
+  saved := YamlMaxDepth;
+  try
+    // build a nested block-map of depth 20: "a:\n  a:\n    a: ... a: 1"
+    yaml := '';
+    indent := '';
+    for i := 0 to 19 do
+    begin
+      if i < 19 then
+        yaml := yaml + indent + 'a:'#10
+      else
+        yaml := yaml + indent + 'a: 1'#10;
+      indent := indent + '  ';
+    end;
+    // deep input beyond the cap must raise EYamlException (not EStackOverflow)
+    YamlMaxDepth := 8;
+    doc.Clear;
+    raised := false;
+    try
+      YamlToVariant(yaml, doc);
+    except
+      on EYamlException do
+        raised := true;
+    end;
+    Check(raised, 'depth 20 must raise EYamlException when YamlMaxDepth=8');
+    // same input parses cleanly when the cap is high enough
+    YamlMaxDepth := 100;
+    doc.Clear;
+    Check(YamlToVariant(yaml, doc),
+      'depth 20 must parse when YamlMaxDepth=100');
+  finally
+    YamlMaxDepth := saved;
+  end;
+end;
+
+procedure TTestCoreYaml._OpenApiEquivalence;
+const
+  // a compact OpenAPI 3.0 slice exercising: nested maps, arrays, $ref,
+  // numeric-looking keys (the "200" response code) and boolean properties
+  OPENAPI_YAML: RawUtf8 =
+    'openapi: 3.0.0'#10 +
+    'info:'#10 +
+    '  title: Petstore'#10 +
+    '  version: 1.0.0'#10 +
+    'paths:'#10 +
+    '  /pets:'#10 +
+    '    get:'#10 +
+    '      operationId: listPets'#10 +
+    '      parameters:'#10 +
+    '        - name: limit'#10 +
+    '          in: query'#10 +
+    '          required: false'#10 +
+    '          schema:'#10 +
+    '            type: integer'#10 +
+    '      responses:'#10 +
+    '        "200":'#10 +
+    '          description: OK'#10 +
+    '          content:'#10 +
+    '            application/json:'#10 +
+    '              schema:'#10 +
+    '                $ref: "#/components/schemas/Pet"'#10 +
+    'components:'#10 +
+    '  schemas:'#10 +
+    '    Pet:'#10 +
+    '      type: object'#10 +
+    '      required:'#10 +
+    '        - id'#10 +
+    '        - name'#10 +
+    '      properties:'#10 +
+    '        id:'#10 +
+    '          type: integer'#10 +
+    '        name:'#10 +
+    '          type: string'#10;
+  OPENAPI_JSON: RawUtf8 =
+    '{"openapi":"3.0.0",' +
+    '"info":{"title":"Petstore","version":"1.0.0"},' +
+    '"paths":{"/pets":{"get":{"operationId":"listPets",' +
+    '"parameters":[{"name":"limit","in":"query","required":false,' +
+    '"schema":{"type":"integer"}}],' +
+    '"responses":{"200":{"description":"OK",' +
+    '"content":{"application/json":{"schema":{' +
+    '"$ref":"#/components/schemas/Pet"}}}}}}}},' +
+    '"components":{"schemas":{"Pet":{"type":"object",' +
+    '"required":["id","name"],' +
+    '"properties":{"id":{"type":"integer"},"name":{"type":"string"}}}}}}';
+const
+  // must match YamlToVariant's default so the two sides are compared apples-
+  // to-apples; otherwise dvoAllowDoubleValue and friends could produce
+  // divergent ToJson output
+  OPENAPI_OPT: TDocVariantOptions =
+    [dvoReturnNullForUnknownProperty, dvoValueCopiedByReference,
+     dvoInternNames, dvoAllowDoubleValue];
+var
+  fromYaml, fromJson: TDocVariantData;
+begin
+  fromYaml.Clear;
+  fromJson.Clear;
+  Check(YamlToVariant(OPENAPI_YAML, fromYaml, OPENAPI_OPT), 'YamlToVariant');
+  Check(fromJson.InitJson(OPENAPI_JSON, OPENAPI_OPT), 'InitJson');
+  CheckEqual(fromYaml.ToJson, fromJson.ToJson,
+    'OpenAPI-shaped YAML must match JSON equivalent');
+end;
+
+
+end.

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -129,6 +129,9 @@ type
     /// validate mormot.net.tftp.server using libcurl (so only POSIX by now)
     procedure TFTPServer;
     {$endif OSPOSIX}
+  protected
+    // helper invoked from OpenAPI to verify YAML dispatch
+    procedure _OpenApiYamlDispatch;
   end;
 
 
@@ -352,6 +355,82 @@ begin
       end;
       NotifyTestSpeed('%', [OpenApiName[i]], 0, length(dto) + length(client), @timer);
     end;
+  // YAML dispatch smoke test: TOpenApiParser must produce identical output
+  // for a YAML spec and its JSON counterpart when consumed via ParseYaml/
+  // ParseFile. Covers the spec-approved invariant behind mopenapi's .yaml
+  // support.
+  _OpenApiYamlDispatch;
+end;
+
+procedure TNetworkProtocols._OpenApiYamlDispatch;
+const
+  YAML_SPEC: RawUtf8 =
+    'openapi: 3.0.0'#10 +
+    'info:'#10 +
+    '  title: DispatchTest'#10 +
+    '  version: 1.0.0'#10 +
+    'paths:'#10 +
+    '  /ping:'#10 +
+    '    get:'#10 +
+    '      operationId: ping'#10 +
+    '      responses:'#10 +
+    '        "200":'#10 +
+    '          description: OK'#10 +
+    'components:'#10 +
+    '  schemas:'#10 +
+    '    Info:'#10 +
+    '      type: object'#10 +
+    '      properties:'#10 +
+    '        name:'#10 +
+    '          type: string'#10;
+  JSON_SPEC: RawUtf8 =
+    '{"openapi":"3.0.0",' +
+    '"info":{"title":"DispatchTest","version":"1.0.0"},' +
+    '"paths":{"/ping":{"get":{"operationId":"ping",' +
+    '"responses":{"200":{"description":"OK"}}}}},' +
+    '"components":{"schemas":{"Info":{"type":"object",' +
+    '"properties":{"name":{"type":"string"}}}}}}';
+var
+  oaYaml, oaJson, oaFile: TOpenApiParser;
+  dtoY, dtoJ, dtoF, clientY, clientJ, clientF: RawUtf8;
+  fn: TFileName;
+begin
+  oaYaml := TOpenApiParser.Create('DispatchYaml');
+  oaJson := TOpenApiParser.Create('DispatchJson');
+  oaFile := TOpenApiParser.Create('DispatchFile');
+  try
+    oaYaml.ParseYaml(YAML_SPEC);
+    oaJson.ParseJson(JSON_SPEC);
+    dtoY := oaYaml.GenerateDtoUnit;
+    dtoJ := oaJson.GenerateDtoUnit;
+    clientY := oaYaml.GenerateClientUnit;
+    clientJ := oaJson.GenerateClientUnit;
+    // the spec's actual names differ (DispatchYaml vs DispatchJson), so we
+    // only check that both produced identical shape with the name swapped
+    Check(dtoY <> '', 'yaml dto');
+    Check(dtoJ <> '', 'json dto');
+    Check(clientY <> '', 'yaml client');
+    Check(clientJ <> '', 'json client');
+    CheckEqual(length(dtoY), length(dtoJ), 'dto length yaml vs json');
+    CheckEqual(length(clientY), length(clientJ), 'client length yaml vs json');
+    // ParseFile with .yaml extension must dispatch to the YAML path
+    fn := WorkDir + 'test.openapi.dispatch.yaml';
+    FileFromString(YAML_SPEC, fn);
+    try
+      oaFile.Name := 'DispatchYaml'; // match oaYaml so outputs are comparable
+      oaFile.ParseFile(fn);
+      dtoF := oaFile.GenerateDtoUnit;
+      clientF := oaFile.GenerateClientUnit;
+      CheckEqual(dtoF, dtoY, 'ParseFile(.yaml) dto must equal ParseYaml');
+      CheckEqual(clientF, clientY, 'ParseFile(.yaml) client must equal ParseYaml');
+    finally
+      DeleteFile(fn);
+    end;
+  finally
+    oaYaml.Free;
+    oaJson.Free;
+    oaFile.Free;
+  end;
 end;
 
 procedure RtspRegressionTests(proxy: TRtspOverHttpServer; test: TSynTestCase;


### PR DESCRIPTION
## Summary

- Adds `mormot.core.yaml` — YAML 1.2 core-schema subset, bidirectional
  TDocVariant conversion (parser YAML -> JSON -> InitJson, writer via
  TTextWriter), guarded by `YamlMaxDepth` to turn would-be EStackOverflow
  on deeply nested specs into a clean `EYamlException`.
- Routes `TOpenApiParser.ParseFile` by file extension (`.yaml`/`.yml` ->
  YAML path, otherwise JSON); adds `ParseYaml` / `ParseYamlFile` symmetric
  entry points (mirror of `ParseJson`).
- `TPascalException.Create` accepts `obtVariant` as a generic
  `VariantResponse` fallback — empty-object response schemas (e.g. GitHub
  REST "304 Not Modified") were previously rejected with "unsupported
  schema".

## Test plan

- [x] `TTestCoreYaml`: 28 goldens + 9 error cases + `_Roundtrip` +
  `_FileApi` + `_RecursionDepth` + `_OpenApiEquivalence` —
  `0 / 179` assertions pass.
- [x] `TNetworkProtocols._OpenApiYamlDispatch`: `ParseYaml` /
  `ParseYamlFile` / `ParseFile(.yaml)` produce output byte-identical to
  `ParseJson` for the same spec.
- [x] Full regression on FPC 3.2.3 i386-win32: all assertions pass (one
  pre-existing host-dependent `Dmi smbios` OEM check reproduces with
  `--test TTestCoreBase` on a clean upstream checkout and is unrelated
  to this PR).
- [x] Stress-tested against four public OpenAPI specs:
  - Petstore v3 (22 KB -> 9 KB / 321 lines client)
  - DigitalOcean public API (100 KB -> 135 KB / 3660 lines)
  - Stripe spec3 (6 MB -> 1.25 MB / 27064 lines)
  - GitHub REST API (9.2 MB -> 2.44 MB / 62001 lines)

  All four pass end-to-end through `mopenapi`.

## Explicitly out of scope

- `&anchor` / `*alias` / `!!tag` / multi-document `---` / tab
  indentation / `%YAML` `%TAG` directives — raise `EYamlException` with
  1-based line number (documented in the unit header).
- Two independent `mopenapi` codegen bugs surfaced by compile-checking
  the Stripe and GitHub generated clients (record parameter passed to
  `array of const`; `+1`/`-1` schema field names sanitized to a bare
  digit) — to be filed as separate issues.
- A small follow-up fix for `TPascalEnum.Create` enum-prefix collisions
  beyond 99 anonymous enums (Stripe / GitHub each have around 100
  anonymous enums sharing the same 2-letter initials, which exhausts
  the current `ES2..ES100` suffix range) — to be submitted as a separate
  PR.
