### PR TITLE
net.client: add STARTTLS support to SendEmail

### DIFF
--- a/ex/ThirdPartyDemos/tobfel/mailtest.dpr
+++ b/ex/ThirdPartyDemos/tobfel/mailtest.dpr
@@ -1,0 +1,150 @@
+/// small stand-alone tool to test SMTP email sending (plain / implicit TLS / STARTTLS)
+// - part of the Open Source Synopse mORMot framework 2 examples
+program mailtest;
+
+{$I ..\..\..\src\mormot.defines.inc}
+
+{$ifdef OSWINDOWS}
+  {$apptype console}
+  {$R ..\..\..\src\mormot.win.default.manifest.res}
+{$endif OSWINDOWS}
+
+uses
+  {$I ..\..\..\src\mormot.uses.inc}
+  {$ifdef OSPOSIX}
+  {$ifdef FPC}
+  cwstring, // needed as fallback if ICU is not available (FPC only)
+  {$endif FPC}
+  mormot.lib.openssl11, // OpenSSL is required for TLS on POSIX
+  {$endif OSPOSIX}
+  sysutils,
+  mormot.core.base,
+  mormot.core.os,
+  mormot.core.text,
+  mormot.core.unicode,
+  mormot.core.log,
+  mormot.net.sock,
+  mormot.net.http,   // for MimeHeaderEncode()
+  mormot.net.client;
+
+procedure Run;
+var
+  smtp: TSmtpConnection;
+  conn, from, dest, subject, body, headers: RawUtf8;
+  tls: TNetTlsContext;
+  tlsp: PNetTlsContext;
+  ok: boolean;
+  i: integer;
+begin
+  // ----- parse the command line -----
+  // usage: mailtest user:password@server:port from@x to@y [subject] [body] [options]
+  tlsp := nil;
+  conn := '';
+  from := '';
+  dest := '';
+  subject := 'mORMot STARTTLS test';
+  body := 'This is a test email sent by the mORMot 2 mailtest tool.';
+  headers := '';
+  i := 1;
+  while i <= ParamCount do
+  begin
+    if IdemPropNameU(StringToUtf8(ParamStr(i)), '--ignorecert') then
+    begin
+      InitNetTlsContext(tls);
+      tls.IgnoreCertificateErrors := true;
+      tlsp := @tls;
+    end
+    else if IdemPropNameU(StringToUtf8(ParamStr(i)), '-h') or
+            IdemPropNameU(StringToUtf8(ParamStr(i)), '--header') then
+    begin
+      // -h "Name: value" adds an individual header line (like curl -H), which
+      // is passed through to SendEmail's Headers parameter (repeatable)
+      inc(i);
+      if i <= ParamCount then
+        headers := headers + StringToUtf8(ParamStr(i)) + #13#10;
+    end
+    else if conn = '' then
+      conn := StringToUtf8(ParamStr(i))
+    else if from = '' then
+      from := StringToUtf8(ParamStr(i))
+    else if dest = '' then
+      dest := StringToUtf8(ParamStr(i))
+    else if subject = 'mORMot STARTTLS test' then
+      subject := StringToUtf8(ParamStr(i))
+    else
+      body := StringToUtf8(ParamStr(i));
+    inc(i);
+  end;
+  if (conn = '') or
+     (from = '') or
+     (dest = '') then
+  begin
+    ConsoleWrite('Usage:');
+    ConsoleWrite('  mailtest user:password@server:port from@x to@y ' +
+      '[subject] [body] [options]');
+    ConsoleWrite('');
+    ConsoleWrite('  -h "Name: value" : add an individual header (like curl, repeatable)');
+    ConsoleWrite('                     e.g. -h "Reply-To: reply@x.de" -h "Cc: cc@x.de"');
+    ConsoleWrite('  --ignorecert     : disable the server certificate validation');
+    ConsoleWrite('');
+    ConsoleWrite('Examples:');
+    ConsoleWrite('  Gmail STARTTLS (port 587, app password):');
+    ConsoleWrite('    mailtest me:app-pwd@smtp.gmail.com:587 me@gmail.com you@x.de');
+    ConsoleWrite('  Implicit TLS (port 465):');
+    ConsoleWrite('    mailtest me:pwd@smtp.example.com:465 me@x.de you@x.de');
+    ConsoleWrite('  Plain SMTP (port 25):');
+    ConsoleWrite('    mailtest @localhost:25 me@x.de you@x.de');
+    ExitCode := 1;
+    exit;
+  end;
+  // ----- resolve the SMTP connection ('user:password@server:port') -----
+  if not smtp.FromText(conn) then
+  begin
+    ConsoleWrite('Invalid connection string: %', [conn]);
+    ExitCode := 1;
+    exit;
+  end;
+  // the TSmtpConnection overload guesses the TLS mode from the port:
+  //   465 -> stlsImplicit, 587 -> stlsStartTls, else stlsNone (plain)
+  ConsoleWrite('Sending mail via %:% (user=%) ...',
+    [smtp.Host, smtp.Port, smtp.User]);
+  try
+    // body is converted to ISO-8859-1 (the SendEmail default TextCharSet)
+    ok := SendEmail(smtp, from, dest, MimeHeaderEncode(subject),
+      Utf8ToWinAnsi(body), headers, 'ISO-8859-1', stlsNone, tlsp);
+    if ok then
+      ConsoleWrite('Success: email accepted by the server.')
+    else
+    begin
+      ConsoleWrite('Failure: server did not accept the email.');
+      ExitCode := 2;
+    end;
+  except
+    on E: Exception do
+    begin
+      ConsoleWrite('Error [%]: %', [ClassNameShort(E)^, StringToUtf8(E.Message)]);
+      ExitCode := 3;
+    end;
+  end;
+end;
+
+begin
+  // full verbose logging echoed to the console, to trace the SMTP/TLS dialog
+  with TSynLog.Family do
+  begin
+    Level := LOG_VERBOSE;
+    EchoToConsole := LOG_VERBOSE;
+  end;
+  {$ifdef OSPOSIX}
+  OpenSslInitialize; // ensure the OpenSSL TLS layer is available on POSIX
+  {$endif OSPOSIX}
+  try
+    Run;
+  except
+    on E: Exception do
+    begin
+      ConsoleShowFatalException(E);
+      ExitCode := 4;
+    end;
+  end;
+end.

