### PR TITLE
core.os: rename ErrorShort procedure overloads to fix Delphi 7 (E2250)

### DIFF
--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -832,11 +832,13 @@ function WinErrorConstant(Code: cardinal): PShortString;
 /// return the error code number, and its regular constant on Windows (if known)
 // - e.g. WinErrorShort(5) = '5 ERROR_ACCESS_DENIED' or
 // WinErrorShort($c00000fd) = 'c00000fd EXCEPTION_STACK_OVERFLOW'
-function WinErrorShort(Code: cardinal; NoInt: boolean = false): TShort47; overload;
+function WinErrorShort(Code: cardinal; NoInt: boolean = false): TShort47;
   {$ifdef FPC} inline; {$endif} // Delphi has sometimes issues inlining this
 
-/// return the error code number, and its regular constant on Windows (if known)
-procedure WinErrorShort(Code: cardinal; var Dest: ShortString; NoInt: boolean = false); overload;
+/// fill Dest with the error code number and its regular constant on Windows
+// - not named WinErrorShort() to avoid a function/procedure overload that
+// Delphi 7 cannot resolve at the call site
+procedure WinErrorShortVar(Code: cardinal; var Dest: ShortString; NoInt: boolean = false);
 
 /// return the error code number, and its regular constant on Linux (if known)
 procedure LinuxErrorShort(Code: cardinal; var Dest: ShortString; NoInt: boolean = false);
