### PR TITLE
fix: valid handle testing under linux 64bits

### DIFF
--- a/src/core/mormot.core.os.posix.inc
+++ b/src/core/mormot.core.os.posix.inc
@@ -1491,7 +1491,9 @@ end;
 
 function ValidHandle(Handle: THandle): boolean;
 begin
-  result := PtrInt(Handle) >= 0; // 0=StdIn is a valid POSIX file descriptor
+  // 0=StdIn is a valid POSIX file descriptor, and descriptors are 32-bit signed
+  // "int" values - so truncate before testing the sign.
+  result := integer(Handle) >= 0;
 end;
 
 function FileHandleToUnixTimeUtc(F: THandle): TUnixTime;


### PR DESCRIPTION
I was running into an issue with log creation under Linux 64bits, it would return an INVALID_HANDLE_VALUE ($ffffffff) which PtrInt() would cast it as 4294967295 instead of -1, thus making it look like it was a success.