--- a/ex/ThirdPartyDemos/tobfel/mailtest.lpi
+++ b/ex/ThirdPartyDemos/tobfel/mailtest.lpi
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="mailtest"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes>
+      <Item Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+    </RunParams>
+    <RequiredPackages>
+      <Item>
+        <PackageName Value="mormot2"/>
+      </Item>
+    </RequiredPackages>
+    <Units>
+      <Unit>
+        <Filename Value="mailtest.dpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <Target>
+      <Filename Value="exe/mailtest"/>
+    </Target>
+    <SearchPaths>
+      <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+    <CodeGeneration>
+      <Optimizations>
+        <OptimizationLevel Value="3"/>
+      </Optimizations>
+    </CodeGeneration>
+    <Linking>
+      <Debugging>
+        <GenerateDebugInfo Value="False"/>
+        <DebugInfoType Value="dsDwarf3"/>
+      </Debugging>
+    </Linking>
+    <Other>
+      <CustomOptions Value="-dFPC_X64MM
+-dFPCMM_SERVER"/>
+    </Other>
+  </CompilerOptions>
+  <Debugging>
+    <Exceptions>
+      <Item>
+        <Name Value="EAbort"/>
+      </Item>
+      <Item>
+        <Name Value="ENetSock"/>
+      </Item>
+      <Item>
+        <Name Value="ESendEmail"/>
+      </Item>
+    </Exceptions>
+  </Debugging>
+</CONFIG>

--- a/src/net/mormot.net.client.pas
+++ b/src/net/mormot.net.client.pas
@@ -2048,6 +2048,16 @@ type
   /// exception class raised by SendEmail() on raw SMTP process
   ESendEmail = class(ESynException);
 
+  /// how TLS should be applied when sending an email via SendEmail()
+  // - stlsNone: plain text connection (typically port 25)
+  // - stlsImplicit: TLS from the first byte of the connection (typically port 465)
+  // - stlsStartTls: plain connection upgraded to TLS via the STARTTLS command
+  // after EHLO (typically the submission port 587, as expected by most providers)
+  TSmtpTls = (
+    stlsNone,
+    stlsImplicit,
+    stlsStartTls);
+
 /// send an email using the SMTP protocol
 // - retry true on success
 // - the Subject is expected to be in plain 7-bit ASCII, so you could use
@@ -2056,11 +2066,15 @@ type
 // - you can optionally set another encoding charset or force TextCharSet='' to
 // expect the 'Content-Type:' to be set in Headers and Text to be the raw body
 // (e.g. a multi-part encoded message)
+// - set Tls to stlsImplicit for TLS-from-start (port 465) or stlsStartTls to
+// upgrade a plain connection via the STARTTLS command (port 587)
+// - optional aTLS could supply a TNetTlsContext to customize the TLS handshake
+// (e.g. aTLS^.IgnoreCertificateErrors), used for stlsImplicit and stlsStartTls
 function SendEmail(const Server, From, CsvDest, Subject: RawUtf8;
   const Text: RawByteString; const Headers: RawUtf8 = ''; const User: RawUtf8 = '';
   const Pass: RawUtf8 = ''; const Port: RawUtf8 = '25';
-  const TextCharSet: RawUtf8  =  'ISO-8859-1'; TLS: boolean = false;
-  TLSIgnoreCertError: boolean = false): boolean; overload;
+  const TextCharSet: RawUtf8  =  'ISO-8859-1'; Tls: TSmtpTls = stlsNone;
+  aTLS: PNetTlsContext = nil): boolean; overload;
 
 /// send an email using the SMTP protocol via a TSmtpConnection definition
 // - retry true on success