@@ -847,13 +849,13 @@ procedure BsdErrorShort(Code: cardinal; var Dest: ShortString; NoInt: boolean = 
 /// return the error code number, and its regular constant on the current OS
 // - redirect to WinErrorShort/LinuxErrorShort/BsdErrorShort() functions
 // - e.g. OsErrorShort(5) = '5 ERROR_ACCESS_DENIED' on Windows or '5 EIO' on POSIX
-procedure OsErrorShort(Code: cardinal; var Dest: ShortString; NoInt: boolean = false); overload;
+procedure OsErrorShortVar(Code: cardinal; var Dest: ShortString; NoInt: boolean = false);
   {$ifdef FPC} inline; {$endif} // Delphi can't inline a ShortString var :(
 
 /// return the error code number, and its regular constant on the current OS
 // - redirect to WinErrorShort/LinuxErrorShort/BsdErrorShort() functions
 // - e.g. OsErrorShort(5) = '5 ERROR_ACCESS_DENIED' on Windows or '5 EIO' on POSIX
-function OsErrorShort(Code: cardinal = 0; NoInt: boolean = false): TShort47; overload;
+function OsErrorShort(Code: cardinal = 0; NoInt: boolean = false): TShort47;
   {$ifdef FPC} inline; {$endif} // Delphi has sometimes issues inlining this
 
 /// append the error code number, and its regular constant on the current OS
@@ -6717,7 +6719,7 @@ var
 begin
   if error = 0 then
     error := GetLastError;
-  OsErrorShort(error, result, {noint=}false); // known E### or ERROR_###
+  OsErrorShortVar(error, result, {noint=}false); // known E### or ERROR_###
   os := GetSystemError(error);
   if os in [seSuccess, seOther] then
     exit;
@@ -6924,10 +6926,10 @@ end;
 
 function WinErrorShort(Code: cardinal; NoInt: boolean): TShort47;
 begin
-  WinErrorShort(Code, result, NoInt);
+  WinErrorShortVar(Code, result, NoInt);
 end;
 
-procedure WinErrorShort(Code: cardinal; var Dest: ShortString; NoInt: boolean);
+procedure WinErrorShortVar(Code: cardinal; var Dest: ShortString; NoInt: boolean);
 begin
   Dest[0] := #0;
   if NoInt then
@@ -7046,7 +7048,7 @@ function OsErrorShort(Code: cardinal; NoInt: boolean): TShort47;
 begin
   if Code = 0 then
     Code := GetLastError;
-  OsErrorShort(Code, result, NoInt); // redirect to Win/Linux/BsdErrorShort()
+  OsErrorShortVar(Code, result, NoInt); // redirect to Win/Linux/BsdErrorShort()
 end;
 
 procedure OsErrorAppend(Code: cardinal; var Dest: ShortString;
@@ -7054,7 +7056,7 @@ procedure OsErrorAppend(Code: cardinal; var Dest: ShortString;
 var
   os: TShort47;
 begin
-  OsErrorShort(Code, os, NoInt); // redirect to Win/Linux/BsdErrorShort()
+  OsErrorShortVar(Code, os, NoInt); // redirect to Win/Linux/BsdErrorShort()
   if Sep <> #0 then
     AppendShortCharSafe(Sep, Dest);
   AppendShort(os, Dest);

--- a/src/core/mormot.core.os.posix.inc
+++ b/src/core/mormot.core.os.posix.inc
@@ -2000,7 +2000,7 @@ const
 
 procedure GetErrorShortVar(error: integer; var dest: ShortString);
 begin
-  OsErrorShort(error, dest, {noint=}true); // known 'E###' on Linux + BSD
+  OsErrorShortVar(error, dest, {noint=}true); // known 'E###' on Linux + BSD
   if dest[0] = #0 then
   {$ifdef FPC}
     dest := StrError(error) // FPC RTL returns its plain text as shortstring
@@ -3178,7 +3178,7 @@ end;
 
 {$ifdef OSBSDDARWIN}
 
-procedure OsErrorShort(Code: cardinal; var Dest: ShortString; NoInt: boolean);
+procedure OsErrorShortVar(Code: cardinal; var Dest: ShortString; NoInt: boolean);
 begin
   BsdErrorShort(Code, Dest, NoInt);
 end;
@@ -3553,7 +3553,7 @@ end;
 
 {$else} // Linux (and Android) specific code
 
-procedure OsErrorShort(Code: cardinal; var Dest: ShortString; NoInt: boolean);
+procedure OsErrorShortVar(Code: cardinal; var Dest: ShortString; NoInt: boolean);
 begin
   LinuxErrorShort(Code, Dest, NoInt);
 end;

--- a/src/core/mormot.core.os.windows.inc
+++ b/src/core/mormot.core.os.windows.inc
@@ -713,9 +713,9 @@ begin
     WinError(error, 0, @dest, nil); // fallback to FormatMessageW
 end;
 
-procedure OsErrorShort(Code: cardinal; var Dest: ShortString; NoInt: boolean);
+procedure OsErrorShortVar(Code: cardinal; var Dest: ShortString; NoInt: boolean);
 begin
-  WinErrorShort(Code, Dest, NoInt);
+  WinErrorShortVar(Code, Dest, NoInt);
 end;
 
 procedure RaiseLastModuleError(const Context: ShortString; Lib: HMODULE;

--- a/src/core/mormot.core.text.pas
+++ b/src/core/mormot.core.text.pas
@@ -10424,7 +10424,7 @@ begin
   begin
     WR.AddDirect(' ', '(');
     {$ifdef OSWINDOWS}
-    WinErrorShort(PtrUInt(Context.ECode), s); // decode most known error codes
+    WinErrorShortVar(PtrUInt(Context.ECode), s); // decode most known error codes
     WR.AddShort(s);
     {$else}
     WR.AddPointer(Context.ECode);

--- a/test/test.core.base.pas
+++ b/test/test.core.base.pas
@@ -8646,9 +8646,9 @@ begin
   CheckEqualShort(WinErrorShort($00090321), '590625 SEC_I_RENEGOTIATE', 'w8');
   CheckEqualShort(WinErrorShort(244, {noint=}false), '244', '244w');
   CheckEqualShort(WinErrorShort(245, {noint=}true), '', '245w');
-  WinErrorShort($80092012, ss);
+  WinErrorShortVar($80092012, ss);
   CheckEqualShort(ss, '80092012 CRYPT_E_NO_REVOCATION_CHECK', 'winrevoc');
-  WinErrorShort($80092012, s7);
+  WinErrorShortVar($80092012, s7);
   CheckEqualShort(s7, '8009201', 'trunc to string[7]');
   BsdErrorShort(1, ss);
   CheckEqualShort(ss, '1 EPERM', '1bsd');


### PR DESCRIPTION
## Problem

The recent `WinErrorShort` / `OsErrorShort` refactoring turned each of them into a **function + procedure overload pair sharing the same name**:

```pascal
function  WinErrorShort(Code: cardinal; NoInt: boolean = false): TShort47; overload;
procedure WinErrorShort(Code: cardinal; var Dest: ShortString; NoInt: boolean = false); overload;
```

**Delphi 7 cannot resolve this overload pair.** At every *procedure* call site (e.g. `mormot.core.os.windows.inc:718` inside `OsErrorShort`, `mormot.core.text.pas`, and the `TTestCoreBase` self-tests) D7 reports:

```
[Error] mormot.core.os.windows.inc(718): E2250 There is no overloaded version of 'WinErrorShort' that can be called with these arguments
```

even though the argument types match the procedure overload exactly. Reordering the two declarations does **not** help (confirmed on D7). Newer Delphi and FPC accept it.

## Fix

Rename the "fill a `var ShortString`" procedure forms so there is no longer a function/procedure name overload, matching the existing `GetErrorShortVar` convention already used in this unit:

- `WinErrorShort(Code; var Dest; NoInt)` → `WinErrorShortVar(...)`
- `OsErrorShort(Code; var Dest; NoInt)` → `OsErrorShortVar(...)`

The **function** forms `WinErrorShort()` / `OsErrorShort()` returning `TShort47` (used as expressions, e.g. `WinErrorShort(err)`) are **unchanged**, so all of those call sites keep working with no change. Updated the internal callers in `os.pas`, `os.windows.inc`, `os.posix.inc`, `text.pas`, and the `TTestCoreBase` self-tests.

## Testing

- **Delphi 7**: the reported `E2250` at `windows.inc:718` (and the other procedure call sites) is gone; builds clean.
- **Delphi 13 (dcc64)**: full `mormot2tests` builds clean (610k lines).
- **FPC**: unaffected by the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
