### PR TITLE
net: fix THttpSocket.GetBody truncation on Connection-close bodies

### DIFF
--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -4570,6 +4570,13 @@ begin
     // mainly for HTTP/1.0: https://www.rfc-editor.org/rfc/rfc7230#section-3.3.3
     if Assigned(OnLog) then
       OnLog(sllTrace, 'GetBody deprecated loop', [], self);
+    // first consume any body bytes already buffered in SockIn together with the
+    // response header: SockReceiveString below reads the raw socket directly and
+    // those leading bytes would otherwise be lost (truncated head on 'Connection:
+    // close' replies without Content-Length nor chunked encoding)
+    len := SockInPending(0);
+    if len > 0 then
+      Append(RawUtf8(Http.Content), RawUtf8(SockInRead(len, {UseOnlySockIn=}true)));
     repeat
       chunk := SockReceiveString; // rough process
       Append(RawUtf8(Http.Content), chunk);


### PR DESCRIPTION
`THttpSocket.GetBody` truncates the start of the body when the reply has no
`Content-Length` and no chunked encoding, only `Connection: close` (HTTP/1.0, or 500 errors).

The header read (`SockInReadLn`/`DoInputSock`) buffers the first body bytes into `fSockIn`,
but the close branch then reads via `SockReceiveString` straight from the socket and skips
`fSockIn`, so those bytes are dropped. Content-Length/chunked paths use `SockInRead` and are fine.

Fix — drain `SockIn` first:

```pascal
len := SockInPending(0);
if len > 0 then
  Append(RawUtf8(Http.Content), RawUtf8(SockInRead(len, {UseOnlySockIn=}true)));
```

Tested with a raw server (header+body in one write, no CL/chunked, then close), D12 Win64:
before `got=7099/8042, headOK=FALSE` → after `got=8042/8042, headOK=TRUE`.