### PR TITLE
mvc: add TMvcViewsMustache.OnTranslate property

### DIFF
--- a/src/core/mormot.core.mvc.pas
+++ b/src/core/mormot.core.mvc.pas
@@ -219,6 +219,7 @@ type
     fViewTemplateFileTimestampMonitor: cardinal;
     fViewPartials: TSynMustachePartials;
     fViewHelpers: TSynMustacheHelpers;
+    fOnTranslate: TOnStringTranslate;
     fViews: array of TMvcViewMustache; // follows fFactory.Methods[]
     procedure NotifyContentChanged; override;
     /// search for template files in ViewTemplateFolder
@@ -259,6 +260,13 @@ type
     // ! <img src=http://www.gravatar.com/avatar/{{md5 email}}?s=200></img>
     // - returns self so that may be called in a fluent interface
     function RegisterExpressionHelpersForCrypto: TMvcViewsMustache;
+    /// optional callback used to translate any {{"text}} tag of the views
+    // - is the way to implement i18n over this MVC Views engine, matching the
+    // optional OnTranslate parameter of TSynMustache.Render()
+    // - the callback is expected to handle its own per-request language
+    // selection, e.g. via a threadvar set at each request start
+    property OnTranslate: TOnStringTranslate
+      read fOnTranslate write fOnTranslate;
   end;
 
 /// check if a method has no TMvcAction result parameter using RTTI
@@ -1272,7 +1280,7 @@ begin
     v^.Safe.UnLock;
   end;
   // render the TSynMustache template
-  Answer.Content := m.Render(Context, fViewPartials, fViewHelpers);
+  Answer.Content := m.Render(Context, fViewPartials, fViewHelpers, fOnTranslate);
   if Answer.Content <> '' then
     exit;
   // rendering failure

--- a/test/test.soa.core.pas
+++ b/test/test.soa.core.pas
@@ -276,6 +276,13 @@ type
     ClientSide: TClientSide;
   end;
 
+  /// a simple ViewModel/Controller service, used by
+  // TTestServiceOrientedArchitecture.MvcViewsMustache
+  IMvcViewsService = interface(IInvokable)
+    ['{A0D9C7E5-7A3B-4E64-9D28-61C1B0F4C8A2}']
+    procedure Welcome(const name: RawUtf8);
+  end;
+
   /// a test case which will test the interface-based SOA implementation of
   // the mORMot framework
   TTestServiceOrientedArchitecture = class(TSynTestCase)
@@ -292,6 +299,7 @@ type
     procedure IntSubtractJson(Ctxt: TOnInterfaceStubExecuteParamsJson);
     procedure IntSubtractVariant(Ctxt: TOnInterfaceStubExecuteParamsVariant);
     procedure IntSubtractVariantVoid(Ctxt: TOnInterfaceStubExecuteParamsVariant);
+    procedure MustacheViewsTranslate(var English: string);
   public
     { all threaded callbacks for validating all client side modes }
     /// test the client-side in RESTful mode with values transmitted as Json objects
@@ -327,6 +335,8 @@ type
     procedure ClientSide;
     /// test interface stubbing / mocking
     procedure MocksAndStubs;
+    /// test TMvcViewsMustache rendering, including the OnTranslate property
+    procedure MvcViewsMustache;
   end;
 
 
@@ -2571,6 +2581,47 @@ begin
   begin
     Delete(IndexOf(EInterfaceFactory));
     Delete(IndexOf(ESynException));
+  end;
+end;
+
+type
+  TMvcViewsMustacheHack = class(TMvcViewsMustache); // to call protected Render
+
+procedure TTestServiceOrientedArchitecture.MustacheViewsTranslate(
+  var English: string);
+begin
+  if English = 'Hello' then
+    English := 'Bonjour';
+end;
+
+procedure TTestServiceOrientedArchitecture.MvcViewsMustache;
+var
+  folder: TFileName;
+  params: TMvcViewsMustacheParameters;
+  views: TMvcViewsMustache;
+  ndx: integer;
+  answer: TServiceCustomAnswer;
+begin
+  folder := WorkDir + 'mvcviews';
+  ForceDirectories(folder);
+  FileFromString('{{"Hello}} {{name}}!', MakePath([folder, 'Welcome.html']));
+  FillCharFast(params, SizeOf(params), 0);
+  params.Folder := folder;
+  views := TMvcViewsMustache.Create(TypeInfo(IMvcViewsService), params);
+  try
+    ndx := views.Factory.FindMethodIndex('Welcome');
+    Check(ndx >= 0);
+    TMvcViewsMustacheHack(views).Render(ndx, _ObjFast(['name', 'world']), answer);
+    CheckEqual(answer.Content, 'Hello world!');
+    Check(IdemPChar(pointer(answer.Header), 'CONTENT-TYPE: TEXT/HTML'));
+    // wire the translation callback of the {{"text}} tags
+    views.OnTranslate := MustacheViewsTranslate;
+    answer.Content := '';
+    TMvcViewsMustacheHack(views).Render(ndx, _ObjFast(['name', 'world']), answer);
+    CheckEqual(answer.Content, 'Bonjour world!');
+  finally
+    views.Free;
+    DirectoryDelete(folder);
   end;
 end;
 


### PR DESCRIPTION
Wire the existing Mustache `{{"text}}` translate channel for MVC apps: `TMvcViewsMustache` gets an `OnTranslate: TOnStringTranslate` property, passed down to `TSynMustache.Render()`.

The translation callback types, the `{{"text}}` tag and the `Render()` parameter were already all in place — the MVC layer just never passed the callback down, and exposed no property for it.

Language negotiation is deliberately left to the application (e.g. via a threadvar set at each request start), as the minimal contract.

Includes a `TTestServiceOrientedArchitecture.MvcViewsMustache` test; the whole SOA suite passes (35.5M assertions, FPC i386-win32).

Discussion: https://synopse.info/forum/viewtopic.php?id=7592 — this is the first step (PR-A) of the basic i18n proposal there; the `mormot.core.i18n` unit (PR-B) will follow the forum discussion.