@@ -2070,11 +2084,12 @@ function SendEmail(const Server, From, CsvDest, Subject: RawUtf8;
 // - you can optionally set another encoding charset or force TextCharSet='' to
 // expect the 'Content-Type:' to be set in Headers and Text to be the raw body
 // (e.g. a multi-part encoded message)
-// - TLS will be forced if the port is either 465 or 587
+// - if Tls is left to stlsNone, it will be guessed from the port number:
+// stlsImplicit for port 465, or stlsStartTls for port 587
 function SendEmail(const Server: TSmtpConnection;
   const From, CsvDest, Subject: RawUtf8; const Text: RawByteString;
   const Headers: RawUtf8 = ''; const TextCharSet: RawUtf8  = 'ISO-8859-1';
-  TLS: boolean = false; TLSIgnoreCertError: boolean = false): boolean; overload;
+  Tls: TSmtpTls = stlsNone; aTLS: PNetTlsContext = nil): boolean; overload;
 
 /// convert a supplied subject text into an Unicode encoding
 // - will convert the text into UTF-8 and append '=?UTF-8?B?'
@@ -6107,29 +6122,43 @@ end;
 
 function SendEmail(const Server: TSmtpConnection;
   const From, CsvDest, Subject: RawUtf8; const Text: RawByteString;
-  const Headers, TextCharSet: RawUtf8; TLS, TLSIgnoreCertError: boolean): boolean;
+  const Headers, TextCharSet: RawUtf8; Tls: TSmtpTls; aTLS: PNetTlsContext): boolean;
 begin
+  if Tls = stlsNone then // guess the TLS mode from the well-known port numbers
+    if Server.Port = '465' then
+      Tls := stlsImplicit
+    else if Server.Port = '587' then
+      Tls := stlsStartTls;
   result := SendEmail(
     Server.Host, From, CsvDest, Subject, Text, Headers,
-    Server.User, Server.Pass, Server.Port, TextCharSet,
-    TLS or (Server.Port = '465') or (Server.Port = '587'), TLSIgnoreCertError);
+    Server.User, Server.Pass, Server.Port, TextCharSet, Tls, aTLS);
 end;
 
 function SendEmail(const Server, From, CsvDest, Subject: RawUtf8;
   const Text: RawByteString; const Headers, User, Pass, Port, TextCharSet: RawUtf8;
-  TLS, TLSIgnoreCertError: boolean): boolean;
+  Tls: TSmtpTls; aTLS: PNetTlsContext): boolean;
 var
   sock: TCrtSocket;
 
-  procedure Expect(const answer: RawUtf8);
+  // send the optional Command, read the whole (multi-line) answer, check the
+  // reply code, raise ESendEmail on mismatch, and return the full answer text
+  // - Command = '' is used to read the initial greeting or a previous send
+  function Exec(const Command, Answer: RawUtf8): RawUtf8;
   var
     res: RawUtf8;
   begin
+    if Command <> '' then
+    begin
+      sock.SockSend(Command);
+      sock.SockSendFlush;
+    end;
+    result := '';
     repeat
       sock.SockRecvLn(res);
+      result := result + res + #13#10;
     until (Length(res) < 4) or
-          (res[4] <> '-'); // - indicates there are other headers following
-    if IdemPChar(pointer(res), pointer(answer)) then
+          (res[4] <> '-'); // '-' indicates there are other lines following
+    if IdemPChar(pointer(res), pointer(Answer)) then
       exit;
     if res = '' then
       res := 'Undefined Error';
@@ -6137,39 +6166,43 @@ var
       [User, Server, Port, res]);
   end;
 
-  procedure Exec(const Command, answer: RawUtf8);
-  begin
-    sock.SockSend(Command);
-    sock.SockSendFlush;
-    Expect(answer)
-  end;
-
 var
   P: PUtf8Char;
-  rec, ToList, head: RawUtf8;
+  rec, ToList, head, caps: RawUtf8;
 begin
   result := false;
   P := pointer(CsvDest);
   if P = nil then
     exit;
-  sock := SocketOpen(Server, Port, TLS, nil, nil, TLSIgnoreCertError);
+  sock := SocketOpen(Server, Port, {tls=}Tls = stlsImplicit, aTLS, nil);
   if sock <> nil then
   try
