### PR TITLE
fmt: basic XML parser - SAX TXmlParser + XmlToVariant late-binding (#487)

### DIFF
--- a/src/core/mormot.core.fmt.pas
+++ b/src/core/mormot.core.fmt.pas
@@ -143,6 +143,120 @@ procedure AddXmlEscape(W: TTextWriter; Text: PUtf8Char);
 function AddJsonToXml(W: TTextWriter; Json: PUtf8Char; ArrayName: PUtf8Char = nil;
   EndOfObject: PUtf8Char = nil): PUtf8Char;
 
+type
+  /// exception raised by TXmlParser on invalid or unsupported XML input
+  EXmlException = class(ESynException);
+
+  /// the kind of tokens returned by TXmlParser.Next
+  // - xtEof is set once the end of the input buffer has been reached
+  // - xtElementStart is returned for each opening <name> or <name ...> tag,
+  // with the parser Name filled - any attribute following as xtAttribute
+  // - xtElementEnd is returned for each </name> or self-closing '/>' mark,
+  // with the parser Name filled
+  // - xtAttribute is returned for each name="value" pair, Name/Value filled
+  // - xtText is returned for any text content between markup, Value filled
+  // with the raw (possibly escaped) text - see ValueToUtf8 to unescape it
+  // - xtCData is returned for each <![CDATA[...]]> section, Value filled
+  // with the verbatim content
+  // - xtComment is returned for each <!--...--> section, if xpoKeepComments
+  // option was defined at Init - silently skipped otherwise
+  // - xtPI is returned for each <?name ...?> processing instruction, if the
+  // xpoKeepPI option was defined at Init - silently skipped otherwise
+  TXmlToken = (
+    xtEof,
+    xtElementStart,
+    xtElementEnd,
+    xtAttribute,
+    xtText,
+    xtCData,
+    xtComment,
+    xtPI);
+
+  /// option to refine TXmlParser process
+  // - xpoStripNamespacePrefix would remove any 'ns:' prefix from the reported
+  // element and attribute names - the prefix is part of the name otherwise
+  // (this "basic" parser does no URI namespace binding by design)
+  // - xpoKeepComments and xpoKeepPI would return xtComment / xtPI tokens,
+  // which are silently skipped by default
+  // - xpoKeepWhiteSpace would return xtText tokens made only of whitespace,
+  // which are silently skipped by default
+  TXmlParserOption = (
+    xpoStripNamespacePrefix,
+    xpoKeepComments,
+    xpoKeepPI,
+    xpoKeepWhiteSpace);
+
+  /// options to refine TXmlParser process
+  TXmlParserOptions = set of TXmlParserOption;
+
+  /// zero-allocation SAX-like parser over an XML UTF-8 memory buffer
+  // - a "basic" parser, from actual simple needs: no DTD support (which makes
+  // it immune to entity expansion attacks by design), only the five XML
+  // predefined entities and numeric character references, prefixes kept as
+  // part of the names with no URI namespace binding
+  // - the input buffer is expected to be UTF-8 encoded and to remain available
+  // in memory during the whole parsing: Name and Value do point within it,
+  // with no memory allocation during the scan - see NameToUtf8/ValueToUtf8
+  // - well-formedness of the tags nesting is verified, and any syntax or
+  // nesting error would raise an EXmlException with the faulty line number
+  // - usage: call Init() then Next in a loop, e.g. as
+  // ! x.Init(pointer(xml), length(xml));
+  // ! while x.Next do
+  // !   case x.Kind of
+  // !     ...
+  {$ifdef USERECORDWITHMETHODS}
+  TXmlParser = record
+  {$else}
+  TXmlParser = object
+  {$endif USERECORDWITHMETHODS}
+  private
+    fCur, fBegin, fAfter, fToken: PUtf8Char;
+    fOptions: TXmlParserOptions;
+    fInElement: boolean; // scanning attributes, up to '>' or '/>'
+    fStack: array of TValuePUtf8Char; // opened elements raw names
+    procedure ParseError(pos: PUtf8Char; const reason: RawUtf8);
+    function ParseName(var p: PUtf8Char): TValuePUtf8Char;
+    procedure SetName(const raw: TValuePUtf8Char);
+  public
+    /// the current token kind, as set by the last Next call
+    Kind: TXmlToken;
+    /// how many elements are currently opened
+    // - incremented after a xtElementStart, decremented after a xtElementEnd
+    Depth: PtrInt;
+    /// the current token name, pointing within the input buffer
+    // - set for xtElementStart, xtElementEnd, xtAttribute and xtPI tokens
+    Name: TValuePUtf8Char;
+    /// the current token raw value, pointing within the input buffer
+    // - set for xtAttribute, xtText, xtCData, xtComment and xtPI tokens
+    // - may still contain XML entities: use ValueToUtf8 to decode them
+    Value: TValuePUtf8Char;
+    /// prepare the parsing of a given XML UTF-8 buffer
+    // - any UTF-8 BOM would be ignored
+    // - the buffer is expected to remain available during the whole parsing
+    procedure Init(Text: PUtf8Char; TextLen: PtrInt;
+      Options: TXmlParserOptions = []);
+    /// iterate to the next token of the input, returning false at xtEof
+    // - raises an EXmlException on any malformed or unsupported input
+    function Next: boolean;
+    /// returns the current Name as an allocated UTF-8 string
+    procedure NameToUtf8(out result: RawUtf8);
+      {$ifdef HASINLINE}inline;{$endif}
+    /// returns the current Value as an allocated UTF-8 string
+    // - decoding any XML entity, unless the current token is a verbatim
+    // xtCData/xtComment section
+    procedure ValueToUtf8(out result: RawUtf8);
+    /// the offset of the current token in the input buffer
+    // - could be used to store a position, then resume a scan from it
+    function Position: PtrInt;
+      {$ifdef HASINLINE}inline;{$endif}
+  end;
+
+/// decode the five XML predefined entities and numeric character references
+// - i.e.   &lt; &gt; &amp; &apos; &quot;   and   &#nnn; &#xhh;   patterns
+// - as used by TXmlParser.ValueToUtf8, or to be called directly
+// - raises EXmlException on any other (i.e. undefined) entity
+procedure XmlUnescape(Text: PUtf8Char; TextLen: PtrInt; out result: RawUtf8);
+
 
 { ************* YAML 1.2 core-schema to JSON or TDocVariant Support }
 
@@ -1399,6 +1513,475 @@ begin
     JsonBufferToXml(tmp.buf, Header, NameSpace, result);
   finally
     tmp.Done;
+  end;
+end;
+
+
+{ TXmlParser }
+
+procedure TXmlParser.ParseError(pos: PUtf8Char; const reason: RawUtf8);
+var
+  line: PtrInt;
+  p: PUtf8Char;
+begin
+  line := 1;
+  p := fBegin;
+  if p <> nil then
+    while p < pos do
+    begin
+      if p^ = #10 then
+        inc(line);
+      inc(p);
+    end;
+  EXmlException.RaiseUtf8('XML error at line %: %', [line, reason]);
+end;
+
+function TXmlParser.ParseName(var p: PUtf8Char): TValuePUtf8Char;
+var
+  s: PUtf8Char;
+begin
+  s := p;
+  while (p < fAfter) and
+        not (p^ in [#0..' ', '<', '>', '/', '=', '?', '"', '''']) do
+    inc(p);
+  result.Text := s;
+  result.Len := p - s;
+  if result.Len = 0 then
+    ParseError(s, 'void or invalid name');
+end;
+
+procedure TXmlParser.SetName(const raw: TValuePUtf8Char);
+var
+  i: PtrInt;
+begin
+  Name := raw;
+  if xpoStripNamespacePrefix in fOptions then
+  begin
+    i := ByteScanIndex(pointer(raw.Text), raw.Len, ord(':'));
+    if i >= 0 then
+    begin
+      inc(Name.Text, i + 1);
+      dec(Name.Len, i + 1);
+    end;
+  end;
+end;
+
+procedure TXmlParser.Init(Text: PUtf8Char; TextLen: PtrInt;
+  Options: TXmlParserOptions);
+begin
+  if (Text <> nil) and
+     (TextLen >= 3) and
+     (PCardinal(Text)^ and $00ffffff = $00bfbbef) then
+  begin
+    inc(Text, 3); // ignore any UTF-8 BOM
+    dec(TextLen, 3);
+  end;
+  fBegin := Text;
+  fCur := Text;
+  fToken := Text;
+  fAfter := Text + TextLen;
+  fOptions := Options;
+  fInElement := false;
+  Depth := 0;
+  Kind := xtEof;
+  Name.Text := nil;
+  Name.Len := 0;
+  Value.Text := nil;
+  Value.Len := 0;
+end;
+
+function TXmlParser.Position: PtrInt;
+begin
+  result := fToken - fBegin;
+end;
+
+function TXmlParser.Next: boolean;
+var
+  p, e, s: PUtf8Char;
+  q: AnsiChar;
+  i: PtrInt;
+  n: TValuePUtf8Char;
+begin
+  result := true;
+  Name.Text := nil;
+  Name.Len := 0;
+  Value.Text := nil;
+  Value.Len := 0;
+  p := fCur;
+  e := fAfter;
+  repeat
+    if fInElement then
+    begin
+      // within <name ... : expect attributes until '>' or '/>'
+      while (p < e) and
+            (p^ <= ' ') do
+        inc(p);
+      if p = e then
+        ParseError(p, 'unexpected end of input within a tag');
+      fToken := p;
+      case p^ of
+        '>':
+          begin
+            inc(p);
+            fInElement := false;
+            continue; // parse the following content
+          end;
+        '/':
+          begin
+            inc(p);
+            if (p = e) or
+               (p^ <> '>') then
+              ParseError(p, 'invalid "/" within a tag');
+            inc(p);
+            fInElement := false;
+            dec(Depth);
+            SetName(fStack[Depth]);
+            Kind := xtElementEnd;
+            break;
+          end;
+      else
+        begin
+          // name="value" attribute pair
+          n := ParseName(p);
+          while (p < e) and
+                (p^ <= ' ') do
+            inc(p);
+          if (p = e) or
+             (p^ <> '=') then
+            ParseError(p, 'attribute expects "="');
+          inc(p);
+          while (p < e) and
+                (p^ <= ' ') do
+            inc(p);
+          if (p = e) or
+             not (p^ in ['"', '''']) then
+            ParseError(p, 'attribute value expects quotes');
+          q := p^;
+          inc(p);
+          i := ByteScanIndex(pointer(p), e - p, ord(q));
+          if i < 0 then
+            ParseError(p, 'unfinished attribute value');
+          SetName(n);
+          Value.Text := p;
+          Value.Len := i;
+          inc(p, i + 1);
+          Kind := xtAttribute;
+          break;
+        end;
+      end;
+    end
+    else if p = e then
+    begin
+      // end of input
+      if Depth > 0 then
+        ParseError(p, 'unexpected end of input: unclosed element');
+      fToken := p;
+      Kind := xtEof;
+      result := false;
+      break;
+    end
+    else if p^ = '<' then
+    begin
+      fToken := p;
+      inc(p);
+      if p = e then
+        ParseError(p, 'unexpected end of input after "<"');
+      case p^ of
+        '/':
+          begin
+            // </name> end tag
+            inc(p);
+            n := ParseName(p);
+            while (p < e) and
+                  (p^ <= ' ') do
+              inc(p);
+            if (p = e) or
+               (p^ <> '>') then
+              ParseError(p, 'end tag expects ">"');
+            inc(p);
+            if Depth = 0 then
+              ParseError(n.Text, 'unexpected end tag');
+            dec(Depth);
+            if (fStack[Depth].Len <> n.Len) or
+               not CompareMemSmall(fStack[Depth].Text, n.Text, n.Len) then
+              ParseError(n.Text, 'mismatched end tag');
+            SetName(n);
+            Kind := xtElementEnd;
+            break;
+          end;
+        '!':
+          begin
+            inc(p);
+            if (e - p >= 2) and
+               (PWord(p)^ = ord('-') + ord('-') shl 8) then
+            begin
+              // <!-- comment -->
+              inc(p, 2);
+              s := p;
+              while (e - p >= 3) and
+                    ((p^ <> '-') or
+                     (p[1] <> '-') or
+                     (p[2] <> '>')) do
+                inc(p);
+              if e - p < 3 then
+                ParseError(s, 'unfinished comment');
+              if xpoKeepComments in fOptions then
+              begin
+                Value.Text := s;
+                Value.Len := p - s;
+                inc(p, 3);
+                Kind := xtComment;
+                break;
+              end;
+              inc(p, 3);
+              continue;
+            end;
+            if (e - p >= 7) and
+               CompareMemSmall(p, PAnsiChar('[CDATA['), 7) then
+            begin
+              // <![CDATA[ ... ]]> verbatim section
+              inc(p, 7);
+              s := p;
+              while (e - p >= 3) and
+                    ((p^ <> ']') or
+                     (p[1] <> ']') or
+                     (p[2] <> '>')) do
+                inc(p);
+              if e - p < 3 then
+                ParseError(s, 'unfinished CDATA');
+              Value.Text := s;
+              Value.Len := p - s;
+              inc(p, 3);
+              Kind := xtCData;
+              break;
+            end;
+            ParseError(p, 'DTD and <!..> markup are not supported');
+          end;
+        '?':
+          begin
+            // <?name ...?> processing instruction
+            inc(p);
+            n := ParseName(p);
+            while (p < e) and
+                  (p^ <= ' ') do
+              inc(p);
+            s := p;
+            while (e - p >= 2) and
+                  ((p^ <> '?') or
+                   (p[1] <> '>')) do
+              inc(p);
+            if e - p < 2 then
+              ParseError(s, 'unfinished processing instruction');
+            if xpoKeepPI in fOptions then
+            begin
+              SetName(n);
+              Value.Text := s;
+              Value.Len := p - s;
+              while (Value.Len > 0) and
+                    (Value.Text[Value.Len - 1] <= ' ') do
+                dec(Value.Len); // right trim
+              inc(p, 2);
+              Kind := xtPI;
+              break;
+            end;
+            inc(p, 2);
+            continue;
+          end;
+      else
+        begin
+          // <name> element start
+          n := ParseName(p);
+          if Depth = length(fStack) then
+            SetLength(fStack, NextGrow(Depth));
+          fStack[Depth] := n;
+          inc(Depth);
+          fInElement := true;
+          SetName(n);
+          Kind := xtElementStart;
+          break;
+        end;
+      end;
+    end
+    else
+    begin
+      // text content until the next markup
+      fToken := p;
+      s := p;
+      i := ByteScanIndex(pointer(p), e - p, ord('<'));
+      if i < 0 then
+        p := e
+      else
+        inc(p, i);
+      if not (xpoKeepWhiteSpace in fOptions) then
+      begin
+        while (s < p) and
+              (s^ <= ' ') do
+          inc(s);
+        if s = p then
+          continue; // ignore any pure-whitespace text
+        s := fToken;
+      end;
+      Value.Text := s;
+      Value.Len := p - s;
+      Kind := xtText;
+      break;
+    end;
+  until false;
+  fCur := p;
+end;
+
+procedure TXmlParser.NameToUtf8(out result: RawUtf8);
+begin
+  FastSetString(result, Name.Text, Name.Len);
+end;
+
+procedure TXmlParser.ValueToUtf8(out result: RawUtf8);
+begin
+  if (Kind in [xtCData, xtComment]) or
+     (ByteScanIndex(pointer(Value.Text), Value.Len, ord('&')) < 0) then
+    FastSetString(result, Value.Text, Value.Len)
+  else
+    XmlUnescape(Value.Text, Value.Len, result);
+end;
+
+procedure XmlUnescape(Text: PUtf8Char; TextLen: PtrInt; out result: RawUtf8);
+var
+  W: TTextWriter;
+  tmp: TTextWriterStackBuffer;
+  p, e, s, a, amp: PUtf8Char;
+  i: PtrInt;
+  c: cardinal;
+  ch: AnsiChar;
+  ent: RawUtf8;
+  buf: array[0..7] of AnsiChar;
+begin
+  p := Text;
+  if (p = nil) or
+     (ByteScanIndex(pointer(p), TextLen, ord('&')) < 0) then
+  begin
+    FastSetString(result, Text, TextLen);
+    exit;
+  end;
+  e := Text + TextLen;
+  W := TTextWriter.CreateOwnedStream(tmp);
+  try
+    repeat
+      i := ByteScanIndex(pointer(p), e - p, ord('&'));
+      if i < 0 then
+      begin
+        W.AddNoJsonEscape(p, e - p);
+        break;
+      end;
+      W.AddNoJsonEscape(p, i);
+      amp := p + i;
+      a := amp + 1; // just after '&'
+      s := a;
+      while (s < e) and
+            (s^ <> ';') and
+            (s - a < 12) do
+        inc(s);
+      if (s = e) or
+         (s^ <> ';') then
+        s := nil
+      else if a^ = '#' then
+      begin
+        // decode &#nnn; or &#xhh; numeric character reference
+        inc(a);
+        c := 0;
+        if (a < s) and
+           (a^ in ['x', 'X']) then
+        begin
+          inc(a);
+          if a = s then
+            s := nil
+          else
+            while a < s do
+            begin
+              case a^ of
+                '0'..'9':
+                  c := c shl 4 + cardinal(ord(a^) - ord('0'));
+                'a'..'f':
+                  c := c shl 4 + cardinal(ord(a^) - ord('a') + 10);
+                'A'..'F':
+                  c := c shl 4 + cardinal(ord(a^) - ord('A') + 10);
+              else
+                begin
+                  s := nil;
+                  break;
+                end;
+              end;
+              if c > $10ffff then
+              begin
+                s := nil;
+                break;
+              end;
+              inc(a);
+            end;
+        end
+        else if a = s then
+          s := nil
+        else
+          while a < s do
+            if a^ in ['0'..'9'] then
+            begin
+              c := c * 10 + cardinal(ord(a^) - ord('0'));
+              if c > $10ffff then
+              begin
+                s := nil;
+                break;
+              end;
+              inc(a);
+            end
+            else
+            begin
+              s := nil;
+              break;
+            end;
+        if (s <> nil) and
+           ((c = 0) or
+            ((c >= $d800) and
+             (c <= $dfff))) then
+          s := nil; // reject #0 and surrogates
+        if s <> nil then
+          W.AddNoJsonEscape(@buf, Ucs4ToUtf8(c, @buf));
+      end
+      else
+      begin
+        // decode one of the five predefined entities
+        ch := #0;
+        case s - a of
+          2:
+            if PWord(a)^ = ord('l') + ord('t') shl 8 then
+              ch := '<'
+            else if PWord(a)^ = ord('g') + ord('t') shl 8 then
+              ch := '>';
+          3:
+            if CompareMemSmall(a, PAnsiChar('amp'), 3) then
+              ch := '&';
+          4:
+            if CompareMemSmall(a, PAnsiChar('apos'), 4) then
+              ch := ''''
+            else if CompareMemSmall(a, PAnsiChar('quot'), 4) then
+              ch := '"';
+        end;
+        if ch = #0 then
+          s := nil
+        else
+          W.Add(ch);
+      end;
+      if s = nil then
+      begin
+        i := e - amp;
+        if i > 16 then
+          i := 16;
+        FastSetString(ent, amp, i);
+        EXmlException.RaiseUtf8('XmlUnescape: invalid entity in "%"', [ent]);
+      end;
+      p := s + 1;
+    until p >= e;
+    W.SetText(result);
+  finally
+    W.Free;
   end;
 end;
 

--- a/src/core/mormot.core.fmt.pas
+++ b/src/core/mormot.core.fmt.pas
@@ -56,6 +56,13 @@ function NeedsHtmlEscape(text: PUtf8Char; fmt: TTextWriterHtmlFormat): boolean;
 /// low-level conversion of an &amp; HTML entity into 32-bit Unicode Code Point
 function EntityToUcs4(entity: PUtf8Char; len: byte): Ucs4CodePoint;
 
+/// low-level decoding of a '#nnn' or '#xhh' numeric character reference
+// - entity should point at the '#' char, len being the reference length
+// (excluding any trailing ';')
+// - returns 0 on invalid input - as used by AddHtmlUnescape/AddXmlUnescape
+function NumCharToUcs4(entity: PUtf8Char; len: PtrUInt): Ucs4CodePoint;
+  {$ifdef HASINLINE}inline;{$endif}
+
 /// escape some UTF-8 text into HTML
 // - just a wrapper around TTextWriter.AddHtmlEscape() process,
 // replacing < > & " chars depending on the HTML layer
@@ -210,10 +217,15 @@ type
   TXmlParser = object
   {$endif USERECORDWITHMETHODS}
   private
-    fCur, fBegin, fAfter, fToken: PUtf8Char;
+    fCur, fBegin, fAfter, fToken, fNameOrigin: PUtf8Char;
     fOptions: TXmlParserOptions;
     fInElement: boolean; // scanning attributes, up to '>' or '/>'
-    fStack: array of TValuePUtf8Char; // opened elements raw names
+    // opened element names, as packed 25-bit offsets from fNameOrigin and
+    // 7-bit lengths - a static 1KB stack, favoring the common SAX use case:
+    // up to 256 nesting levels and 127-byte names, with the offsets origin
+    // reset each time the nesting level returns to 0 (so no 32MB limit for
+    // any consecutive documents/fragments, but only within a single root)
+    fStack: array[byte] of cardinal;
     procedure ParseError(pos: PUtf8Char; const reason: RawUtf8);
     function ParseName(var p: PUtf8Char): TValuePUtf8Char;
     procedure SetName(const raw: TValuePUtf8Char);
@@ -251,8 +263,17 @@ type
       {$ifdef HASINLINE}inline;{$endif}
   end;
 
+/// unescape some XML text into a TTextWriter instance
+// - decode the five XML predefined entities and numeric character references,
+// i.e.   &lt; &gt; &amp; &apos; &quot;   and   &#nnn; &#xhh;   patterns
+// - as AddHtmlUnescape(), the first '&' position could be supplied in amp,
+// if the caller did already search for it
+// - raises EXmlException on any other (i.e. undefined) entity
+procedure AddXmlUnescape(W: TTextWriter; p, amp: PUtf8Char; plen: PtrUInt);
+
 /// decode the five XML predefined entities and numeric character references
-// - i.e.   &lt; &gt; &amp; &apos; &quot;   and   &#nnn; &#xhh;   patterns
+// - just a wrapper around AddXmlUnescape(), with no allocation if no '&'
+// entity appears in the input text
 // - as used by TXmlParser.ValueToUtf8, or to be called directly
 // - raises EXmlException on any other (i.e. undefined) entity
 procedure XmlUnescape(Text: PUtf8Char; TextLen: PtrInt; out result: RawUtf8);
@@ -1017,12 +1038,25 @@ begin
     inc(p); // ignore '&'
     dec(plen);
     l := 0;
-    while (l < plen) and
-          (p[l] in ['a'..'z', 'A'..'Z', '1'..'4']) do
+    if (plen <> 0) and
+       (p^ = '#') then
+    begin
+      // numeric character reference, e.g. &#233; or &#xE9;
       inc(l);
+      while (l < plen) and
+            (p[l] in ['0'..'9', 'x', 'X', 'a'..'f', 'A'..'F']) do
+        inc(l);
+    end
+    else
+      while (l < plen) and
+            (p[l] in ['a'..'z', 'A'..'Z', '1'..'4']) do
+        inc(l);
     if p[l] = ';' then
     begin
-      c := EntityToUcs4(p, l); // &lt; -> ord('<')
+      if p^ = '#' then
+        c := NumCharToUcs4(p, l)
+      else
+        c := EntityToUcs4(p, l); // &lt; -> ord('<')
       if c <> 0 then
       begin
         if c = $00a0 then             // &nbsp;
@@ -1032,7 +1066,7 @@ begin
         else if c = $2026 then
           W.AddShort4(DOT_24, 3)      // &hellip;
         else
-          W.AddWideChar(WideChar(c)); // &Eacute;
+          W.AddUcs4(c);               // &Eacute; or any code point
         inc(l); // consume ending ;
         inc(p, l);
         dec(plen, l);
@@ -1198,6 +1232,56 @@ begin
      else
        inc(ndx, $00a0 - 7); // &nbsp; = U+00A0, &iexcl; = U+00A1, ...
 ok:result := ndx;
+end;
+
+function NumCharToUcs4(entity: PUtf8Char; len: PtrUInt): Ucs4CodePoint;
+var
+  c: cardinal;
+begin
+  result := 0; // 0 = invalid
+  inc(entity); // ignore leading '#'
+  dec(len);
+  if len = 0 then
+    exit;
+  c := 0;
+  if entity^ in ['x', 'X'] then
+  begin
+    inc(entity);
+    dec(len);
+    if len = 0 then
+      exit;
+    repeat
+      case entity^ of
+        '0' .. '9':
+          c := c shl 4 + cardinal(ord(entity^) - ord('0'));
+        'a' .. 'f':
+          c := c shl 4 + cardinal(ord(entity^) - (ord('a') - 10));
+        'A' .. 'F':
+          c := c shl 4 + cardinal(ord(entity^) - (ord('A') - 10));
+      else
+        exit;
+      end;
+      if c > $10ffff then
+        exit;
+      inc(entity);
+      dec(len);
+    until len = 0;
+  end
+  else
+    repeat
+      if entity^ in ['0' .. '9'] then
+        c := c * 10 + cardinal(ord(entity^) - ord('0'))
+      else
+        exit;
+      if c > $10ffff then
+        exit;
+      inc(entity);
+      dec(len);
+    until len = 0;
+  if (c >= $d800) and
+     (c <= $dfff) then
+    exit; // reject UTF-16 surrogates
+  result := c;
 end;
 
 function HtmlUnescape(const text: RawUtf8): RawUtf8;
@@ -1570,14 +1654,16 @@ end;
 
 function TXmlParser.ParseName(var p: PUtf8Char): TValuePUtf8Char;
 var
-  s: PUtf8Char;
+  s, e: PUtf8Char; // scan on locals (i.e. registers), not the var parameter
 begin
   s := p;
-  while (p < fAfter) and
-        not (p^ in [#0..' ', '<', '>', '/', '=', '?', '"', '''']) do
-    inc(p);
+  e := fAfter;
   result.Text := s;
-  result.Len := p - s;
+  while (s < e) and
+        not (s^ in [#0..' ', '<', '>', '/', '=', '?', '"', '''']) do
+    inc(s);
+  result.Len := s - p;
+  p := s;
   if result.Len = 0 then
     ParseError(s, 'void or invalid name');
 end;
@@ -1611,6 +1697,7 @@ begin
   fBegin := Text;
   fCur := Text;
   fToken := Text;
+  fNameOrigin := Text;
   fAfter := Text + TextLen;
   fOptions := Options;
   fInElement := false;
@@ -1667,7 +1754,9 @@ begin
             inc(p);
             fInElement := false;
             dec(Depth);
-            SetName(fStack[Depth]);
+            n.Text := fNameOrigin + (fStack[Depth] shr 7);
+            n.Len := fStack[Depth] and 127;
+            SetName(n);
             Kind := xtElementEnd;
             break;
           end;
@@ -1734,8 +1823,9 @@ begin
             if Depth = 0 then
               ParseError(n.Text, 'unexpected end tag');
             dec(Depth);
-            if (fStack[Depth].Len <> n.Len) or
-               not CompareMemSmall(fStack[Depth].Text, n.Text, n.Len) then
+            if ((fStack[Depth] and 127) <> cardinal(n.Len)) or
+               not CompareMemSmall(fNameOrigin + (fStack[Depth] shr 7),
+                 n.Text, n.Len) then
               ParseError(n.Text, 'mismatched end tag');
             SetName(n);
             Kind := xtElementEnd;
@@ -1823,9 +1913,17 @@ begin
         begin
           // <name> element start
           n := ParseName(p);
-          if Depth = length(fStack) then
-            SetLength(fStack, NextGrow(Depth));
-          fStack[Depth] := n;
+          if Depth = 0 then
+            // no more opened element: reset the packed offsets origin
+            fNameOrigin := n.Text
+          else if Depth > high(fStack) then
+            ParseError(n.Text, 'too much nesting');
+          if n.Len > 127 then
+            ParseError(n.Text, 'unexpectedly long name');
+          if n.Text - fNameOrigin >= 1 shl 25 then
+            ParseError(n.Text, 'single root spanning over 32MB');
+          fStack[Depth] := cardinal(n.Text - fNameOrigin) shl 7 +
+                           cardinal(n.Len);
           inc(Depth);
           fInElement := true;
           SetName(n);
@@ -1869,156 +1967,114 @@ end;
 
 procedure TXmlParser.ValueToUtf8(out result: RawUtf8);
 begin
-  if (Kind in [xtCData, xtComment]) or
-     (ByteScanIndex(pointer(Value.Text), Value.Len, ord('&')) < 0) then
-    FastSetString(result, Value.Text, Value.Len)
+  if Kind in [xtCData, xtComment] then
+    FastSetString(result, Value.Text, Value.Len) // verbatim sections
   else
     XmlUnescape(Value.Text, Value.Len, result);
 end;
 
+procedure AddXmlUnescape(W: TTextWriter; p, amp: PUtf8Char; plen: PtrUInt);
+var
+  l: PtrUInt;
+  c: Ucs4CodePoint;
+  ent: RawUtf8;
+begin
+  repeat
+    if amp = nil then
+    begin
+      amp := PosChar(p, plen, '&');
+      if amp = nil then
+      begin
+        W.AddNoJsonEscape(p, plen); // no more entity to decode
+        exit;
+      end;
+    end;
+    l := amp - p;
+    if l <> 0 then
+    begin
+      W.AddNoJsonEscape(p, l);
+      dec(plen, l);
+      p := amp;
+    end;
+    amp := nil; // call PosChar() on next iteration
+    inc(p); // ignore '&'
+    dec(plen);
+    // scan up to ';' (references are short - cap the search)
+    l := 0;
+    while (l < plen) and
+          (l < 12) and
+          (p[l] <> ';') do
+      inc(l);
+    c := 0;
+    if (l < plen) and
+       (p[l] = ';') then
+      // cascaded case of the five predefined entities + numeric references
+      case p^ of
+        '#':
+          c := NumCharToUcs4(p, l);
+        'l':
+          if (l = 2) and
+             (p[1] = 't') then
+            c := ord('<');
+        'g':
+          if (l = 2) and
+             (p[1] = 't') then
+            c := ord('>');
+        'a':
+          if (l = 3) and
+             (PCardinal(p)^ and $00ffffff =
+              ord('a') + ord('m') shl 8 + ord('p') shl 16) then
+            c := ord('&')
+          else if (l = 4) and
+             (PCardinal(p)^ =
+              ord('a') + ord('p') shl 8 + ord('o') shl 16 + ord('s') shl 24) then
+            c := ord('''');
+        'q':
+          if (l = 4) and
+             (PCardinal(p)^ =
+              ord('q') + ord('u') shl 8 + ord('o') shl 16 + ord('t') shl 24) then
+            c := ord('"');
+      end;
+    if c = 0 then
+    begin
+      l := plen + 1;
+      if l > 16 then
+        l := 16;
+      FastSetString(ent, p - 1, l);
+      EXmlException.RaiseUtf8('XmlUnescape: invalid entity in "%"', [ent]);
+    end;
+    if c <= $7f then
+      W.AddDirect(AnsiChar(c))
+    else
+      W.AddUcs4(c);
+    inc(l); // consume ending ';'
+    inc(p, l);
+    dec(plen, l);
+  until plen = 0;
+end;
+
 procedure XmlUnescape(Text: PUtf8Char; TextLen: PtrInt; out result: RawUtf8);
 var
+  amp: PUtf8Char;
   W: TTextWriter;
   tmp: TTextWriterStackBuffer;
-  p, e, s, a, amp: PUtf8Char;
-  i: PtrInt;
-  c: cardinal;
-  ch: AnsiChar;
-  ent: RawUtf8;
-  buf: array[0..7] of AnsiChar;
 begin
-  p := Text;
-  if (p = nil) or
-     (ByteScanIndex(pointer(p), TextLen, ord('&')) < 0) then
+  amp := nil;
+  if TextLen > 0 then
+    amp := PosChar(Text, TextLen, '&');
+  if amp = nil then
   begin
-    FastSetString(result, Text, TextLen);
+    FastSetString(result, Text, TextLen); // no allocation if no entity
     exit;
   end;
-  e := Text + TextLen;
   W := TTextWriter.CreateOwnedStream(tmp);
   try
-    repeat
-      i := ByteScanIndex(pointer(p), e - p, ord('&'));
-      if i < 0 then
-      begin
-        W.AddNoJsonEscape(p, e - p);
-        break;
-      end;
-      W.AddNoJsonEscape(p, i);
-      amp := p + i;
-      a := amp + 1; // just after '&'
-      s := a;
-      while (s < e) and
-            (s^ <> ';') and
-            (s - a < 12) do
-        inc(s);
-      if (s = e) or
-         (s^ <> ';') then
-        s := nil
-      else if a^ = '#' then
-      begin
-        // decode &#nnn; or &#xhh; numeric character reference
-        inc(a);
-        c := 0;
-        if (a < s) and
-           (a^ in ['x', 'X']) then
-        begin
-          inc(a);
-          if a = s then
-            s := nil
-          else
-            while a < s do
-            begin
-              case a^ of
-                '0'..'9':
-                  c := c shl 4 + cardinal(ord(a^) - ord('0'));
-                'a'..'f':
-                  c := c shl 4 + cardinal(ord(a^) - ord('a') + 10);
-                'A'..'F':
-                  c := c shl 4 + cardinal(ord(a^) - ord('A') + 10);
-              else
-                begin
-                  s := nil;
-                  break;
-                end;
-              end;
-              if c > $10ffff then
-              begin
-                s := nil;
-                break;
-              end;
-              inc(a);
-            end;
-        end
-        else if a = s then
-          s := nil
-        else
-          while a < s do
-            if a^ in ['0'..'9'] then
-            begin
-              c := c * 10 + cardinal(ord(a^) - ord('0'));
-              if c > $10ffff then
-              begin
-                s := nil;
-                break;
-              end;
-              inc(a);
-            end
-            else
-            begin
-              s := nil;
-              break;
-            end;
-        if (s <> nil) and
-           ((c = 0) or
-            ((c >= $d800) and
-             (c <= $dfff))) then
-          s := nil; // reject #0 and surrogates
-        if s <> nil then
-          W.AddNoJsonEscape(@buf, Ucs4ToUtf8(c, @buf));
-      end
-      else
-      begin
-        // decode one of the five predefined entities
-        ch := #0;
-        case s - a of
-          2:
-            if PWord(a)^ = ord('l') + ord('t') shl 8 then
-              ch := '<'
-            else if PWord(a)^ = ord('g') + ord('t') shl 8 then
-              ch := '>';
-          3:
-            if CompareMemSmall(a, PAnsiChar('amp'), 3) then
-              ch := '&';
-          4:
-            if CompareMemSmall(a, PAnsiChar('apos'), 4) then
-              ch := ''''
-            else if CompareMemSmall(a, PAnsiChar('quot'), 4) then
-              ch := '"';
-        end;
-        if ch = #0 then
-          s := nil
-        else
-          W.Add(ch);
-      end;
-      if s = nil then
-      begin
-        i := e - amp;
-        if i > 16 then
-          i := 16;
-        FastSetString(ent, amp, i);
-        EXmlException.RaiseUtf8('XmlUnescape: invalid entity in "%"', [ent]);
-      end;
-      p := s + 1;
-    until p >= e;
+    AddXmlUnescape(W, Text, amp, TextLen);
     W.SetText(result);
   finally
     W.Free;
   end;
 end;
-
-const
-  XMLPARSER_MAX_DEPTH = 512; // avoid EStackOverflow on pathological input
 
 procedure XmlDocAddOrAppend(var doc: TDocVariantData; const name: RawUtf8;
   const v: variant; const opt: TDocVariantOptions);
@@ -2056,8 +2112,7 @@ var
   v: variant;
 begin
   // fill from attributes and content, until the matching xtElementEnd
-  if x.Depth > XMLPARSER_MAX_DEPTH then
-    x.ParseError(x.Name.Text, 'too much nesting');
+  // (nesting is bounded by the TXmlParser 256 levels static stack)
   obj.Init(opt, dvObject);
   txt := '';
   while x.Next do

--- a/src/core/mormot.core.fmt.pas
+++ b/src/core/mormot.core.fmt.pas
@@ -257,6 +257,38 @@ type
 // - raises EXmlException on any other (i.e. undefined) entity
 procedure XmlUnescape(Text: PUtf8Char; TextLen: PtrInt; out result: RawUtf8);
 
+const
+  /// TDocVariant options used by default for XmlToVariant()
+  // - no number type inference is done: XML content is text by nature, so
+  // all values are stored as (lossless) strings
+  JSON_XML = JSON_FAST;
+
+/// parse XML UTF-8 content into a TDocVariant document
+// - a late-binding-friendly mapping, following common XML-to-JSON conventions:
+// each element becomes an object field named after it; repeated sibling
+// elements of the same name are gathered into an array; attributes appear as
+// fields with a '@' prefix; an element with no attribute and only text becomes
+// a plain string value; mixed content stores its text as a '#text' field;
+// CDATA sections are handled as text; comments and PI are ignored
+// - all values are stored as strings - XML is untyped text by nature
+// - only xpoStripNamespacePrefix is used from ParseOptions
+// - raises EXmlException on any malformed or unsupported input (e.g. DTD)
+procedure XmlToVariant(const Xml: RawUtf8; out Doc: TDocVariantData;
+  ParseOptions: TXmlParserOptions = [];
+  Options: TDocVariantOptions = JSON_XML);
+
+/// convenient wrapper around XmlToVariant() with no EXmlException
+// - will catch internally any EXmlException and return false on failure
+function TryXmlToVariant(const Xml: RawUtf8; out Doc: TDocVariantData;
+  ParseOptions: TXmlParserOptions = [];
+  Options: TDocVariantOptions = JSON_XML): boolean;
+
+/// convert XML UTF-8 content into a JSON object
+// - just a wrapper around XmlToVariant() + TDocVariantData.ToJson
+// - see JsonToXml() for the reverse process
+function XmlToJson(const Xml: RawUtf8;
+  ParseOptions: TXmlParserOptions = []): RawUtf8;
+
 
 { ************* YAML 1.2 core-schema to JSON or TDocVariant Support }
 
@@ -1983,6 +2015,147 @@ begin
   finally
     W.Free;
   end;
+end;
+
+const
+  XMLPARSER_MAX_DEPTH = 512; // avoid EStackOverflow on pathological input
+
+procedure XmlDocAddOrAppend(var doc: TDocVariantData; const name: RawUtf8;
+  const v: variant; const opt: TDocVariantOptions);
+var
+  i: PtrInt;
+  arr: PDocVariantData;
+  a: TDocVariantData;
+  prev: variant;
+begin
+  // gather repeated sibling elements of the same name into an array
+  i := doc.GetValueIndex(name);
+  if i < 0 then
+    doc.AddValue(name, v)
+  else
+  begin
+    arr := _Safe(doc.Values[i]);
+    if arr^.IsArray then
+      arr^.AddItem(v)
+    else
+    begin
+      prev := doc.Values[i];
+      a.Init(opt, dvArray);
+      a.AddItem(prev);
+      a.AddItem(v);
+      doc.Value[name] := variant(a);
+    end;
+  end;
+end;
+
+procedure XmlElementToVariant(var x: TXmlParser;
+  const opt: TDocVariantOptions; out result: variant);
+var
+  obj: TDocVariantData;
+  n, txt, seg: RawUtf8;
+  v: variant;
+begin
+  // fill from attributes and content, until the matching xtElementEnd
+  if x.Depth > XMLPARSER_MAX_DEPTH then
+    x.ParseError(x.Name.Text, 'too much nesting');
+  obj.Init(opt, dvObject);
+  txt := '';
+  while x.Next do
+    case x.Kind of
+      xtAttribute:
+        begin
+          x.NameToUtf8(n);
+          x.ValueToUtf8(seg);
+          RawUtf8ToVariant(seg, v);
+          obj.AddValue('@' + n, v);
+        end;
+      xtElementStart:
+        begin
+          x.NameToUtf8(n);
+          XmlElementToVariant(x, opt, v);
+          XmlDocAddOrAppend(obj, n, v, opt);
+        end;
+      xtText,
+      xtCData:
+        begin
+          x.ValueToUtf8(seg);
+          txt := txt + seg;
+        end;
+      xtElementEnd:
+        break;
+    end;
+  if obj.Count = 0 then
+  begin
+    // no attribute nor child element: as a plain string value
+    RawUtf8ToVariant(txt, result);
+    obj.Clear;
+  end
+  else
+  begin
+    if txt <> '' then
+    begin
+      RawUtf8ToVariant(txt, v);
+      obj.AddValue('#text', v);
+    end;
+    result := variant(obj);
+  end;
+end;
+
+procedure XmlToVariant(const Xml: RawUtf8; out Doc: TDocVariantData;
+  ParseOptions: TXmlParserOptions; Options: TDocVariantOptions);
+var
+  x: TXmlParser;
+  n, txt, seg: RawUtf8;
+  v: variant;
+begin
+  Doc.Init(Options, dvObject);
+  x.Init(pointer(Xml), length(Xml),
+    ParseOptions * [xpoStripNamespacePrefix]);
+  txt := '';
+  while x.Next do
+    case x.Kind of
+      xtElementStart:
+        begin
+          x.NameToUtf8(n);
+          XmlElementToVariant(x, Options, v);
+          XmlDocAddOrAppend(Doc, n, v, Options);
+        end;
+      xtText,
+      xtCData:
+        begin
+          x.ValueToUtf8(seg);
+          txt := txt + seg;
+        end;
+    end;
+  if txt <> '' then
+  begin
+    RawUtf8ToVariant(txt, v);
+    Doc.AddValue('#text', v);
+  end;
+end;
+
+function TryXmlToVariant(const Xml: RawUtf8; out Doc: TDocVariantData;
+  ParseOptions: TXmlParserOptions; Options: TDocVariantOptions): boolean;
+begin
+  try
+    XmlToVariant(Xml, Doc, ParseOptions, Options);
+    result := true;
+  except
+    on EXmlException do
+    begin
+      Doc.Clear;
+      result := false;
+    end;
+  end;
+end;
+
+function XmlToJson(const Xml: RawUtf8;
+  ParseOptions: TXmlParserOptions): RawUtf8;
+var
+  doc: TDocVariantData;
+begin
+  XmlToVariant(Xml, doc, ParseOptions);
+  result := doc.ToJson;
 end;
 
 

--- a/test/mormot2tests.dpr
+++ b/test/mormot2tests.dpr
@@ -148,6 +148,7 @@ begin
   AddCase([
     TTestCoreBase,
     TTestCoreProcess,
+    TTestCoreXml,
     TTestCoreYaml,
     {$ifdef HASGENERICS} // do-nothing on oldest compilers (e.g. <= Delphi XE7)
     TTestCoreCollections,

--- a/test/test.core.data.pas
+++ b/test/test.core.data.pas
@@ -200,7 +200,7 @@ type
   protected
     procedure Walk(var p: TXmlParser; kind: TXmlToken;
       const name: RawUtf8 = ''; const value: RawUtf8 = '');
-    procedure ExpectRaise(const Context, Xml: RawUtf8;
+    procedure ExpectRaise(const Context: string; const Xml: RawUtf8;
       Options: TXmlParserOptions = []);
   published
     /// SAX-level tokens over elements, attributes, text and CData
@@ -9172,8 +9172,8 @@ begin
   CheckEqual(v, value, 'value');
 end;
 
-procedure TTestCoreXml.ExpectRaise(const Context, Xml: RawUtf8;
-  Options: TXmlParserOptions);
+procedure TTestCoreXml.ExpectRaise(const Context: string;
+  const Xml: RawUtf8; Options: TXmlParserOptions);
 var
   p: TXmlParser;
   n, v: RawUtf8;
@@ -9232,13 +9232,18 @@ end;
 procedure TTestCoreXml.SaxEntities;
 var
   p: TXmlParser;
+  chinese: RawUtf8;
+  buf: array[0..7] of AnsiChar;
 const
   X: RawUtf8 = '<r q="&quot;&apos;">&lt;&amp;&gt; &#65;&#x42;c &#x4E2D;</r>';
 begin
+  // compute the U+4E2D UTF-8 bytes at runtime: a #$e4#$b8#$ad literal would
+  // be re-encoded from UTF-16 chars by the Delphi compiler
+  SetString(chinese, PAnsiChar(@buf), Ucs4ToUtf8($4E2D, @buf));
   p.Init(pointer(X), length(X));
   Walk(p, xtElementStart, 'r');
   Walk(p, xtAttribute, 'q', '"''');
-  Walk(p, xtText, '', '<&> ABc ' + #$e4#$b8#$ad); // U+4E2D as UTF-8
+  Walk(p, xtText, '', '<&> ABc ' + chinese);
   Walk(p, xtElementEnd, 'r');
   Check(not p.Next);
 end;

--- a/test/test.core.data.pas
+++ b/test/test.core.data.pas
@@ -211,6 +211,8 @@ type
     procedure SaxOptions;
     /// malformed input and the "basic profile" rejection set (e.g. DTD)
     procedure SaxErrors;
+    /// XmlToVariant/TryXmlToVariant/XmlToJson mapping conventions
+    procedure ToVariant;
   end;
 
   /// this test case will test most functions, classes and types defined and
@@ -9306,6 +9308,48 @@ begin
   ExpectRaise('eof in comment', '<a><!-- x</a>');
   ExpectRaise('eof in cdata', '<a><![CDATA[x</a>');
   ExpectRaise('void name', '< a></a>');
+end;
+
+procedure TTestCoreXml.ToVariant;
+var
+  doc: TDocVariantData;
+begin
+  // plain string value for text-only elements
+  CheckEqual(XmlToJson('<a>hello</a>'), '{"a":"hello"}');
+  // void element as an empty string
+  CheckEqual(XmlToJson('<a/>'), '{"a":""}');
+  // attribute-only element
+  CheckEqual(XmlToJson('<a d="x"/>'), '{"a":{"@d":"x"}}');
+  // all values remain (lossless) strings
+  CheckEqual(XmlToJson('<c><sipId>34020000001320000001</sipId>' +
+    '<port>5060</port></c>'),
+    '{"c":{"sipId":"34020000001320000001","port":"5060"}}');
+  // attributes with '@' prefix, repeated siblings as arrays, mixed as #text
+  CheckEqual(XmlToJson('<a><b>1</b><b>2</b><c d="x">t</c></a>'),
+    '{"a":{"b":["1","2"],"c":{"@d":"x","#text":"t"}}}');
+  CheckEqual(XmlToJson('<a><b>1</b><b>2</b><b>3</b></a>'),
+    '{"a":{"b":["1","2","3"]}}');
+  // mixed content
+  CheckEqual(XmlToJson('<a>pre<b/>post</a>'),
+    '{"a":{"b":"","#text":"prepost"}}');
+  // entities and CDATA
+  CheckEqual(XmlToJson('<a>x &amp; y</a>'), '{"a":"x & y"}');
+  CheckEqual(XmlToJson('<a><![CDATA[<raw> & unescaped]]></a>'),
+    '{"a":"<raw> & unescaped"}');
+  // XML declaration and comments are ignored
+  CheckEqual(XmlToJson(XMLUTF8_HEADER + '<a><!-- c --><b>1</b></a>'),
+    '{"a":{"b":"1"}}');
+  // namespace prefixes kept by default, stripped on request
+  CheckEqual(XmlToJson('<s:e><s:b>x</s:b></s:e>'),
+    '{"s:e":{"s:b":"x"}}');
+  CheckEqual(XmlToJson('<s:e xmlns:s="u"><s:b>x</s:b></s:e>',
+    [xpoStripNamespacePrefix]),
+    '{"e":{"@s":"u","b":"x"}}');
+  // TryXmlToVariant
+  Check(TryXmlToVariant('<a><b>1</b></a>', doc), 'try ok');
+  CheckEqual(doc.ToJson, '{"a":{"b":"1"}}');
+  Check(not TryXmlToVariant('<a><b></a>', doc), 'try mismatch');
+  CheckEqual(doc.Count, 0);
 end;
 
 

--- a/test/test.core.data.pas
+++ b/test/test.core.data.pas
@@ -9246,6 +9246,8 @@ begin
   Walk(p, xtText, '', '<&> ABc ' + chinese);
   Walk(p, xtElementEnd, 'r');
   Check(not p.Next);
+  // the shared NumCharToUcs4() decoder is also wired into HTML unescape
+  CheckEqual(HtmlUnescape('x &#65;&#x42; &amp; y'), 'x AB & y');
 end;
 
 procedure TTestCoreXml.SaxOptions;
@@ -9299,6 +9301,9 @@ begin
 end;
 
 procedure TTestCoreXml.SaxErrors;
+var
+  deep, big: RawUtf8;
+  i: integer;
 begin
   ExpectRaise('dtd', '<!DOCTYPE foo [<!ENTITY x "y">]><a>&x;</a>');
   ExpectRaise('mismatch', '<a><b></a>');
@@ -9313,6 +9318,14 @@ begin
   ExpectRaise('eof in comment', '<a><!-- x</a>');
   ExpectRaise('eof in cdata', '<a><![CDATA[x</a>');
   ExpectRaise('void name', '< a></a>');
+  ExpectRaise('dangling amp', '<a>&</a>');
+  deep := '';
+  for i := 1 to 300 do
+    deep := deep + '<a>';
+  ExpectRaise('too much nesting', deep);
+  SetLength(big, 130);
+  FillCharFast(pointer(big)^, 130, ord('n'));
+  ExpectRaise('name too long', '<' + big + '/>');
 end;
 
 procedure TTestCoreXml.ToVariant;

--- a/test/test.core.data.pas
+++ b/test/test.core.data.pas
@@ -195,6 +195,24 @@ type
     procedure OpenapiEquivalence;
   end;
 
+  /// regression tests for the mormot.core.fmt XML parser
+  TTestCoreXml = class(TSynTestCase)
+  protected
+    procedure Walk(var p: TXmlParser; kind: TXmlToken;
+      const name: RawUtf8 = ''; const value: RawUtf8 = '');
+    procedure ExpectRaise(const Context, Xml: RawUtf8;
+      Options: TXmlParserOptions = []);
+  published
+    /// SAX-level tokens over elements, attributes, text and CData
+    procedure SaxTokens;
+    /// the five predefined entities and numeric character references
+    procedure SaxEntities;
+    /// xpoStripNamespacePrefix/xpoKeepComments/xpoKeepPI/xpoKeepWhiteSpace
+    procedure SaxOptions;
+    /// malformed input and the "basic profile" rejection set (e.g. DTD)
+    procedure SaxErrors;
+  end;
+
   /// this test case will test most functions, classes and types defined and
   // implemented e.g. in the mormot.core.zip / mormot.lib.lizard units
   TTestCoreCompression = class(TSynTestCase)
@@ -9136,6 +9154,159 @@ begin
     'OpenAPI-shaped YAML must match JSON equivalent');
 end;
 
+
+{ TTestCoreXml }
+
+procedure TTestCoreXml.Walk(var p: TXmlParser; kind: TXmlToken;
+  const name, value: RawUtf8);
+var
+  n, v: RawUtf8;
+begin
+  Check(p.Next, 'no more tokens');
+  Check(p.Kind = kind, 'kind');
+  p.NameToUtf8(n);
+  p.ValueToUtf8(v);
+  CheckEqual(n, name, 'name');
+  CheckEqual(v, value, 'value');
+end;
+
+procedure TTestCoreXml.ExpectRaise(const Context, Xml: RawUtf8;
+  Options: TXmlParserOptions);
+var
+  p: TXmlParser;
+  n, v: RawUtf8;
+  ok: boolean;
+begin
+  ok := false;
+  try
+    p.Init(pointer(Xml), length(Xml), Options);
+    while p.Next do
+    begin
+      p.NameToUtf8(n);
+      p.ValueToUtf8(v);
+    end;
+  except
+    on EXmlException do
+      ok := true;
+  end;
+  Check(ok, Context);
+end;
+
+const
+  XML1: RawUtf8 = '<?xml version="1.0" encoding="UTF-8"?>'#13#10 +
+    '<root a="1" b=''two''>'#10 +
+    '  <item>some text</item>'#10 +
+    '  <empty/>'#10 +
+    '  <![CDATA[raw <>&'' " ]]>'#10 +
+    '  <!-- a comment -->tail</root>';
+
+procedure TTestCoreXml.SaxTokens;
+var
+  p: TXmlParser;
+begin
+  p.Init(pointer(XML1), length(XML1));
+  CheckEqual(p.Depth, 0);
+  Walk(p, xtElementStart, 'root');
+  CheckEqual(p.Depth, 1);
+  Walk(p, xtAttribute, 'a', '1');
+  Walk(p, xtAttribute, 'b', 'two');
+  Walk(p, xtElementStart, 'item');
+  CheckEqual(p.Depth, 2);
+  Walk(p, xtText, '', 'some text');
+  Walk(p, xtElementEnd, 'item');
+  CheckEqual(p.Depth, 1);
+  Walk(p, xtElementStart, 'empty');
+  Walk(p, xtElementEnd, 'empty');
+  CheckEqual(p.Depth, 1);
+  Walk(p, xtCData, '', 'raw <>&'' " ');
+  Walk(p, xtText, '', 'tail');
+  Walk(p, xtElementEnd, 'root');
+  CheckEqual(p.Depth, 0);
+  Check(not p.Next, 'eof');
+  Check(p.Kind = xtEof);
+  Check(not p.Next, 'still eof');
+end;
+
+procedure TTestCoreXml.SaxEntities;
+var
+  p: TXmlParser;
+const
+  X: RawUtf8 = '<r q="&quot;&apos;">&lt;&amp;&gt; &#65;&#x42;c &#x4E2D;</r>';
+begin
+  p.Init(pointer(X), length(X));
+  Walk(p, xtElementStart, 'r');
+  Walk(p, xtAttribute, 'q', '"''');
+  Walk(p, xtText, '', '<&> ABc ' + #$e4#$b8#$ad); // U+4E2D as UTF-8
+  Walk(p, xtElementEnd, 'r');
+  Check(not p.Next);
+end;
+
+procedure TTestCoreXml.SaxOptions;
+var
+  p: TXmlParser;
+const
+  NS: RawUtf8 = '<ns:a xsi:x="1"><ns:b/></ns:a>';
+  WS: RawUtf8 = '<a>  <b/>  </a>';
+begin
+  // namespace prefixes are part of the names by default
+  p.Init(pointer(NS), length(NS));
+  Walk(p, xtElementStart, 'ns:a');
+  Walk(p, xtAttribute, 'xsi:x', '1');
+  Walk(p, xtElementStart, 'ns:b');
+  Walk(p, xtElementEnd, 'ns:b');
+  Walk(p, xtElementEnd, 'ns:a');
+  Check(not p.Next);
+  // ... but can be stripped on request
+  p.Init(pointer(NS), length(NS), [xpoStripNamespacePrefix]);
+  Walk(p, xtElementStart, 'a');
+  Walk(p, xtAttribute, 'x', '1');
+  Walk(p, xtElementStart, 'b');
+  Walk(p, xtElementEnd, 'b');
+  Walk(p, xtElementEnd, 'a');
+  Check(not p.Next);
+  // comments and processing instructions on request
+  p.Init(pointer(XML1), length(XML1), [xpoKeepComments, xpoKeepPI]);
+  Walk(p, xtPI, 'xml', 'version="1.0" encoding="UTF-8"');
+  Walk(p, xtElementStart, 'root');
+  Walk(p, xtAttribute, 'a', '1');
+  Walk(p, xtAttribute, 'b', 'two');
+  Walk(p, xtElementStart, 'item');
+  Walk(p, xtText, '', 'some text');
+  Walk(p, xtElementEnd, 'item');
+  Walk(p, xtElementStart, 'empty');
+  Walk(p, xtElementEnd, 'empty');
+  Walk(p, xtCData, '', 'raw <>&'' " ');
+  Walk(p, xtComment, '', ' a comment ');
+  Walk(p, xtText, '', 'tail');
+  Walk(p, xtElementEnd, 'root');
+  Check(not p.Next);
+  // pure whitespace text nodes on request
+  p.Init(pointer(WS), length(WS), [xpoKeepWhiteSpace]);
+  Walk(p, xtElementStart, 'a');
+  Walk(p, xtText, '', '  ');
+  Walk(p, xtElementStart, 'b');
+  Walk(p, xtElementEnd, 'b');
+  Walk(p, xtText, '', '  ');
+  Walk(p, xtElementEnd, 'a');
+  Check(not p.Next);
+end;
+
+procedure TTestCoreXml.SaxErrors;
+begin
+  ExpectRaise('dtd', '<!DOCTYPE foo [<!ENTITY x "y">]><a>&x;</a>');
+  ExpectRaise('mismatch', '<a><b></a>');
+  ExpectRaise('unclosed', '<a><b>text');
+  ExpectRaise('eof in tag', '<a');
+  ExpectRaise('eof in attr', '<a b="c');
+  ExpectRaise('unquoted attr', '<a b=c/>');
+  ExpectRaise('unknown entity', '<a>&nbsp;</a>');
+  ExpectRaise('bad numeric ref', '<a>&#xzz;</a>');
+  ExpectRaise('overflow ref', '<a>&#x110000;</a>');
+  ExpectRaise('lone end tag', '</a>');
+  ExpectRaise('eof in comment', '<a><!-- x</a>');
+  ExpectRaise('eof in cdata', '<a><![CDATA[x</a>');
+  ExpectRaise('void name', '< a></a>');
+end;
 
 
 { TTestCoreCompression }


### PR DESCRIPTION
Implements directions 1 + 3 of #487, as proposed in https://github.com/synopse/mORMot2/issues/487#issuecomment-5140101717.

**SAX layer** — `TXmlParser` record in `mormot.core.fmt.pas`: zero-allocation scan over an UTF-8 buffer; `Name`/`Value` point within the input; token positions available to resume a scan (groundwork for direction 4); well-formedness of the tags nesting is verified; `EXmlException` with the faulty line number on malformed input.

"Basic profile" scope, by design:

- no DTD processing at all — which makes the parser immune to entity expansion (billion laughs) by construction; only the five predefined entities and numeric character references are resolved, anything else raises;
- the parser core is UTF-8 only;
- namespaces: the prefix is kept as part of the name (`xpoStripNamespacePrefix` option to strip it), no URI binding;
- `xpoKeepComments` / `xpoKeepPI` / `xpoKeepWhiteSpace` options — those tokens are silently skipped by default;
- non-goals: XPath, XML Schema validation, XSLT.

**Variant layer** — `XmlToVariant` / `TryXmlToVariant` / `XmlToJson`, mirroring the `YamlToVariant()` API family from #466 (same unit): elements as object fields, repeated siblings gathered into arrays, `@` prefix for attributes, `#text` field for mixed content, CDATA as text; all values remain lossless strings, since XML is untyped text by nature.

**Tests**: new `TTestCoreXml` suite (SAX tokens / entities / options / errors + the mapping conventions, 219 assertions); the whole mormot2tests suite is green on FPC i386-win32 (199,376,126 assertions). Also validated against a corpus of real ONVIF device responses (full SOAP envelopes from Dahua/Hikvision cameras: namespaces, deep nesting, repeated profile elements) produced by a gsoap-based stack.

Points I would like your feedback on:

- the exact placement of the variant-layer helpers (kept in the "Basic XML Conversions" section for now);
- the attribute/child mapping convention (`@` / `#text`);
- direction 2 (zero-allocation node tree) can build on this SAX layer as a second step — the token positions are already exposed for it.