-    sock.CreateSockIn; // we use SockIn for buffered SockRecvLn() in Expect()
-    Expect('220');
+    sock.CreateSockIn; // we use SockIn for buffered SockRecvLn() in Exec()
+    Exec('', '220');
+    // EHLO is always sent first: needed for STARTTLS and AUTH capabilities
+    caps := Exec('EHLO ' + Server, '250');
+    if Tls = stlsStartTls then
+    begin
+      // upgrade the plain connection to TLS via the STARTTLS command
+      Exec('STARTTLS', '220');
+      if aTLS <> nil then
+        sock.TLS := aTLS^; // apply the caller TLS options before the handshake
+      sock.DoTlsAfter(cstaConnect); // perform the TLS handshake on this socket
+      caps := Exec('EHLO ' + Server, '250'); // re-issue EHLO over TLS
+    end;
     if (User <> '') and
        (Pass <> '') then
-    begin
-      Exec('EHLO ' + Server, '25');
-      Exec('AUTH LOGIN', '334');
-      Exec(BinToBase64(User), '334');
-      Exec(BinToBase64(Pass), '235');
-    end
-    else
-      Exec('HELO ' + Server, '25');
+      if PosI('LOGIN', caps) <> 0 then
+      begin
+        Exec('AUTH LOGIN', '334');
+        Exec(BinToBase64(User), '334');
+        Exec(BinToBase64(Pass), '235');
+      end
+      else // AUTH PLAIN fallback: base64(#0 user #0 pass)
+        Exec('AUTH PLAIN ' + BinToBase64(Join([#0, User, #0, Pass])), '235');
     sock.SockSendLine(['MAIL FROM:<', From, '>']);
     sock.SockSendFlush;
-    Expect('250');
+    Exec('', '250');
     repeat
       GetNextItem(P, ',', rec);
       TrimSelf(rec);


### PR DESCRIPTION
## Summary

Adds **STARTTLS** support to `SendEmail()` in `mormot.net.client`, implemented natively on top of `TCrtSocket.DoTlsAfter` (SChannel on Windows, OpenSSL on POSIX) - no external process.

Motivation: `SendEmail()` only supported plain SMTP (port 25) and *implicit* TLS, and the `TSmtpConnection` overload forced *implicit* TLS on port **587** - the STARTTLS submission port that most providers (Gmail, Office365, GMX...) expect and where implicit TLS is rejected.

This PR was reworked to a **single, focused commit** following the review feedback.

## Changes

- new `TSmtpTls = (stlsNone, stlsImplicit, stlsStartTls)` enum, replacing the former `TLS: boolean` parameter of both overloads;
- native STARTTLS via the `STARTTLS` command + `TCrtSocket.DoTlsAfter(cstaConnect)`;
- `TSmtpConnection` overload derives the mode from the port: 465 -> implicit, 587 -> STARTTLS;
- **replaced the `TLSIgnoreCertError` boolean by an optional `aTLS: PNetTlsContext`**, so the caller can specify any TLS option (as suggested in review);
- `EHLO` captured once; `AUTH PLAIN` used as a fallback when `AUTH LOGIN` is not advertised;
- **merged `Expect`/`Exec`/capability helpers into a single `Exec()` sub-function**;
- example uses `{$ifdef OSPOSIX}` consistently; ANSI encoding preserved (no stray non-ASCII byte).

Adds `ex/mail-starttls/mailtest.dpr` (+ `.lpi`). Builds with Delphi (dcc64) and FPC/Lazarus, and was verified to **cross-compile and link for x86_64-linux** as well. Verified end-to-end against a live provider on port 587.

## Note on certificate revocation (out of scope here, for discussion)

While testing against a real server I hit a Windows/SChannel-only issue worth flagging separately: some certificate chains carry **no reachable revocation info** (no CRL Distribution Point / OCSP), so SChannel aborts the handshake with `CRYPT_E_NO_REVOCATION_CHECK` even for otherwise-trusted certificates. The existing `SCH_CRED_IGNORE_REVOCATION_OFFLINE` only covers the "responder offline" case, not "no revocation info at all".

The only current workaround is `IgnoreCertificateErrors`, which disables *all* validation (trust chain, host name, expiration) - heavier than needed.

**Possible clean solution (happy to open as a separate PR if you're interested):** an opt-in `TNetTlsContext.IgnoreCertificateRevocation` flag that, on the SChannel client, additionally sets `SCH_CRED_IGNORE_NO_REVOCATION_CHECK` - turning revocation into best-effort (soft-fail) while still fully validating the trust chain, host name and expiration (the behaviour browsers use by default). No effect on OpenSSL, which does not check revocation by default. With the new `aTLS: PNetTlsContext` parameter above, callers could then request exactly that per email, without any Mail-specific flag.

I kept this out of the present PR to stay focused; let me know if you'd like it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
