### PR TITLE
core: add mormot.core.i18n - basic i18n unit

### DIFF
--- a/src/core/mormot.core.i18n.pas
+++ b/src/core/mormot.core.i18n.pas
@@ -1,0 +1,426 @@
+/// Framework Core Basic Internationalization Support
+// - this unit is a part of the Open Source Synopse mORMot framework 2,
+// licensed under a MPL/GPL/LGPL three license - see LICENSE.md
+unit mormot.core.i18n;
+
+{
+  *****************************************************************************
+
+   Basic Internationalization (i18n) Support
+    - TSynLanguage per-language translation table
+    - TSynLanguages registry with per-thread language selection
+    - global wiring of the framework translation hooks
+
+   Connects the translation slots kept since mORMot 1 mORMoti18n.pas:
+   TOnStringTranslate / TOnUtf8Translate callbacks, LoadResStringTranslate,
+   i18nDateText / i18nDateTimeText, and the TSynMustache {{"text}} channel -
+   see https://synopse.info/forum/viewtopic.php?id=7592
+
+  *****************************************************************************
+}
+
+interface
+
+{$I ..\mormot.defines.inc}
+
+uses
+  sysutils,
+  classes,
+  mormot.core.base,
+  mormot.core.os,
+  mormot.core.unicode,
+  mormot.core.text,
+  mormot.core.datetime,
+  mormot.core.data,
+  mormot.core.variants,
+  mormot.core.json;
+
+
+{ ************* TSynLanguage per-language Translation Table }
+
+type
+  /// exception raised on invalid i18n definition or process
+  EI18nException = class(ESynException);
+
+  /// implement one translation table for a given language
+  // - table keys are expected to be the original English text, following the
+  // mORMot 1 mORMoti18n.pas semantic and the Mustache {{"English text}}
+  // convention - so a missing key just fallbacks to the original English
+  // - thread-safe access via an internal TSynDictionary
+  TSynLanguage = class(TSynPersistent)
+  protected
+    fLanguage: TLanguage;
+    fIso: RawUtf8;
+    fTexts: TSynDictionary; // RawUtf8 (english/key) -> RawUtf8 (translated)
+    fDateFormat, fDateTimeFormat: string;
+  public
+    /// initialize the table for a given language
+    constructor Create(aLanguage: TLanguage); reintroduce;
+    /// finalize this instance
+    destructor Destroy; override;
+    /// merge translations from a JSON object, e.g. {"Hello":"Bonjour"}
+    // - returns the number of added or replaced pairs, or -1 on invalid JSON
+    function AddFromJson(const Json: RawUtf8): integer;
+    /// merge translations from an UTF-8 JSON object file (BOM tolerated)
+    function AddFromJsonFile(const FileName: TFileName): integer;
+    /// translate the supplied text in-place
+    // - returns true if the key was found and Text was replaced
+    // - returns false and leaves Text untouched (fallback to original text)
+    function Translate(var Text: RawUtf8): boolean;
+    /// TOnStringTranslate-compatible callback, e.g. to be assigned to
+    // TMvcViewsMustache.OnTranslate or supplied to TSynMustache.Render()
+    procedure TranslateString(var English: string);
+    /// TOnUtf8Translate-compatible callback
+    // - Translated is left '' if the key was not found (i.e. caller fallback)
+    procedure TranslateUtf8(English: PUtf8Char; EnglishLen: integer;
+      var Translated: RawUtf8);
+    /// the associated language of this table
+    property Language: TLanguage
+      read fLanguage;
+    /// the ISO 639-1 text of this language, e.g. 'en' or 'zh'
+    property Iso: RawUtf8
+      read fIso;
+    /// optional FormatDateTime() pattern used by the i18nDateText hook
+    // - default '' will use the plain RTL DateToStr() rendering
+    property DateFormat: string
+      read fDateFormat write fDateFormat;
+    /// optional FormatDateTime() pattern used by the i18nDateTimeText hook
+    // - default '' will use the plain RTL DateTimeToStr() rendering
+    property DateTimeFormat: string
+      read fDateTimeFormat write fDateTimeFormat;
+    /// how many translation pairs are stored in this table
+    function Count: integer;
+  end;
+
+
+{ ************* TSynLanguages Registry with per-thread Language }
+
+  /// registry of TSynLanguage tables with per-thread language selection
+  // - typical web usage: load the tables once at startup, then call
+  // TSynLanguages.SetThreadLanguage() at each request start (e.g. from an
+  // URI parameter or a cookie), and assign TranslateString to the Mustache
+  // views engine (e.g. TMvcViewsMustache.OnTranslate)
+  TSynLanguages = class(TSynPersistent)
+  protected
+    fLang: array[TLanguage] of TSynLanguage; // owned instances
+    fDefaultLanguage: TLanguage;
+    function GetLanguage(aLanguage: TLanguage): TSynLanguage;
+  public
+    /// finalize the registry and all its owned tables
+    destructor Destroy; override;
+    /// get or create the translation table of a given language
+    property Language[aLanguage: TLanguage]: TSynLanguage
+      read GetLanguage;
+    /// return the table of a language, nil if none was loaded
+    function Find(aLanguage: TLanguage): TSynLanguage;
+    /// return the table matching an ISO 639-1 text, e.g. 'fr' - nil if none
+    function FindIso(const Iso: RawUtf8): TSynLanguage;
+    /// load all <iso>.json files from a folder, e.g. en.json or zh.json
+    // - returns the number of recognized language files
+    function LoadFromFolder(const Folder: TFileName): integer;
+    /// language used when no per-thread language was set
+    // - equals lngUndefined by default, i.e. no translation at all
+    property DefaultLanguage: TLanguage
+      read fDefaultLanguage write fDefaultLanguage;
+    /// set the language of the current thread, e.g. at HTTP request start
+    // - setting lngUndefined would fallback to DefaultLanguage
+    class procedure SetThreadLanguage(aLanguage: TLanguage);
+    /// the language of the current thread, as set by SetThreadLanguage
+    class function ThreadLanguage: TLanguage;
+    /// the table effective for the current thread
+    // - i.e. the thread language table, or the DefaultLanguage table, or nil
+    function Current: TSynLanguage;
+    /// translate the supplied text using the current thread language
+    function Translate(var Text: RawUtf8): boolean;
+    /// TOnStringTranslate-compatible callback using the thread language
+    // - to be assigned e.g. to TMvcViewsMustache.OnTranslate
+    procedure TranslateString(var English: string);
+    /// TOnUtf8Translate-compatible callback using the thread language
+    procedure TranslateUtf8(English: PUtf8Char; EnglishLen: integer;
+      var Translated: RawUtf8);
+    /// wire this instance to the global framework translation hooks
+    // - set self as the main I18n instance, and assign the global
+    // LoadResStringTranslate slot - which translates the GetCaptionFrom*
+    // family of this framework, not the RTL resourcestring loading - and the
+    // i18nDateText / i18nDateTimeText slots, using each language optional
+    // DateFormat / DateTimeFormat patterns
+    procedure SetGlobal;
+  end;
+
+/// the main TSynLanguages instance, as set by TSynLanguages.SetGlobal
+// - nil if no SetGlobal call was made
+function I18n: TSynLanguages;
+
+
+implementation
+
+
+{ ************* TSynLanguage per-language Translation Table }
+
+{ TSynLanguage }
+
+constructor TSynLanguage.Create(aLanguage: TLanguage);
+begin
+  inherited Create;
+  if aLanguage = lngUndefined then
+    EI18nException.RaiseUtf8('%.Create(lngUndefined)', [self]);
+  fLanguage := aLanguage;
+  fIso := LANG_ISO[aLanguage];
+  fTexts := TSynDictionary.Create(
+    TypeInfo(TRawUtf8DynArray), TypeInfo(TRawUtf8DynArray));
+end;
+
+destructor TSynLanguage.Destroy;
+begin
+  fTexts.Free;
+  inherited Destroy;
+end;
+
+function TSynLanguage.AddFromJson(const Json: RawUtf8): integer;
+var
+  doc: TDocVariantData;
+  i: PtrInt;
+  v: RawUtf8;
+begin
+  result := -1;
+  if not doc.InitJson(Json, JSON_FAST) or
+     not doc.IsObject then
+    exit;
+  result := 0;
+  for i := 0 to doc.Count - 1 do
+  begin
+    VariantToUtf8(doc.Values[i], v);
+    fTexts.AddOrUpdate(doc.Names[i], v);
+    inc(result);
+  end;
+end;
+
+function TSynLanguage.AddFromJsonFile(const FileName: TFileName): integer;
+var
+  json: RawUtf8;
+begin
+  json := RawUtf8(StringFromFile(FileName));
+  if (length(json) >= 3) and
+     (PCardinal(json)^ and $00ffffff = $00bfbbef) then
+    delete(json, 1, 3); // ignore any UTF-8 BOM
+  result := AddFromJson(json);
+end;
+
+function TSynLanguage.Translate(var Text: RawUtf8): boolean;
+var
+  tr: RawUtf8;
+begin
+  result := (Text <> '') and
+            fTexts.FindAndCopy(Text, tr, {updatetimeout=}false);
+  if result then
+    Text := tr;
+end;
+
+procedure TSynLanguage.TranslateString(var English: string);
+var
+  u: RawUtf8;
+begin
+  StringToUtf8(English, u);
+  if Translate(u) then
+    English := Utf8ToString(u);
+end;
+
+procedure TSynLanguage.TranslateUtf8(English: PUtf8Char; EnglishLen: integer;
+  var Translated: RawUtf8);
+var
+  key: RawUtf8;
+begin
+  FastSetString(key, English, EnglishLen);
+  if not fTexts.FindAndCopy(key, Translated, {updatetimeout=}false) then
+    Translated := ''; // caller would fallback to the English text
+end;
+
+function TSynLanguage.Count: integer;
+begin
+  if self = nil then
+    result := 0
+  else
+    result := fTexts.Count;
+end;
+
+
+{ ************* TSynLanguages Registry with per-thread Language }
+
+threadvar
+  _ThreadLanguage: TLanguage;
+
+var
+  _MainI18n: TSynLanguages;
+
+function I18n: TSynLanguages;
+begin
+  result := _MainI18n;
+end;
+
+procedure _LoadResStringTranslate(var Text: string);
+begin
+  if _MainI18n <> nil then
+    _MainI18n.TranslateString(Text);
+end;
+
+function _I18nDateTimeText(const DateTime: TDateTime): string;
+var
+  lang: TSynLanguage;
+begin
+  lang := nil;
+  if _MainI18n <> nil then
+    lang := _MainI18n.Current;
+  if (lang <> nil) and
+     (lang.DateTimeFormat <> '') then
+    result := FormatDateTime(lang.DateTimeFormat, DateTime)
+  else
+    result := DateTimeToStr(DateTime);
+end;
+
+function _I18nDateText(const Iso: TTimeLog): string;
+var
+  lang: TSynLanguage;
+  dt: TDateTime;
+begin
+  dt := PTimeLogBits(@Iso)^.ToDateTime;
+  lang := nil;
+  if _MainI18n <> nil then
+    lang := _MainI18n.Current;
+  if (lang <> nil) and
+     (lang.DateFormat <> '') then
+    result := FormatDateTime(lang.DateFormat, dt)
+  else
+    result := DateToStr(dt);
+end;
+
+{ TSynLanguages }
+
+destructor TSynLanguages.Destroy;
+var
+  l: TLanguage;
+begin
+  if _MainI18n = self then
+  begin
+    // unhook the global slots pointing to this instance
+    _MainI18n := nil;
+    LoadResStringTranslate := nil;
+    i18nDateText := nil;
+    i18nDateTimeText := nil;
+  end;
+  for l := low(fLang) to high(fLang) do
+    fLang[l].Free;
+  inherited Destroy;
+end;
+
+function TSynLanguages.GetLanguage(aLanguage: TLanguage): TSynLanguage;
+begin
+  if aLanguage = lngUndefined then
+    EI18nException.RaiseUtf8('%.Language[lngUndefined]', [self]);
+  result := fLang[aLanguage];
+  if result = nil then
+  begin
+    result := TSynLanguage.Create(aLanguage);
+    fLang[aLanguage] := result;
+  end;
+end;
+
+function TSynLanguages.Find(aLanguage: TLanguage): TSynLanguage;
+begin
+  if self = nil then
+    result := nil
+  else
+    result := fLang[aLanguage];
+end;
+
+function TSynLanguages.FindIso(const Iso: RawUtf8): TSynLanguage;
+begin
+  result := Find(IsoTextToLanguage(Iso));
+end;
+
+function TSynLanguages.LoadFromFolder(const Folder: TFileName): integer;
+var
+  sr: TSearchRec;
+  lng: TLanguage;
+  fn: TFileName;
+begin
+  result := 0;
+  if FindFirst(IncludeTrailingPathDelimiter(Folder) + '*.json',
+       faAnyFile, sr) = 0 then
+  begin
+    repeat
+      fn := GetFileNameWithoutExt(sr.Name);
+      lng := IsoTextToLanguage(StringToUtf8(fn));
+      if lng <> lngUndefined then
+      begin
+        Language[lng].AddFromJsonFile(
+          IncludeTrailingPathDelimiter(Folder) + sr.Name);
+        inc(result);
+      end;
+    until FindNext(sr) <> 0;
+    FindClose(sr);
+  end;
+end;
+
+class procedure TSynLanguages.SetThreadLanguage(aLanguage: TLanguage);
+begin
+  _ThreadLanguage := aLanguage;
+end;
+
+class function TSynLanguages.ThreadLanguage: TLanguage;
+begin
+  result := _ThreadLanguage;
+end;
+
+function TSynLanguages.Current: TSynLanguage;
+var
+  lng: TLanguage;
+begin
+  lng := _ThreadLanguage;
+  if lng = lngUndefined then
+    lng := fDefaultLanguage;
+  if lng = lngUndefined then
+    result := nil
+  else
+    result := fLang[lng];
+end;
+
+function TSynLanguages.Translate(var Text: RawUtf8): boolean;
+var
+  lang: TSynLanguage;
+begin
+  lang := Current;
+  result := (lang <> nil) and
+            lang.Translate(Text);
+end;
+
+procedure TSynLanguages.TranslateString(var English: string);
+var
+  lang: TSynLanguage;
+begin
+  lang := Current;
+  if lang <> nil then
+    lang.TranslateString(English);
+end;
+
+procedure TSynLanguages.TranslateUtf8(English: PUtf8Char; EnglishLen: integer;
+  var Translated: RawUtf8);
+var
+  lang: TSynLanguage;
+begin
+  lang := Current;
+  if lang = nil then
+    Translated := ''
+  else
+    lang.TranslateUtf8(English, EnglishLen, Translated);
+end;
+
+procedure TSynLanguages.SetGlobal;
+begin
+  _MainI18n := self;
+  LoadResStringTranslate := _LoadResStringTranslate;
+  i18nDateText := _I18nDateText;
+  i18nDateTimeText := _I18nDateTimeText;
+end;
+
+
+end.

--- a/src/core/mormot.core.i18n.pas
+++ b/src/core/mormot.core.i18n.pas
@@ -11,10 +11,23 @@ unit mormot.core.i18n;
     - TSynLanguages registry with per-thread language selection
     - global wiring of the framework translation hooks
 
+   Translation tables map the original English text to its translation, and
+   are loaded from .po (GNU gettext) as the main format - .ini, .yaml and
+   .json, with its relaxed JSON5 / JSONC / HJson variants, are also supported.
+
+   Once loaded, three wiring channels are available: the TSynMustache
+   translate tag views channel, the LoadResStringTranslate slot consumed by
+   the GetCaptionFrom* captions, and - on FPC only - the whole executable
+   resourcestring table via TSynLanguages.TranslateResourceStrings.
+
    Connects the translation slots kept since mORMot 1 mORMoti18n.pas:
    TOnStringTranslate / TOnUtf8Translate callbacks, LoadResStringTranslate,
-   i18nDateText / i18nDateTimeText, and the TSynMustache {{"text}} channel -
-   see https://synopse.info/forum/viewtopic.php?id=7592
+   i18nDateText / i18nDateTimeText, and the TSynMustache translate tag
+   channel - see https://synopse.info/forum/viewtopic.php?id=7592
+
+   Note: the translate tag literal syntax appears in the TSynLanguage
+   documentation below, but never within this block comment - on Delphi, a
+   curly brace would close the comment right there (no nested comments).
 
   *****************************************************************************
 }
@@ -33,7 +46,8 @@ uses
   mormot.core.datetime,
   mormot.core.data,
   mormot.core.variants,
-  mormot.core.json;
+  mormot.core.json,
+  mormot.core.fmt;
 
 
 { ************* TSynLanguage per-language Translation Table }
@@ -58,11 +72,60 @@ type
     constructor Create(aLanguage: TLanguage); reintroduce;
     /// finalize this instance
     destructor Destroy; override;
+    /// merge translations from a TDocVariantData object document
+    // - this is the shared implementation of AddFromJson and AddFromYaml: each
+    // document field name is the English key, and its value the translation
+    // - returns the number of added or replaced pairs, or -1 if Doc is not an
+    // object document (e.g. is void or is an array)
+    function AddFromVariant(const Doc: TDocVariantData): integer;
     /// merge translations from a JSON object, e.g. {"Hello":"Bonjour"}
+    // - the relaxed JSON5 / JSONC / HJson variants are also supported, i.e.
+    // comments and unquoted property names, as our settings units do
     // - returns the number of added or replaced pairs, or -1 on invalid JSON
     function AddFromJson(const Json: RawUtf8): integer;
     /// merge translations from an UTF-8 JSON object file (BOM tolerated)
     function AddFromJsonFile(const FileName: TFileName): integer;
+    /// merge translations from a YAML mapping content, e.g. as
+    // ! Hello: Bonjour
+    // ! World: Monde
+    // - use the YAML 1.2 core-schema subset parser of mormot.core.fmt
+    // - returns the number of added or replaced pairs, or -1 on invalid YAML
+    function AddFromYaml(const Yaml: RawUtf8): integer;
+    /// merge translations from a GNU gettext .po file content
+    // - the .po msgid is the original English text and msgstr its translation,
+    // which maps 1:1 on our "key = English text" convention
+    // - fuzzy entries, the empty-msgid header and untranslated (void msgstr)
+    // entries are just ignored
+    // - both CRLF and LF line endings are supported, and the C-like \n \t \r
+    // \b \f \\ \" escapes are decoded - any unsupported escape sequence (e.g.
+    // \u or \x) just keeps the escaped character itself
+    // - non-goals of this basic parser: msgctxt disambiguation, and the
+    // msgid_plural / msgstr[] plural forms - such entries are just ignored
+    // - returns the number of added or replaced translations
+    function AddFromPo(const Po: RawUtf8): integer;
+    /// merge translations from an UTF-8 GNU gettext .po file (BOM tolerated)
+    function AddFromPoFile(const FileName: TFileName): integer;
+    /// merge translations from INI-like content, e.g. as
+    // ! Hello=Bonjour
+    // ! World=Monde
+    // - if aSection is set, only this [aSection] content would be parsed,
+    // otherwise the whole content is, ignoring any section header
+    // - blank lines, ';' or '#' comment lines, and lines with a void key or a
+    // void value are just ignored; blanks around '=' and any trailing CR are
+    // trimmed, and both CRLF and LF line endings are supported
+    // - note that the INI format has no escaping at all: as a consequence, a
+    // translation containing a line feed can't be expressed as INI - use the
+    // .po or JSON formats for such texts
+    // - returns the number of added or replaced translations
+    function AddFromIni(const Ini: RawUtf8; const Section: RawUtf8 = ''): integer;
+    /// merge translations from an INI file (UTF-8, BOM tolerated)
+    function AddFromIniFile(const FileName: TFileName;
+      const Section: RawUtf8 = ''): integer;
+    /// merge translations from a file, recognized by its extension
+    // - .po (gettext), .ini or .msg, .yaml or .yml, .json / .jsonc / .json5
+    // / .hjson (the relaxed JSON variants are read by our JSON parser)
+    // - returns -1 if the file does not exist or its extension is unknown
+    function AddFromFile(const FileName: TFileName): integer;
     /// translate the supplied text in-place
     // - returns true if the key was found and Text was replaced
     // - returns false and leaves Text untouched (fallback to original text)
@@ -82,10 +145,18 @@ type
       read fIso;
     /// optional FormatDateTime() pattern used by the i18nDateText hook
     // - default '' will use the plain RTL DateToStr() rendering
+    // - this pattern is independent from the process locale: '/' and ':' are
+    // rendered as such, and are not rewritten into the RTL DateSeparator /
+    // TimeSeparator locale globals - e.g. 'yyyy/mm/dd' does render slashes,
+    // even on a POSIX/C locale system where DateSeparator is '-'
     property DateFormat: string
       read fDateFormat write fDateFormat;
     /// optional FormatDateTime() pattern used by the i18nDateTimeText hook
     // - default '' will use the plain RTL DateTimeToStr() rendering
+    // - this pattern is independent from the process locale: '/' and ':' are
+    // rendered as such, and are not rewritten into the RTL DateSeparator /
+    // TimeSeparator locale globals - e.g. 'yyyy/mm/dd hh:nn' does render
+    // slashes and colons, whatever the system locale is
     property DateTimeFormat: string
       read fDateTimeFormat write fDateTimeFormat;
     /// how many translation pairs are stored in this table
@@ -94,6 +165,10 @@ type
 
 
 { ************* TSynLanguages Registry with per-thread Language }
+
+  /// a dynamic array of TLanguage values
+  // - as returned e.g. by TSynLanguages.LoadedLanguages
+  TLanguageDynArray = array of TLanguage;
 
   /// registry of TSynLanguage tables with per-thread language selection
   // - typical web usage: load the tables once at startup, then call
@@ -115,9 +190,16 @@ type
     function Find(aLanguage: TLanguage): TSynLanguage;
     /// return the table matching an ISO 639-1 text, e.g. 'fr' - nil if none
     function FindIso(const Iso: RawUtf8): TSynLanguage;
-    /// load all <iso>.json files from a folder, e.g. en.json or zh.json
+    /// load all <iso>.<ext> files from a folder, e.g. en.json or zh.po
+    // - the file name (without its extension) is the ISO 639-1 language text,
+    // and any extension supported by TSynLanguage.AddFromFile is recognized
     // - returns the number of recognized language files
     function LoadFromFolder(const Folder: TFileName): integer;
+    /// return the languages currently loaded in this registry
+    // - i.e. those for which a TSynLanguage table does exist, in TLanguage
+    // enumerate order - void if nothing was loaded yet
+    // - e.g. to fill a language selection list in the User Interface
+    function LoadedLanguages: TLanguageDynArray;
     /// language used when no per-thread language was set
     // - equals lngUndefined by default, i.e. no translation at all
     property DefaultLanguage: TLanguage
@@ -144,7 +226,29 @@ type
     // family of this framework, not the RTL resourcestring loading - and the
     // i18nDateText / i18nDateTimeText slots, using each language optional
     // DateFormat / DateTimeFormat patterns
+    // - those two date/time slots are rendering-only: the supplied value is
+    // formatted as such, with no time zone conversion at all
     procedure SetGlobal;
+    /// translate all resourcestring of this executable using the current
+    // thread language
+    // - on FPC, the resourcestring values are stored in a per-unit writable
+    // table, which this method rewrites via the objpas.SetResourceStrings()
+    // official API, using the original English text as translation key
+    // - the previous values are restored first, so switching the language at
+    // runtime is safe - and calling it with no language set would just reset
+    // the executable to its original English text
+    // - warning: the effect is process-wide and this method is NOT thread-safe
+    // - only the language to apply is read from the calling thread: the tables
+    // it rewrites are global to the process, and are patched with no lock at
+    // all, so any concurrent thread reading a resourcestring could race - call
+    // it at startup, or when no other thread is using those texts
+    // - the translations are stored with an explicit CP_UTF8 header, so are
+    // consumed losslessly by Format() or any string concatenation, as long as
+    // mormot.core.os did set DefaultSystemCodePage := CP_UTF8 on FPC
+    // - do nothing on Delphi, which stores its resourcestring within the
+    // executable resources, with no such writable runtime table: use the
+    // Mustache {{"text}} channel or the caption hook instead
+    procedure TranslateResourceStrings;
   end;
 
 /// the main TSynLanguages instance, as set by TSynLanguages.SetGlobal
@@ -156,6 +260,81 @@ implementation
 
 
 { ************* TSynLanguage per-language Translation Table }
+
+function LoadUtf8File(const FileName: TFileName): RawUtf8;
+begin
+  result := RawUtf8(StringFromFile(FileName));
+  if (length(result) >= 3) and
+     (PCardinal(result)^ and $00ffffff = BOM_UTF8) then
+    delete(result, 1, 3); // ignore any UTF-8 BOM
+end;
+
+const
+  /// the file extensions recognized by TSynLanguage.AddFromFile()
+  LANGUAGE_EXT: array[0 .. 8] of TFileName = (
+    'po',                                 // 0     = GNU gettext
+    'ini', 'msg',                         // 1, 2  = INI-like
+    'yaml', 'yml',                        // 3, 4  = YAML
+    'json', 'jsonc', 'json5', 'hjson');   // 5..8  = JSON and relaxed variants
+
+/// recognize the translation file format from its extension, -1 if unsupported
+function LanguageFileFormat(const FileName: TFileName): PtrInt;
+begin
+  result := SameExt(FileName, LANGUAGE_EXT, {withoutdot=}true);
+end;
+
+type
+  /// which .po text slot is currently filled by TSynLanguage.AddFromPo()
+  TPoSlot = (
+    poNone,
+    poId,
+    poStr);
+
+/// decode one .po "quoted text" and append its content to Text
+// - P is expected to point to the initial '"' - any other input is ignored
+// - reuse the JSON_UNESCAPE[] lookup table for the \n \t \r \b \f \\ \" C-like
+// escapes, since JSON and .po do share the very same syntax for those - and
+// any other escape (e.g. \u which is JSON-specific, or \x) is left as its
+// escaped character, as expected by the .po format
+procedure PoUnescapeAppend(P: PUtf8Char; var Text: RawUtf8);
+var
+  c: AnsiChar;
+  n: PtrInt;
+  d: PUtf8Char;
+  tmp: TSynTempBuffer;
+begin
+  if (P = nil) or
+     (P^ <> '"') then
+    exit; // no quoted text on this line
+  inc(P);
+  n := GetLineSize(P, nil); // unescaping can only shrink: this is the maximum
+  if n = 0 then
+    exit;
+  d := tmp.Init(n);
+  repeat
+    c := P^;
+    if (c = '"') or  // normal ending of this quoted text
+       (c = #0) or
+       (c = #10) or
+       (c = #13) then // tolerate any unterminated line
+      break;
+    if c = '\' then
+    begin
+      inc(P);
+      c := P^;
+      if c = #0 then
+        break; // pending backslash at the very end of the input
+      if JSON_UNESCAPE[c] > JSON_UNESCAPE_UTF16 then
+        c := JSON_UNESCAPE[c]; // #0 = non-ASCII and #1 = \u keep c as it is
+    end;
+    d^ := c;
+    inc(d);
+    inc(P);
+  until false;
+  Append(Text, tmp.buf, d - PUtf8Char(tmp.buf));
+  tmp.Done;
+end;
+
 
 { TSynLanguage }
 
@@ -176,34 +355,228 @@ begin
   inherited Destroy;
 end;
 
-function TSynLanguage.AddFromJson(const Json: RawUtf8): integer;
+function TSynLanguage.AddFromVariant(const Doc: TDocVariantData): integer;
 var
-  doc: TDocVariantData;
   i: PtrInt;
   v: RawUtf8;
 begin
   result := -1;
-  if not doc.InitJson(Json, JSON_FAST) or
-     not doc.IsObject then
+  if not Doc.IsObject then
     exit;
   result := 0;
-  for i := 0 to doc.Count - 1 do
+  for i := 0 to Doc.Count - 1 do
   begin
-    VariantToUtf8(doc.Values[i], v);
-    fTexts.AddOrUpdate(doc.Names[i], v);
+    VariantToUtf8(Doc.Values[i], v);
+    fTexts.AddOrUpdate(Doc.Names[i], v);
     inc(result);
   end;
 end;
 
-function TSynLanguage.AddFromJsonFile(const FileName: TFileName): integer;
+function TSynLanguage.AddFromJson(const Json: RawUtf8): integer;
 var
-  json: RawUtf8;
+  doc: TDocVariantData;
+  normalized: RawUtf8;
 begin
-  json := RawUtf8(StringFromFile(FileName));
-  if (length(json) >= 3) and
-     (PCardinal(json)^ and $00ffffff = $00bfbbef) then
-    delete(json, 1, 3); // ignore any UTF-8 BOM
-  result := AddFromJson(json);
+  result := -1;
+  if Json = '' then
+    exit;
+  if doc.InitJson(Json, JSON_FAST) then
+    result := AddFromVariant(doc)
+  else
+  begin
+    doc.Clear; // release any partially parsed content before trying again
+    // JsonBufferReformat() recognizes the JSON5/JSONC/HJson relaxed variants,
+    // as JsonSettingsToObject() does for our settings classes
+    if JsonBufferReformat(pointer(Json), normalized,
+         jsonUnquotedPropNameCompact) and
+       doc.InitJson(normalized, JSON_FAST) then
+      result := AddFromVariant(doc);
+  end;
+end;
+
+function TSynLanguage.AddFromJsonFile(const FileName: TFileName): integer;
+begin
+  result := AddFromJson(LoadUtf8File(FileName));
+end;
+
+function TSynLanguage.AddFromYaml(const Yaml: RawUtf8): integer;
+var
+  doc: TDocVariantData;
+begin
+  if TryYamlToVariant(Yaml, doc, JSON_FAST) then
+    result := AddFromVariant(doc)
+  else
+    result := -1;
+end;
+
+function TSynLanguage.AddFromPo(const Po: RawUtf8): integer;
+var
+  P, L: PUtf8Char;
+  id, str: RawUtf8;
+  slot: TPoSlot;
+  skip: boolean;
+
+  procedure Flush; // store any pending entry, then reset the parsing state
+  begin
+    if not skip and
+       (id <> '') and    // ignore the void msgid header entry
+       (str <> '') then  // ignore any untranslated entry
+    begin
+      fTexts.AddOrUpdate(id, str);
+      inc(result);
+    end;
+    FastAssignNew(id);
+    FastAssignNew(str);
+    slot := poNone;
+    skip := false;
+  end;
+
+begin
+  result := 0;
+  slot := poNone;
+  skip := false;
+  P := pointer(Po);
+  if P = nil then
+    exit;
+  repeat
+    L := GotoNextNotSpaceSameLine(P); // tolerate any indentation
+    case L^ of
+      '#': // a comment always introduces the next entry
+        begin
+          if (id <> '') or
+             (str <> '') then
+            Flush;
+          if (L[1] = ',') and
+             GetLineContains(L + 2, nil, 'FUZZY') then
+            skip := true; // fuzzy = pending human review, so unusable as such
+        end;
+      '"': // continuation of the current multi-line msgid/msgstr text
+        case slot of
+          poId:
+            PoUnescapeAppend(L, id);
+          poStr:
+            PoUnescapeAppend(L, str);
+        end;
+      'm',
+      'M':
+        case IdemPCharSep(L, 'MSGID_PLURAL|MSGSTR[|MSGCTXT|MSGID|MSGSTR|') of
+          0,   // msgid_plural "..."
+          1:   // msgstr[0] "..."
+            begin
+              skip := true; // plural forms are not supported yet
+              slot := poNone;
+            end;
+          2:   // msgctxt "..." introduces the next entry
+            begin
+              if (id <> '') or
+                 (str <> '') then
+                Flush;
+              skip := true; // context disambiguation is not supported yet
+              slot := poNone;
+            end;
+          3:   // msgid "..."
+            begin
+              if (id <> '') or
+                 (str <> '') then
+                Flush; // previous entry is done: store it before starting anew
+              slot := poId;
+              PoUnescapeAppend(GotoNextNotSpaceSameLine(L + 5), id);
+            end;
+          4:   // msgstr "..."
+            begin
+              slot := poStr;
+              PoUnescapeAppend(GotoNextNotSpaceSameLine(L + 6), str);
+            end;
+        end;
+    end;
+    P := GotoNextLine(P);
+  until P = nil;
+  Flush; // store the last pending entry
+end;
+
+function TSynLanguage.AddFromPoFile(const FileName: TFileName): integer;
+begin
+  result := AddFromPo(LoadUtf8File(FileName));
+end;
+
+function TSynLanguage.AddFromIni(const Ini, Section: RawUtf8): integer;
+var
+  P, L, V, E: PUtf8Char;
+  key, value: RawUtf8;
+  up: TByteToAnsiChar;
+begin
+  result := 0;
+  P := pointer(Ini);
+  if P = nil then
+    exit;
+  if Section <> '' then
+  begin
+    PWord(UpperCopy255(@up, Section))^ := ord(']'); // e.g. 'FR]'#0
+    if not FindSectionFirstLine(P, @up) then
+      exit; // no such [Section] in this content
+  end;
+  repeat
+    L := GotoNextNotSpaceSameLine(P); // tolerate any indentation
+    if L^ = '[' then
+    begin
+      if Section <> '' then
+        break; // end of the requested [Section]
+      // no Section: just ignore this header line and continue
+    end
+    else if not (L^ in [#0, #10, #13, ';', '#']) then
+    begin
+      // this line is not void nor a comment: search for its 'key=value' pair
+      V := L;
+      while not (V^ in [#0, #10, #13, '=']) do
+        inc(V);
+      if V^ = '=' then
+      begin
+        E := V; // trim any blank before '='
+        while (E > L) and
+              (E[-1] in [#9, ' ']) do
+          dec(E);
+        FastSetString(key, L, E - L);
+        V := GotoNextNotSpaceSameLine(V + 1); // trim any blank after '='
+        E := V;
+        while not (E^ in [#0, #10, #13]) do // stop before any trailing CRLF
+          inc(E);
+        while (E > V) and
+              (E[-1] in [#9, ' ']) do
+          dec(E); // trim any blank at the end of this line
+        FastSetString(value, V, E - V);
+        if (key <> '') and
+           (value <> '') then
+        begin
+          fTexts.AddOrUpdate(key, value);
+          inc(result);
+        end;
+      end;
+    end;
+    P := GotoNextLine(P);
+  until P = nil;
+end;
+
+function TSynLanguage.AddFromIniFile(const FileName: TFileName;
+  const Section: RawUtf8): integer;
+begin
+  result := AddFromIni(LoadUtf8File(FileName), Section);
+end;
+
+function TSynLanguage.AddFromFile(const FileName: TFileName): integer;
+begin
+  result := -1;
+  if not FileExists(FileName) then
+    exit;
+  case LanguageFileFormat(FileName) of
+    0:      // .po
+      result := AddFromPoFile(FileName);
+    1, 2:   // .ini .msg
+      result := AddFromIniFile(FileName);
+    3, 4:   // .yaml .yml
+      result := AddFromYaml(LoadUtf8File(FileName));
+    5 .. 8: // .json .jsonc .json5 .hjson
+      result := AddFromJson(LoadUtf8File(FileName));
+  end;
 end;
 
 function TSynLanguage.Translate(var Text: RawUtf8): boolean;
@@ -263,6 +636,26 @@ begin
     _MainI18n.TranslateString(Text);
 end;
 
+// both hooks below are rendering-only slots: the supplied value is already the
+// wall clock the caller wants to be displayed - e.g. TTimeLogBits.i18nText
+// gives its own TTimeLog bits, just as its unhooked fallback would render them
+// - so no time zone math is done here, and the mormot.core.os UtcToLocal /
+// LocalToUtc functions are deliberately not called: converting an UTC value
+// into local time is the caller responsibility, not this unit business
+
+var
+  // the TFormatSettings used by the two hooks below, filled at initialization
+  // - the RTL FormatDateTime() does not render '/' and ':' as such: it rewrites
+  // them into the DateSeparator / TimeSeparator fields of the supplied settings,
+  // which default to process-wide locale globals - e.g. a POSIX/C locale gives
+  // DateSeparator = '-', so 'yyyy/mm/dd' would render as '2026-07-31'
+  // - we do promise a per-language date layout, so the pattern can't be silently
+  // rewritten by whatever locale the process happens to run with: mapping both
+  // separators to themselves makes '/' and ':' literal, as '-' or '.' already are
+  // - all other fields (month/day names, AM/PM, TwoDigitYearCenturyWindow...) are
+  // copied from the RTL defaults, so e.g. 'mmm' or 'ampm' still behave as usual
+  _I18nFormat: TFormatSettings;
+
 function _I18nDateTimeText(const DateTime: TDateTime): string;
 var
   lang: TSynLanguage;
@@ -272,7 +665,7 @@ begin
     lang := _MainI18n.Current;
   if (lang <> nil) and
      (lang.DateTimeFormat <> '') then
-    result := FormatDateTime(lang.DateTimeFormat, DateTime)
+    result := FormatDateTime(lang.DateTimeFormat, DateTime, _I18nFormat)
   else
     result := DateTimeToStr(DateTime);
 end;
@@ -288,10 +681,36 @@ begin
     lang := _MainI18n.Current;
   if (lang <> nil) and
      (lang.DateFormat <> '') then
-    result := FormatDateTime(lang.DateFormat, dt)
+    result := FormatDateTime(lang.DateFormat, dt, _I18nFormat)
   else
     result := DateToStr(dt);
 end;
+
+{$ifdef FPC}
+
+// objpas.TResourceIterator callback, with arg = the TSynLanguage table to apply
+// - arg may be nil, i.e. no language: every entry keeps its DefaultValue
+// - note that objpas is part of the units implicitly available in objfpc/delphi
+// modes, so needs no explicit uses clause entry
+function _TranslateResourceString(Name, Value: AnsiString; Hash: LongInt;
+  arg: pointer): AnsiString;
+var
+  u: RawUtf8;
+begin
+  result := ''; // a void result keeps the current value untouched
+  if arg = nil then
+    exit; // no language: keep the English text restored by ResetResourceTables
+  // Value is the original English DefaultValue, as supplied by the RTL: get our
+  // RawUtf8 key via the framework unknown code page AnsiString conversion
+  AnyAnsiToUtf8Var(Value, u);
+  if not TSynLanguage(arg).Translate(u) then
+    exit; // unknown text: fallback to the English text
+  // return those UTF-8 bytes as such, with an explicit CP_UTF8 header: the RTL
+  // just stores this AnsiString into the table CurrentValue field, as-is
+  FastSetStringCP(result, pointer(u), length(u), CP_UTF8);
+end;
+
+{$endif FPC}
 
 { TSynLanguages }
 
@@ -341,24 +760,43 @@ function TSynLanguages.LoadFromFolder(const Folder: TFileName): integer;
 var
   sr: TSearchRec;
   lng: TLanguage;
-  fn: TFileName;
+  dir, fn: TFileName;
 begin
   result := 0;
-  if FindFirst(IncludeTrailingPathDelimiter(Folder) + '*.json',
-       faAnyFile, sr) = 0 then
+  dir := IncludeTrailingPathDelimiter(Folder);
+  if FindFirst(dir + FILES_ALL, faAnyFile, sr) = 0 then
   begin
     repeat
-      fn := GetFileNameWithoutExt(sr.Name);
-      lng := IsoTextToLanguage(StringToUtf8(fn));
-      if lng <> lngUndefined then
+      if SearchRecValidFile(sr) and
+         (LanguageFileFormat(sr.Name) >= 0) then // e.g. ignore any .txt file
       begin
-        Language[lng].AddFromJsonFile(
-          IncludeTrailingPathDelimiter(Folder) + sr.Name);
-        inc(result);
+        fn := GetFileNameWithoutExt(sr.Name);
+        lng := IsoTextToLanguage(StringToUtf8(fn));
+        if lng <> lngUndefined then
+        begin
+          Language[lng].AddFromFile(dir + sr.Name);
+          inc(result);
+        end;
       end;
     until FindNext(sr) <> 0;
     FindClose(sr);
   end;
+end;
+
+function TSynLanguages.LoadedLanguages: TLanguageDynArray;
+var
+  l: TLanguage;
+  n: PtrInt;
+begin
+  SetLength(result, length(fLang)); // single allocation, then truncate below
+  n := 0;
+  for l := low(fLang) to high(fLang) do
+    if fLang[l] <> nil then
+    begin
+      result[n] := l;
+      inc(n);
+    end;
+  SetLength(result, n);
 end;
 
 class procedure TSynLanguages.SetThreadLanguage(aLanguage: TLanguage);
@@ -422,5 +860,30 @@ begin
   i18nDateTimeText := _I18nDateTimeText;
 end;
 
+procedure TSynLanguages.TranslateResourceStrings;
+begin
+  {$ifdef FPC}
+  // restore the English DefaultValue of every entry first: any text which the
+  // new language does not translate would otherwise keep its previous value
+  ResetResourceTables;
+  // SetResourceStrings() is called even with no language (i.e. a nil arg, which
+  // the callback maps to "keep the English text"), because it is the only RTL
+  // entry point ending with UpdateResourceStringRefs: ResetResourceTables alone
+  // would leave any "var s: string = SomeResourceString" global out of sync
+  SetResourceStrings(@_TranslateResourceString, Current); // thread language
+  {$endif FPC}
+end;
+
+
+initialization
+  // start from the RTL locale settings, to keep its month/day names and AM/PM
+  {$ifdef FPC}
+  _I18nFormat := DefaultFormatSettings; // FPC RTL global
+  {$else}
+  _I18nFormat := SysUtils.FormatSettings; // Delphi RTL global
+  {$endif FPC}
+  // then make the '/' and ':' pattern characters render as themselves
+  _I18nFormat.DateSeparator := '/';
+  _I18nFormat.TimeSeparator := ':';
 
 end.

--- a/src/core/mormot.core.i18n.pas
+++ b/src/core/mormot.core.i18n.pas
@@ -12,8 +12,9 @@ unit mormot.core.i18n;
     - global wiring of the framework translation hooks
 
    Translation tables map the original English text to its translation, and
-   are loaded from .po (GNU gettext) as the main format - .ini, .yaml and
-   .json, with its relaxed JSON5 / JSONC / HJson variants, are also supported.
+   are loaded from .po and its compiled .mo binary (GNU gettext) as the main
+   formats - .ini, .yaml and .json, with its relaxed JSON5 / JSONC / HJson
+   variants, are also supported.
 
    Once loaded, three wiring channels are available: the TSynMustache
    translate tag views channel, the LoadResStringTranslate slot consumed by
@@ -105,6 +106,27 @@ type
     function AddFromPo(const Po: RawUtf8): integer;
     /// merge translations from an UTF-8 GNU gettext .po file (BOM tolerated)
     function AddFromPoFile(const FileName: TFileName): integer;
+    /// merge translations from GNU gettext .mo binary content
+    // - .mo is the binary format compiled from a .po source by msgfmt: both
+    // hold the very same msgid/msgstr pairs, so this method is just the
+    // binary counterpart of AddFromPo()
+    // - .mo files generated on a reverse endianness machine are supported
+    // - the void msgid header entry and untranslated (void msgstr) entries
+    // are just ignored, as AddFromPo() does - and msgfmt does not include
+    // any fuzzy entry in its .mo output, unless --use-fuzzy is specified
+    // - non-goals, as for AddFromPo(): msgctxt disambiguation, and the
+    // msgid_plural / msgstr[] plural forms - such entries are just ignored
+    // - the strings are expected to be UTF-8 encoded, as declared by the
+    // header of any modern .mo file, and as AddFromPo() does for its source
+    // - the whole input is validated before any merge, so that an invalid
+    // .mo content is rejected as a whole, and never merges anything
+    // - returns the number of added or replaced translations, or -1 if the
+    // supplied content is no valid .mo binary
+    function AddFromMo(const Mo: RawByteString): integer;
+    /// merge translations from a GNU gettext .mo binary file
+    // - returns the number of added or replaced translations, or -1 if this
+    // file does not exist or is no valid .mo binary
+    function AddFromMoFile(const FileName: TFileName): integer;
     /// merge translations from INI-like content, e.g. as
     // ! Hello=Bonjour
     // ! World=Monde
@@ -122,8 +144,8 @@ type
     function AddFromIniFile(const FileName: TFileName;
       const Section: RawUtf8 = ''): integer;
     /// merge translations from a file, recognized by its extension
-    // - .po (gettext), .ini or .msg, .yaml or .yml, .json / .jsonc / .json5
-    // / .hjson (the relaxed JSON variants are read by our JSON parser)
+    // - .po or .mo (gettext), .ini or .msg, .yaml or .yml, .json / .jsonc /
+    // .json5 / .hjson (the relaxed JSON variants are read by our JSON parser)
     // - returns -1 if the file does not exist or its extension is unknown
     function AddFromFile(const FileName: TFileName): integer;
     /// translate the supplied text in-place
@@ -193,6 +215,11 @@ type
     /// load all <iso>.<ext> files from a folder, e.g. en.json or zh.po
     // - the file name (without its extension) is the ISO 639-1 language text,
     // and any extension supported by TSynLanguage.AddFromFile is recognized
+    // - several files of the same language are merged into its single table,
+    // in a deterministic order - by name, then by ascending format index as
+    // defined by the LANGUAGE_EXT[] order - so that if they do define the
+    // same key, the winner does not depend on the OS enumeration order: in
+    // particular, a compiled fr.mo wins over the fr.po source it came from
     // - returns the number of recognized language files
     function LoadFromFolder(const Folder: TFileName): integer;
     /// return the languages currently loaded in this registry
@@ -271,11 +298,15 @@ end;
 
 const
   /// the file extensions recognized by TSynLanguage.AddFromFile()
-  LANGUAGE_EXT: array[0 .. 8] of TFileName = (
-    'po',                                 // 0     = GNU gettext
+  // - this order is also the TSynLanguages.LoadFromFolder() loading order,
+  // i.e. the priority of each format: the last one does win, so that a
+  // compiled .mo takes precedence over the .po source it was generated from
+  LANGUAGE_EXT: array[0 .. 9] of TFileName = (
+    'po',                                 // 0     = GNU gettext source
     'ini', 'msg',                         // 1, 2  = INI-like
     'yaml', 'yml',                        // 3, 4  = YAML
-    'json', 'jsonc', 'json5', 'hjson');   // 5..8  = JSON and relaxed variants
+    'json', 'jsonc', 'json5', 'hjson',    // 5..8  = JSON and relaxed variants
+    'mo');                                // 9     = GNU gettext binary
 
 /// recognize the translation file format from its extension, -1 if unsupported
 function LanguageFileFormat(const FileName: TFileName): PtrInt;
@@ -334,6 +365,33 @@ begin
   Append(Text, tmp.buf, d - PUtf8Char(tmp.buf));
   tmp.Done;
 end;
+
+const
+  /// the magic number stored at the beginning of any GNU gettext .mo file
+  // - is stored in the endianness of the machine which did generate the file
+  MO_MAGIC = $950412de;
+
+type
+  /// map the fixed-size header of a GNU gettext .mo binary file
+  TMoHeader = packed record
+    Magic: cardinal;
+    Revision: cardinal;  // major shl 16 + minor
+    Count: cardinal;     // number of strings
+    OrigTab: cardinal;   // offset of the original strings table
+    TransTab: cardinal;  // offset of the translated strings table
+    HashSize: cardinal;  // the hash table is unused by TSynLanguage.AddFromMo
+    HashTab: cardinal;
+  end;
+  PMoHeader = ^TMoHeader;
+
+  /// map one (length, offset) pair of a GNU gettext .mo string table
+  // - the string itself is #0 terminated, and Len does not include it
+  TMoEntry = packed record
+    Len: cardinal;
+    Offset: cardinal;
+  end;
+  TMoEntryArray = array[0 .. (MaxInt div SizeOf(TMoEntry)) - 1] of TMoEntry;
+  PMoEntryArray = ^TMoEntryArray;
 
 
 { TSynLanguage }
@@ -499,6 +557,90 @@ begin
   result := AddFromPo(LoadUtf8File(FileName));
 end;
 
+function TSynLanguage.AddFromMo(const Mo: RawByteString): integer;
+var
+  h: PMoHeader;
+  o, t: PMoEntryArray;
+  len, n, ot, tt, rev, tab: PtrUInt;
+  i, cnt: PtrInt;
+  swap: boolean;
+  id, str: RawUtf8;
+
+  function Get(const e: TMoEntry; Text: PRawUtf8): boolean;
+  var
+    l, ofs: PtrUInt;
+  begin
+    l := e.Len;
+    ofs := e.Offset;
+    if swap then
+    begin
+      l := bswap32(l);
+      ofs := bswap32(ofs);
+    end;
+    result := (l < len) and      // the #0 terminator is part of the content
+              (ofs < len - l);   // unsigned arithmetic: no overflow possible
+    if result and
+       (Text <> nil) then
+      FastSetString(Text^, @PByteArray(Mo)[ofs], PtrInt(l));
+  end;
+
+begin
+  result := -1;
+  len := PtrUInt(length(Mo));
+  if len < SizeOf(TMoHeader) then
+    exit; // clearly not a .mo binary file
+  h := pointer(Mo);
+  swap := h^.Magic <> MO_MAGIC;
+  if swap and
+     (h^.Magic <> bswap32(MO_MAGIC)) then
+    exit; // invalid magic number
+  n := h^.Count;
+  ot := h^.OrigTab;
+  tt := h^.TransTab;
+  rev := h^.Revision;
+  if swap then // this .mo was generated on a reverse endianness machine
+  begin
+    n := bswap32(n);
+    ot := bswap32(ot);
+    tt := bswap32(tt);
+    rev := bswap32(rev);
+  end;
+  if rev shr 16 > 1 then
+    exit; // unsupported major .mo format revision
+  if n > len div SizeOf(TMoEntry) then
+    exit; // more entries than this content could ever store
+  tab := n * SizeOf(TMoEntry); // size of each strings table, in bytes
+  if (ot > len - tab) or
+     (tt > len - tab) then
+    exit; // any strings table is out of range
+  o := @PByteArray(Mo)[ot];
+  t := @PByteArray(Mo)[tt];
+  cnt := n; // n was cropped above, so it does fit in a PtrInt
+  for i := 0 to cnt - 1 do // validate first: an invalid .mo merges nothing
+    if not Get(o^[i], nil) or
+       not Get(t^[i], nil) then
+      exit;
+  result := 0;
+  for i := 0 to cnt - 1 do
+  begin
+    Get(o^[i], @id);
+    if (id = '') or                  // ignore the void msgid header entry
+       (PosExChar(#0, id) <> 0) or   // msgid + #0 + msgid_plural
+       (PosExChar(#4, id) <> 0) then // msgctxt + #4 + msgid
+      continue;
+    Get(t^[i], @str);
+    if str = '' then // ignore any untranslated entry
+      continue;
+    fTexts.AddOrUpdate(id, str);
+    inc(result);
+  end;
+end;
+
+function TSynLanguage.AddFromMoFile(const FileName: TFileName): integer;
+begin
+  result := AddFromMo(StringFromFile(FileName)); // binary: no LoadUtf8File()
+end;
+
 function TSynLanguage.AddFromIni(const Ini, Section: RawUtf8): integer;
 var
   P, L, V, E: PUtf8Char;
@@ -576,6 +718,8 @@ begin
       result := AddFromYaml(LoadUtf8File(FileName));
     5 .. 8: // .json .jsonc .json5 .hjson
       result := AddFromJson(LoadUtf8File(FileName));
+    9:      // .mo
+      result := AddFromMoFile(FileName);
   end;
 end;
 
@@ -760,27 +904,41 @@ function TSynLanguages.LoadFromFolder(const Folder: TFileName): integer;
 var
   sr: TSearchRec;
   lng: TLanguage;
-  dir, fn: TFileName;
+  dir: TFileName;
+  files: TFileNameDynArray;
+  da: TDynArray;
+  f, i, n: PtrInt;
 begin
   result := 0;
   dir := IncludeTrailingPathDelimiter(Folder);
+  // first retrieve all the translation file names available in this folder
+  n := 0;
+  da.Init(TypeInfo(TFileNameDynArray), files, @n);
   if FindFirst(dir + FILES_ALL, faAnyFile, sr) = 0 then
   begin
     repeat
       if SearchRecValidFile(sr) and
          (LanguageFileFormat(sr.Name) >= 0) then // e.g. ignore any .txt file
-      begin
-        fn := GetFileNameWithoutExt(sr.Name);
-        lng := IsoTextToLanguage(StringToUtf8(fn));
-        if lng <> lngUndefined then
-        begin
-          Language[lng].AddFromFile(dir + sr.Name);
-          inc(result);
-        end;
-      end;
+        da.Add(sr.Name);
     until FindNext(sr) <> 0;
     FindClose(sr);
   end;
+  if n = 0 then
+    exit;
+  // merge them by name, then by ascending LANGUAGE_EXT[] format index, so
+  // that the result does not depend on the OS folder enumeration order
+  da.Sort(SortDynArrayFileName);
+  for f := 0 to high(LANGUAGE_EXT) do
+    for i := 0 to n - 1 do
+      if LanguageFileFormat(files[i]) = f then
+      begin
+        lng := IsoTextToLanguage(StringToUtf8(GetFileNameWithoutExt(files[i])));
+        if lng <> lngUndefined then
+        begin
+          Language[lng].AddFromFile(dir + files[i]);
+          inc(result);
+        end;
+      end;
 end;
 
 function TSynLanguages.LoadedLanguages: TLanguageDynArray;

--- a/test/mormot2tests.dpr
+++ b/test/mormot2tests.dpr
@@ -148,6 +148,7 @@ begin
   AddCase([
     TTestCoreBase,
     TTestCoreProcess,
+    TTestCoreI18n,
     {$ifdef HASGENERICS} // do-nothing on oldest compilers (e.g. <= Delphi XE7)
     TTestCoreCollections,
     {$endif HASGENERICS}

--- a/test/test.core.data.pas
+++ b/test/test.core.data.pas
@@ -225,6 +225,12 @@ type
     procedure LanguagesRegistry;
     /// global hooks: captions and date/time rendering
     procedure GlobalHooks;
+    /// GNU gettext .po parsing into a TSynLanguage table
+    procedure PoFormat;
+    /// INI and YAML parsing, and the per-extension file loaders
+    procedure IniAndFiles;
+    /// the FPC resourcestring table rewriting channel
+    procedure ResourceStrings;
   end;
 
   /// this test case will test most functions, classes and types defined and
@@ -10026,15 +10032,22 @@ var
   langs: TSynLanguages;
   m: TSynMustache;
   u: RawUtf8;
+  loaded: TLanguageDynArray;
 begin
   langs := TSynLanguages.Create;
   try
+    CheckEqual(length(langs.LoadedLanguages), 0, 'void registry');
     CheckEqual(langs.Language[lngFrench].AddFromJson('{"Hello":"Bonjour"}'), 1);
     CheckEqual(langs.Language[lngChinese].AddFromJson('{"Hello":"NiHao"}'), 1);
     Check(langs.Find(lngFrench) <> nil);
     Check(langs.Find(lngGerman) = nil);
     Check(langs.FindIso('fr') = langs.Find(lngFrench));
     Check(langs.FindIso('xx') = nil);
+    // LoadedLanguages returns the loaded tables, in TLanguage enumerate order
+    loaded := langs.LoadedLanguages;
+    CheckEqual(length(loaded), 2, 'LoadedLanguages count');
+    Check(loaded[0] = lngChinese, 'lngChinese comes first in TLanguage');
+    Check(loaded[1] = lngFrench);
     // no thread language nor default: passthrough
     Check(TSynLanguages.ThreadLanguage = lngUndefined);
     Check(langs.Current = nil);
@@ -10097,6 +10110,411 @@ begin
   Check(I18n = nil, 'unhooked');
   Check(not Assigned(LoadResStringTranslate));
   Check(not Assigned(i18nDateTimeText));
+end;
+
+const
+  // a realistic GNU gettext .po sample, mixing CRLF and LF line endings
+  _PO: RawUtf8 =
+    '# French translation of the demo'#13#10 +
+    '# Copyright (C) 2026'#13#10 +
+    'msgid ""'#13#10 +
+    'msgstr "Project-Id-Version: demo\n"'#13#10 +
+    '"Content-Type: text/plain; charset=UTF-8\n"'#13#10 +
+    '"Plural-Forms: nplurals=2; plural=(n > 1);\n"'#13#10 +
+    #13#10 +
+    '#: src/main.c:42'#13#10 +
+    'msgid "Hello"'#13#10 +
+    'msgstr "Bonjour"'#13#10 +
+    #13#10 +
+    '#. a multi-line entry, using .po continuation lines'#10 +
+    'msgid "Hello "'#10 +
+    '"World"'#10 +
+    'msgstr "Bonjour "'#10 +
+    '"Monde"'#10 +
+    #10 +
+    '#: src/main.c:50'#10 +
+    '#, fuzzy, c-format'#10 +
+    'msgid "Fuzzy"'#10 +
+    'msgstr "Flou"'#10 +
+    #10 +
+    'msgid "Untranslated"'#10 +
+    'msgstr ""'#10 +
+    #10 +
+    'msgctxt "menu"'#10 +
+    'msgid "Open"'#10 +
+    'msgstr "Ouvrir"'#10 +
+    #10 +
+    'msgid "One file"'#10 +
+    'msgid_plural "%d files"'#10 +
+    'msgstr[0] "Un fichier"'#10 +
+    'msgstr[1] "%d fichiers"'#10 +
+    #10 +
+    'msgid "a\nb\tc \"d\" e\\f"'#10 +
+    'msgstr "A\nB\tC \"D\" E\\F"'#10 +
+    #10 +
+    'msgid "unknown \q and \u escapes"'#10 +
+    'msgstr "inconnu \q et \u"'#10 +
+    #10 +
+    '  msgid "Indented"'#10 +
+    '  msgstr "Indente"'#10;
+
+procedure TTestCoreI18n.PoFormat;
+var
+  l: TSynLanguage;
+  t, cha: RawUtf8;
+  fn: TFileName;
+  tmp: array[0 .. 15] of AnsiChar;
+begin
+  l := TSynLanguage.Create(lngFrench);
+  try
+    CheckEqual(l.AddFromPo(''), 0, 'void input');
+    CheckEqual(l.Count, 0);
+    CheckEqual(l.AddFromPo('# only'#10#10'#. comments'#10'#, fuzzy'#10#10), 0,
+      'comments and blank lines only');
+    CheckEqual(l.Count, 0);
+    // the whole reference sample: 5 entries out of 9 msgid blocks
+    CheckEqual(l.AddFromPo(_PO), 5, 'sample entries');
+    CheckEqual(l.Count, 5, 'no extra key stored');
+    // plain msgid/msgstr pair
+    t := 'Hello';
+    Check(l.Translate(t), 'plain pair');
+    CheckEqual(t, 'Bonjour');
+    // multi-line msgid/msgstr continuation
+    t := 'Hello World';
+    Check(l.Translate(t), 'continuation lines');
+    CheckEqual(t, 'Bonjour Monde');
+    // \n \t \" \\ escape decoding, on both msgid and msgstr
+    t := 'a'#10'b'#9'c "d" e\f';
+    Check(l.Translate(t), 'escapes');
+    CheckEqual(t, 'A'#10'B'#9'C "D" E\F');
+    // unknown escapes keep the escaped character itself
+    t := 'unknown q and u escapes';
+    Check(l.Translate(t), 'unknown escapes');
+    CheckEqual(t, 'inconnu q et u');
+    // leading blanks are tolerated
+    t := 'Indented';
+    Check(l.Translate(t), 'indented lines');
+    CheckEqual(t, 'Indente');
+    // fuzzy entries are pending human review: they should be ignored
+    t := 'Fuzzy';
+    Check(not l.Translate(t), 'fuzzy is skipped');
+    CheckEqual(t, 'Fuzzy');
+    // a void msgstr is an untranslated entry
+    t := 'Untranslated';
+    Check(not l.Translate(t), 'void msgstr is skipped');
+    CheckEqual(t, 'Untranslated');
+    // msgctxt disambiguation is not supported yet
+    t := 'Open';
+    Check(not l.Translate(t), 'msgctxt is skipped');
+    CheckEqual(t, 'Open');
+    // msgid_plural / msgstr[] plural forms are not supported yet
+    t := 'One file';
+    Check(not l.Translate(t), 'plural forms are skipped');
+    CheckEqual(t, 'One file');
+    // the void msgid header entry should never pollute the table
+    t := 'Project-Id-Version: demo'#10 +
+         'Content-Type: text/plain; charset=UTF-8'#10 +
+         'Plural-Forms: nplurals=2; plural=(n > 1);'#10;
+    Check(not l.Translate(t), 'header is skipped');
+    // a missing ending line feed should still store the last entry
+    CheckEqual(l.AddFromPo('msgid "EOF"'#10'msgstr "Fin"'), 1, 'no ending LF');
+    CheckEqual(l.Count, 6);
+    t := 'EOF';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Fin');
+    // an existing key is replaced, not duplicated
+    CheckEqual(l.AddFromPo('msgid "Hello"'#10'msgstr "Salut"'#10), 1, 'replace');
+    CheckEqual(l.Count, 6, 'replaced, not added');
+    t := 'Hello';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Salut');
+    // the parser should be transparent to any UTF-8 multi-byte content
+    FastSetString(cha, @tmp, Ucs4ToUtf8($8336, @tmp)); // U+8336 = tea ideogram
+    CheckEqual(length(cha), 3, 'utf-8 3 bytes');
+    CheckEqual(l.AddFromPo('msgid "Tea"'#10'msgstr "' + cha + '"'#10), 1);
+    t := 'Tea';
+    Check(l.Translate(t));
+    CheckEqual(t, cha, 'utf-8 passthrough');
+    // AddFromPoFile() should ignore any leading UTF-8 BOM
+    fn := WorkDir + 'test.po';
+    Check(FileFromString(BOM_UTF8_CHARS +
+      'msgid "File"'#10'msgstr "Fichier"'#10, fn), 'po file');
+    CheckEqual(l.AddFromPoFile(fn), 1, 'AddFromPoFile');
+    CheckEqual(l.Count, 8);
+    t := 'File';
+    Check(l.Translate(t), 'BOM skipped');
+    CheckEqual(t, 'Fichier');
+    Check(DeleteFile(fn));
+  finally
+    l.Free;
+  end;
+end;
+
+const
+  // an INI sample mixing CRLF and LF line endings, comments and sections
+  _INI: RawUtf8 =
+    '; a leading comment'#13#10 +
+    '# another comment'#10 +
+    #13#10 +                        // a blank line
+    '   '#10 +                      // a blank-only line
+    'Hello=Bonjour'#13#10 +         // plain pair, CRLF ended
+    '  World  =  Monde  '#10 +      // indentation and blanks around '='
+    'Void='#10 +                    // a void value is ignored
+    '=NoKey'#10 +                   // a void key is ignored
+    'NoEqualSignHere'#10 +          // a line without '=' is ignored
+    '[fr]'#13#10 +
+    'Hello=Salut'#10 +
+    '; in-section comment'#10 +
+    'Bye=Au revoir'#10 +
+    '[de]'#10 +
+    'Hello=Hallo'#10;
+
+procedure TTestCoreI18n.IniAndFiles;
+var
+  l: TSynLanguage;
+  langs: TSynLanguages;
+  t, cha: RawUtf8;
+  folder: TFileName;
+  tmp: array[0 .. 15] of AnsiChar;
+
+  function Fn(const Ext: TFileName): TFileName;
+  begin
+    result := WorkDir + 'i18ntest.' + Ext;
+  end;
+
+begin
+  FastSetString(cha, @tmp, Ucs4ToUtf8($8336, @tmp)); // U+8336 = tea ideogram
+  l := TSynLanguage.Create(lngFrench);
+  try
+    // INI basics: no section, so any [section] header is just ignored
+    CheckEqual(l.AddFromIni(''), 0, 'void input');
+    CheckEqual(l.Count, 0);
+    CheckEqual(l.AddFromIni('; only'#10'# comments'#10#13#10), 0, 'comments only');
+    CheckEqual(l.Count, 0);
+    CheckEqual(l.AddFromIni(_INI), 5, 'all sections merged');
+    CheckEqual(l.Count, 3, 'Hello + World + Bye');
+    t := 'World';
+    Check(l.Translate(t), 'blanks around = are trimmed');
+    CheckEqual(t, 'Monde');
+    t := 'Hello';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Hallo', 'last [de] value did overwrite the previous ones');
+    t := 'Bye';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Au revoir');
+    t := 'Void';
+    Check(not l.Translate(t), 'void value is skipped');
+    t := 'NoKey';
+    Check(not l.Translate(t), 'void key is skipped');
+    t := 'NoEqualSignHere';
+    Check(not l.Translate(t), 'line without = is skipped');
+  finally
+    l.Free;
+  end;
+  l := TSynLanguage.Create(lngFrench);
+  try
+    // INI with an explicit [section] filter
+    CheckEqual(l.AddFromIni(_INI, 'fr'), 2, '[fr] section only');
+    CheckEqual(l.Count, 2);
+    t := 'Hello';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Salut', '[fr] value, not the [de] one');
+    t := 'Bye';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Au revoir');
+    t := 'World';
+    Check(not l.Translate(t), 'content before any section is out of [fr]');
+    CheckEqual(l.AddFromIni(_INI, 'DE'), 1, 'section name is case-insensitive');
+    CheckEqual(l.Count, 2, 'Hello was replaced, not added');
+    t := 'Hello';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Hallo');
+    CheckEqual(l.AddFromIni(_INI, 'nosuchsection'), 0, 'unknown section');
+    CheckEqual(l.Count, 2);
+    // the INI parser should be transparent to any UTF-8 multi-byte content
+    CheckEqual(length(cha), 3, 'utf-8 3 bytes');
+    CheckEqual(l.AddFromIni('Tea = ' + cha + #13#10), 1, 'utf-8 value');
+    t := 'Tea';
+    Check(l.Translate(t));
+    CheckEqual(t, cha, 'utf-8 passthrough');
+    // YAML mapping
+    CheckEqual(l.AddFromYaml('Hello: Bonjour'#10'World: Monde'#10), 2, 'yaml');
+    t := 'Hello';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Bonjour', 'yaml did overwrite the INI value');
+    t := 'World';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Monde');
+    CheckEqual(l.AddFromYaml('- one'#10'- two'#10), -1, 'yaml array is no table');
+    // the relaxed JSON variants are supported by AddFromJson()
+    CheckEqual(l.AddFromJson('{ // a JSONC comment'#10' "Six": "Sixieme"'#10'}'),
+      1, 'jsonc');
+    t := 'Six';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Sixieme');
+    CheckEqual(l.AddFromJson('{ /* JSON5 */ Seven: "Septieme", }'), 1, 'json5');
+    t := 'Seven';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Septieme');
+    CheckEqual(l.AddFromJson('invalid'), -1, 'invalid JSON');
+    CheckEqual(l.AddFromJson(''), -1, 'void JSON');
+    CheckEqual(l.AddFromJson('["Hello"]'), -1, 'JSON array is no table');
+  finally
+    l.Free;
+  end;
+  l := TSynLanguage.Create(lngFrench);
+  try
+    // AddFromFile() dispatches on the file extension
+    CheckEqual(l.AddFromFile(WorkDir + 'i18nnotexisting.json'), -1, 'no file');
+    Check(FileFromString('this is no translation file', Fn('txt')));
+    CheckEqual(l.AddFromFile(Fn('txt')), -1, 'unknown extension');
+    Check(DeleteFile(Fn('txt')));
+    Check(FileFromString('msgid "One"'#10'msgstr "Un"'#10, Fn('po')));
+    CheckEqual(l.AddFromFile(Fn('po')), 1, '.po');
+    Check(DeleteFile(Fn('po')));
+    Check(FileFromString('[fr]'#13#10'Two=Deux'#13#10, Fn('ini')));
+    CheckEqual(l.AddFromFile(Fn('ini')), 1, '.ini');
+    Check(DeleteFile(Fn('ini')));
+    Check(FileFromString('Five=Cinq'#10, Fn('msg')));
+    CheckEqual(l.AddFromFile(Fn('msg')), 1, '.msg');
+    Check(DeleteFile(Fn('msg')));
+    Check(FileFromString(BOM_UTF8_CHARS + '{"Three":"Trois"}', Fn('json')));
+    CheckEqual(l.AddFromFile(Fn('json')), 1, '.json');
+    Check(DeleteFile(Fn('json')));
+    Check(FileFromString('Four: Quatre'#10, Fn('yaml')));
+    CheckEqual(l.AddFromFile(Fn('yaml')), 1, '.yaml');
+    Check(DeleteFile(Fn('yaml')));
+    CheckEqual(l.Count, 5, 'po + ini + msg + json + yaml');
+    t := 'One';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Un');
+    t := 'Two';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Deux');
+    t := 'Three';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Trois');
+    t := 'Four';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Quatre');
+    t := 'Five';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Cinq');
+  finally
+    l.Free;
+  end;
+  // TSynLanguages.LoadFromFolder() with several extensions
+  folder := EnsureDirectoryExists([WorkDir, 'i18n']);
+  Check(folder <> '', 'folder');
+  Check(FileFromString('msgid "Hello"'#10'msgstr "Bonjour"'#10, folder + 'fr.po'));
+  Check(FileFromString('Hello=' + cha + #10, folder + 'zh.ini'));
+  Check(FileFromString('ignored', folder + 'en.txt'), 'unknown extension');
+  Check(FileFromString('ignored', folder + 'nolang.json'), 'unknown iso');
+  langs := TSynLanguages.Create;
+  try
+    CheckEqual(langs.LoadFromFolder(folder), 2, 'fr.po + zh.ini');
+    Check(langs.Find(lngEnglish) = nil, '.txt is not a translation file');
+    Check(langs.Find(lngFrench) <> nil);
+    CheckEqual(langs.Find(lngFrench).Count, 1);
+    t := 'Hello';
+    TSynLanguages.SetThreadLanguage(lngFrench);
+    Check(langs.Translate(t), 'from fr.po');
+    CheckEqual(t, 'Bonjour');
+    Check(langs.Find(lngChinese) <> nil);
+    CheckEqual(langs.Find(lngChinese).Count, 1);
+    t := 'Hello';
+    TSynLanguages.SetThreadLanguage(lngChinese);
+    Check(langs.Translate(t), 'from zh.ini');
+    CheckEqual(t, cha);
+  finally
+    TSynLanguages.SetThreadLanguage(lngUndefined);
+    langs.Free;
+  end;
+  Check(DirectoryDelete(folder), 'cleanup');
+end;
+
+resourcestring
+  // the one and only resourcestring of this test executable we do translate
+  RS_I18N_TEST = 'i18n test string';
+
+{$ifdef FPC}
+var
+  // FPC does allow a global variable to be initialized from a resourcestring,
+  // and registers its reference into the RTL _FPC_ResStrInitTables so that
+  // SetResourceStrings() refreshes it - this is the FPC_HAS_RESSTRINITS
+  // feature, which has no Delphi equivalent since a Delphi resourcestring is
+  // no compile-time constant, so can't initialize a global variable
+  RS_I18N_VAR: string = RS_I18N_TEST;
+{$endif FPC}
+
+procedure TTestCoreI18n.ResourceStrings;
+var
+  langs: TSynLanguages;
+  cha, tr: RawUtf8;
+  tmp: array[0 .. 15] of AnsiChar;
+
+  function Rs: RawUtf8; // current RS_I18N_TEST value, as raw UTF-8 bytes
+  begin
+    {$ifdef FPC} // no conversion at all: check the exact stored bytes
+    FastSetString(result, pointer(RS_I18N_TEST), length(RS_I18N_TEST));
+    {$else}      // Delphi resourcestring are UnicodeString
+    StringToUtf8(RS_I18N_TEST, result);
+    {$endif FPC}
+  end;
+
+  {$ifdef FPC}
+  function RsVar: RawUtf8; // current RS_I18N_VAR value, as raw UTF-8 bytes
+  begin
+    FastSetString(result, pointer(RS_I18N_VAR), length(RS_I18N_VAR));
+  end;
+  {$endif FPC}
+
+begin
+  FastSetString(cha, @tmp, Ucs4ToUtf8($8336, @tmp)); // U+8336 = tea ideogram
+  tr := 'traduit ' + cha; // a translation with some non-ASCII UTF-8 content
+  CheckEqual(Rs, 'i18n test string', 'initial English text');
+  {$ifdef FPC}
+  CheckEqual(RsVar, 'i18n test string', 'initial variable text');
+  {$endif FPC}
+  langs := TSynLanguages.Create;
+  try
+    CheckEqual(langs.Language[lngFrench].AddFromJson(
+      '{"i18n test string":"' + tr + '"}'), 1);
+    TSynLanguages.SetThreadLanguage(lngFrench);
+    langs.TranslateResourceStrings;
+    {$ifdef FPC}
+    // FPC does maintain a writable per-unit resourcestring table
+    CheckEqual(Rs, tr, 'resourcestring translated');
+    // the FPC_HAS_RESSTRINITS references do follow the translation
+    CheckEqual(RsVar, tr, 'variable translated');
+    // a language with no table restores the original English text
+    TSynLanguages.SetThreadLanguage(lngGerman);
+    langs.TranslateResourceStrings;
+    CheckEqual(Rs, 'i18n test string', 'unknown language');
+    CheckEqual(RsVar, 'i18n test string', 'variable of unknown language');
+    // switching back and forth is safe, thanks to the ResetResourceTables call
+    TSynLanguages.SetThreadLanguage(lngFrench);
+    langs.TranslateResourceStrings;
+    CheckEqual(Rs, tr, 'translated again');
+    CheckEqual(RsVar, tr, 'variable translated again');
+    TSynLanguages.SetThreadLanguage(lngUndefined);
+    langs.TranslateResourceStrings;
+    CheckEqual(Rs, 'i18n test string', 'ResetResourceTables');
+    // no language should also revert the references, not just the table
+    CheckEqual(RsVar, 'i18n test string', 'variable of no language');
+    {$else}
+    // Delphi has no such writable table: the method is a no-op, but callable
+    CheckEqual(Rs, 'i18n test string', 'no-op on Delphi');
+    {$endif FPC}
+  finally
+    TSynLanguages.SetThreadLanguage(lngUndefined);
+    langs.TranslateResourceStrings; // no pollution of the following tests
+    langs.Free;
+  end;
+  CheckEqual(Rs, 'i18n test string', 'restored');
+  {$ifdef FPC}
+  CheckEqual(RsVar, 'i18n test string', 'variable restored');
+  {$endif FPC}
 end;
 
 

--- a/test/test.core.data.pas
+++ b/test/test.core.data.pas
@@ -227,6 +227,8 @@ type
     procedure GlobalHooks;
     /// GNU gettext .po parsing into a TSynLanguage table
     procedure PoFormat;
+    /// GNU gettext .mo binary parsing into a TSynLanguage table
+    procedure MoFormat;
     /// INI and YAML parsing, and the per-extension file loaders
     procedure IniAndFiles;
     /// the FPC resourcestring table rewriting channel
@@ -10248,6 +10250,221 @@ begin
   finally
     l.Free;
   end;
+end;
+
+// generate some GNU gettext .mo binary content, as msgfmt would
+// - Swapped will store the multi-byte numbers in the reverse endianness of this
+// CPU, to validate the byte swapping code path of TSynLanguage.AddFromMo()
+// - Revision and CountDelta allow to generate some deliberately invalid content
+function MakeMo(const Ids, Strs: array of RawUtf8; Swapped: boolean;
+  Revision: cardinal = 0; CountDelta: integer = 0): RawByteString;
+const
+  MO_HEAD = 28; // fixed size of the .mo header, in bytes
+var
+  n, i, p: PtrInt;
+  nul: AnsiChar;
+  txt: RawByteString;
+
+  procedure AddCard(V: cardinal);
+  begin
+    if Swapped then
+      V := bswap32(V);
+    Append(result, @V, 4);
+  end;
+
+begin
+  result := '';
+  txt := '';
+  nul := #0;
+  n := length(Ids);
+  AddCard($950412de);                // magic number
+  AddCard(Revision);                 // major shl 16 + minor file format
+  AddCard(n + CountDelta);           // number of strings
+  AddCard(MO_HEAD);                  // original strings table offset
+  AddCard(MO_HEAD + n * 8);          // translated strings table offset
+  AddCard(0);                        // hash table size
+  AddCard(0);                        // hash table offset
+  p := MO_HEAD + n * 16;             // where the #0 terminated strings begin
+  for i := 0 to n - 1 do             // original strings (length, offset) table
+  begin
+    AddCard(length(Ids[i]));
+    AddCard(p);
+    inc(p, length(Ids[i]) + 1);      // each string has its #0 terminator
+  end;
+  for i := 0 to n - 1 do             // translated strings (length, offset) table
+  begin
+    AddCard(length(Strs[i]));
+    AddCard(p);
+    inc(p, length(Strs[i]) + 1);
+  end;
+  for i := 0 to n - 1 do
+  begin
+    Append(txt, Ids[i]);
+    Append(txt, @nul, 1);
+  end;
+  for i := 0 to n - 1 do
+  begin
+    Append(txt, Strs[i]);
+    Append(txt, @nul, 1);
+  end;
+  Append(result, txt);
+end;
+
+procedure TTestCoreI18n.MoFormat;
+var
+  l, l2: TSynLanguage;
+  langs: TSynLanguages;
+  mo, bad: RawByteString;
+  t, cha: RawUtf8;
+  fn, folder: TFileName;
+  swapped: boolean;
+  i: PtrInt;
+  tmp: array[0 .. 15] of AnsiChar;
+begin
+  FastSetString(cha, @tmp, Ucs4ToUtf8($8336, @tmp)); // U+8336 = tea ideogram
+  // the same .mo content, in this CPU endianness and in the reverse one
+  for swapped := false to true do
+  begin
+    mo := MakeMo([
+      '',                                 // the void msgid header entry
+      'Hello',
+      'Hello World',
+      'Untranslated',
+      'One file'#0'%d files',             // msgid + #0 + msgid_plural
+      'menu'#4'Open',                     // msgctxt + #4 + msgid
+      'Tea'], [
+      'Project-Id-Version: demo'#10'Content-Type: text/plain; charset=UTF-8'#10,
+      'Bonjour',
+      'Bonjour tout le monde',
+      '',                                 // an untranslated entry
+      'Un fichier'#0'%d fichiers',        // msgstr[0] + #0 + msgstr[1]
+      'Ouvrir',
+      cha], swapped);
+    l := TSynLanguage.Create(lngFrench);
+    try
+      CheckEqual(l.AddFromMo(mo), 3, 'Hello + Hello World + Tea');
+      CheckEqual(l.Count, 3, 'no extra key stored');
+      t := 'Hello';
+      Check(l.Translate(t), 'plain pair');
+      CheckEqual(t, 'Bonjour');
+      t := 'Hello World';
+      Check(l.Translate(t), 'no escaping in the binary format');
+      CheckEqual(t, 'Bonjour tout le monde');
+      // the parser should be transparent to any UTF-8 multi-byte content
+      t := 'Tea';
+      Check(l.Translate(t));
+      CheckEqual(t, cha, 'utf-8 passthrough');
+      // the void msgid header entry should never pollute the table
+      t := 'Project-Id-Version: demo'#10 +
+           'Content-Type: text/plain; charset=UTF-8'#10;
+      Check(not l.Translate(t), 'header is skipped');
+      // a void msgstr is an untranslated entry, as with AddFromPo()
+      t := 'Untranslated';
+      Check(not l.Translate(t), 'void msgstr is skipped');
+      CheckEqual(t, 'Untranslated');
+      // msgid_plural / msgstr[] plural forms are not supported yet, as for .po
+      t := 'One file';
+      Check(not l.Translate(t), 'plural forms are skipped');
+      // msgctxt disambiguation is not supported yet, as for .po
+      t := 'Open';
+      Check(not l.Translate(t), 'msgctxt is skipped');
+      t := 'menu'#4'Open';
+      Check(not l.Translate(t), 'the raw msgctxt key is not stored either');
+    finally
+      l.Free;
+    end;
+  end;
+  // a .mo and the .po source it was compiled from should give the same table
+  l := TSynLanguage.Create(lngFrench);
+  l2 := TSynLanguage.Create(lngFrench);
+  try
+    CheckEqual(l.AddFromPo('msgid "Hello"'#10'msgstr "Bonjour"'#10 +
+      'msgid "Hello World"'#10'msgstr "Bonjour tout le monde"'#10), 2, '.po');
+    CheckEqual(l2.AddFromMo(MakeMo(['Hello', 'Hello World'],
+      ['Bonjour', 'Bonjour tout le monde'], false)), 2, '.mo');
+    CheckEqual(l.Count, l2.Count, 'same entry count as its .po source');
+    t := 'Hello';
+    Check(l2.Translate(t));
+    CheckEqual(t, 'Bonjour', 'same translation as its .po source');
+    t := 'Hello World';
+    Check(l2.Translate(t));
+    CheckEqual(t, 'Bonjour tout le monde');
+  finally
+    l2.Free;
+    l.Free;
+  end;
+  // invalid content should be rejected, and should never merge anything
+  l := TSynLanguage.Create(lngFrench);
+  l2 := TSynLanguage.Create(lngFrench);
+  try
+    CheckEqual(l.AddFromMo(''), -1, 'void input');
+    CheckEqual(l.AddFromMo('too short for a header'), -1, 'truncated header');
+    CheckEqual(l.Count, 0);
+    mo := MakeMo(['One'], ['Un'], false);
+    CheckEqual(l.AddFromMo(mo), 1, 'reference sample');
+    CheckEqual(l.Count, 1);
+    bad := mo;
+    bad[1] := 'X'; // whatever the endianness is, the magic is broken
+    CheckEqual(l.AddFromMo(bad), -1, 'invalid magic number');
+    CheckEqual(l.AddFromMo(MakeMo(['One'], ['Un'], false, 1 shl 16)), 1,
+      'revision 1.0 is supported');
+    CheckEqual(l.AddFromMo(MakeMo(['One'], ['Un'], false, 2 shl 16)), -1,
+      'unsupported major revision');
+    CheckEqual(l.AddFromMo(MakeMo(['One'], ['Un'], false, 0, 1)), -1,
+      'one more entry than actually supplied');
+    CheckEqual(l.AddFromMo(MakeMo(['One'], ['Un'], false, 0, 1 shl 20)), -1,
+      'way more entries than this content could store');
+    CheckEqual(l.Count, 1, 'no invalid content did pollute the table');
+    CheckEqual(l.AddFromMo(MakeMo([], [], false)), 0, 'valid but void .mo');
+    // any truncated content should be rejected, and merge nothing at all
+    for i := 1 to length(mo) - 1 do
+    begin
+      CheckEqual(l2.AddFromMo(copy(mo, 1, i)), -1, 'truncated');
+      CheckEqual(l2.Count, 0, 'nothing merged from a truncated input');
+    end;
+    // AddFromMoFile() should read the file as binary, and AddFromFile() should
+    // dispatch on the .mo extension
+    fn := WorkDir + 'i18ntest.mo';
+    Check(FileFromString(mo, fn), 'mo file');
+    CheckEqual(l2.AddFromMoFile(fn), 1, 'AddFromMoFile');
+    CheckEqual(l2.AddFromFile(fn), 1, '.mo dispatch');
+    CheckEqual(l2.Count, 1);
+    t := 'One';
+    Check(l2.Translate(t));
+    CheckEqual(t, 'Un');
+    Check(DeleteFile(fn));
+  finally
+    l2.Free;
+    l.Free;
+  end;
+  // TSynLanguages.LoadFromFolder() should load the files in a deterministic
+  // order, whatever the OS folder enumeration order is
+  folder := EnsureDirectoryExists([WorkDir, 'i18nmo']);
+  Check(folder <> '', 'folder');
+  Check(FileFromString('msgid "Hello"'#10'msgstr "FromPo"'#10 +
+    'msgid "OnlyPo"'#10'msgstr "SeulementPo"'#10, folder + 'fr.po'));
+  Check(FileFromString(MakeMo(['Hello', 'OnlyMo'],
+    ['FromMo', 'SeulementMo'], false), folder + 'fr.mo'));
+  langs := TSynLanguages.Create;
+  try
+    CheckEqual(langs.LoadFromFolder(folder), 2, 'fr.po + fr.mo');
+    Check(langs.Find(lngFrench) <> nil);
+    CheckEqual(langs.Find(lngFrench).Count, 3, 'Hello + OnlyPo + OnlyMo');
+    TSynLanguages.SetThreadLanguage(lngFrench);
+    t := 'Hello';
+    Check(langs.Translate(t));
+    CheckEqual(t, 'FromMo', 'the compiled .mo wins over its .po source');
+    t := 'OnlyPo';
+    Check(langs.Translate(t), 'both files are merged');
+    CheckEqual(t, 'SeulementPo');
+    t := 'OnlyMo';
+    Check(langs.Translate(t));
+    CheckEqual(t, 'SeulementMo');
+  finally
+    TSynLanguages.SetThreadLanguage(lngUndefined);
+    langs.Free;
+  end;
+  Check(DirectoryDelete(folder), 'cleanup');
 end;
 
 const

--- a/test/test.core.data.pas
+++ b/test/test.core.data.pas
@@ -88,6 +88,7 @@ uses
   mormot.core.rtti,
   mormot.core.json,
   mormot.core.fmt,
+  mormot.core.i18n,
   mormot.core.variants,
   mormot.crypt.core,
   mormot.crypt.secure,
@@ -213,6 +214,17 @@ type
     procedure _XML;
     /// regression tests for the mormot.core.fmt YAML parser
     procedure _YAML;
+  end;
+
+  /// regression tests for the mormot.core.i18n unit
+  TTestCoreI18n = class(TSynTestCase)
+  published
+    /// TSynLanguage table load and translation with fallback
+    procedure LanguageTable;
+    /// TSynLanguages registry, thread language and Mustache wiring
+    procedure LanguagesRegistry;
+    /// global hooks: captions and date/time rendering
+    procedure GlobalHooks;
   end;
 
   /// this test case will test most functions, classes and types defined and
@@ -9973,6 +9985,118 @@ begin
       inc(n);
     end;
   CheckEqual(n, 2);
+end;
+
+
+{ TTestCoreI18n }
+
+procedure TTestCoreI18n.LanguageTable;
+var
+  l: TSynLanguage;
+  t: RawUtf8;
+  s: string;
+begin
+  l := TSynLanguage.Create(lngFrench);
+  try
+    CheckEqual(l.Iso, 'fr');
+    Check(l.Language = lngFrench);
+    CheckEqual(l.Count, 0);
+    CheckEqual(l.AddFromJson('{"Hello":"Bonjour","World":"Monde"}'), 2);
+    CheckEqual(l.Count, 2);
+    CheckEqual(l.AddFromJson('invalid'), -1);
+    t := 'Hello';
+    Check(l.Translate(t));
+    CheckEqual(t, 'Bonjour');
+    t := 'Missing';
+    Check(not l.Translate(t));
+    CheckEqual(t, 'Missing', 'fallback keeps input');
+    s := 'World';
+    l.TranslateString(s);
+    Check(s = 'Monde');
+    s := 'Missing';
+    l.TranslateString(s);
+    Check(s = 'Missing');
+  finally
+    l.Free;
+  end;
+end;
+
+procedure TTestCoreI18n.LanguagesRegistry;
+var
+  langs: TSynLanguages;
+  m: TSynMustache;
+  u: RawUtf8;
+begin
+  langs := TSynLanguages.Create;
+  try
+    CheckEqual(langs.Language[lngFrench].AddFromJson('{"Hello":"Bonjour"}'), 1);
+    CheckEqual(langs.Language[lngChinese].AddFromJson('{"Hello":"NiHao"}'), 1);
+    Check(langs.Find(lngFrench) <> nil);
+    Check(langs.Find(lngGerman) = nil);
+    Check(langs.FindIso('fr') = langs.Find(lngFrench));
+    Check(langs.FindIso('xx') = nil);
+    // no thread language nor default: passthrough
+    Check(TSynLanguages.ThreadLanguage = lngUndefined);
+    Check(langs.Current = nil);
+    u := 'Hello';
+    Check(not langs.Translate(u));
+    CheckEqual(u, 'Hello');
+    // per-thread selection
+    TSynLanguages.SetThreadLanguage(lngFrench);
+    Check(TSynLanguages.ThreadLanguage = lngFrench);
+    Check(langs.Current = langs.Find(lngFrench));
+    u := 'Hello';
+    Check(langs.Translate(u));
+    CheckEqual(u, 'Bonjour');
+    // fallback to DefaultLanguage when no thread language is set
+    TSynLanguages.SetThreadLanguage(lngUndefined);
+    langs.DefaultLanguage := lngChinese;
+    Check(langs.Current = langs.Find(lngChinese));
+    u := 'Hello';
+    Check(langs.Translate(u));
+    CheckEqual(u, 'NiHao');
+    // Mustache {{"text}} channel end-to-end
+    TSynLanguages.SetThreadLanguage(lngFrench);
+    m := TSynMustache.Parse('{{"Hello}} {{name}}!');
+    CheckEqual(m.Render(_ObjFast(['name', 'world']), nil, nil,
+      langs.TranslateString), 'Bonjour world!');
+    TSynLanguages.SetThreadLanguage(lngUndefined);
+    langs.DefaultLanguage := lngUndefined;
+    CheckEqual(m.Render(_ObjFast(['name', 'world']), nil, nil,
+      langs.TranslateString), 'Hello world!', 'passthrough fallback');
+  finally
+    TSynLanguages.SetThreadLanguage(lngUndefined);
+    langs.Free;
+  end;
+end;
+
+procedure TTestCoreI18n.GlobalHooks;
+var
+  langs: TSynLanguages;
+  s: string;
+begin
+  Check(I18n = nil);
+  langs := TSynLanguages.Create;
+  try
+    langs.Language[lngFrench].AddFromJson('{"Hello world":"Bonjour monde"}');
+    langs.Language[lngFrench].DateTimeFormat := 'yyyy/mm/dd hh:nn';
+    langs.SetGlobal;
+    Check(I18n = langs);
+    TSynLanguages.SetThreadLanguage(lngFrench);
+    // LoadResStringTranslate is consumed by the GetCaptionFrom* family
+    GetCaptionFromPCharLen('HelloWorld', s);
+    Check(s = 'Bonjour monde', 'caption translation');
+    // date/time hooks
+    Check(Assigned(i18nDateTimeText));
+    s := i18nDateTimeText(EncodeDate(2026, 7, 31) + EncodeTime(12, 30, 0, 0));
+    Check(s = '2026/07/31 12:30', 'DateTimeFormat pattern');
+  finally
+    TSynLanguages.SetThreadLanguage(lngUndefined);
+    langs.Free; // also unhooks the global slots
+  end;
+  Check(I18n = nil, 'unhooked');
+  Check(not Assigned(LoadResStringTranslate));
+  Check(not Assigned(i18nDateTimeText));
 end;
 
 

--- a/test/test.core.data.pas
+++ b/test/test.core.data.pas
@@ -10091,14 +10091,14 @@ begin
   Check(I18n = nil);
   langs := TSynLanguages.Create;
   try
-    langs.Language[lngFrench].AddFromJson('{"Hello world":"Bonjour monde"}');
+    langs.Language[lngFrench].AddFromJson('{"Hello world":"Bonjour tout le monde"}');
     langs.Language[lngFrench].DateTimeFormat := 'yyyy/mm/dd hh:nn';
     langs.SetGlobal;
     Check(I18n = langs);
     TSynLanguages.SetThreadLanguage(lngFrench);
     // LoadResStringTranslate is consumed by the GetCaptionFrom* family
     GetCaptionFromPCharLen('HelloWorld', s);
-    Check(s = 'Bonjour monde', 'caption translation');
+    Check(s = 'Bonjour tout le monde', 'caption translation');
     // date/time hooks
     Check(Assigned(i18nDateTimeText));
     s := i18nDateTimeText(EncodeDate(2026, 7, 31) + EncodeTime(12, 30, 0, 0));
@@ -10130,7 +10130,7 @@ const
     'msgid "Hello "'#10 +
     '"World"'#10 +
     'msgstr "Bonjour "'#10 +
-    '"Monde"'#10 +
+    '"tout le monde"'#10 +
     #10 +
     '#: src/main.c:50'#10 +
     '#, fuzzy, c-format'#10 +
@@ -10182,7 +10182,7 @@ begin
     // multi-line msgid/msgstr continuation
     t := 'Hello World';
     Check(l.Translate(t), 'continuation lines');
-    CheckEqual(t, 'Bonjour Monde');
+    CheckEqual(t, 'Bonjour tout le monde');
     // \n \t \" \\ escape decoding, on both msgid and msgstr
     t := 'a'#10'b'#9'c "d" e\f';
     Check(l.Translate(t), 'escapes');
@@ -10269,6 +10269,13 @@ const
     '[de]'#10 +
     'Hello=Hallo'#10;
 
+var
+  // some WinAnsi chars to avoid any charset/IDE conflict during tests
+  _uC9, _uE7, _uE8, _uE9: RawUtf8;
+
+const
+  UTF8_ACCENTS: array[0..3] of byte = ($C9, $E7, $E8, $E9);
+
 procedure TTestCoreI18n.IniAndFiles;
 var
   l: TSynLanguage;
@@ -10347,15 +10354,15 @@ begin
     CheckEqual(t, 'Monde');
     CheckEqual(l.AddFromYaml('- one'#10'- two'#10), -1, 'yaml array is no table');
     // the relaxed JSON variants are supported by AddFromJson()
-    CheckEqual(l.AddFromJson('{ // a JSONC comment'#10' "Six": "Sixieme"'#10'}'),
+    CheckEqual(l.AddFromJson(RawUtf8('{ // a JSONC comment'#10' "Six": "Sixi') + _uE8 + 'me"'#10'}'),
       1, 'jsonc');
     t := 'Six';
     Check(l.Translate(t));
-    CheckEqual(t, 'Sixieme');
-    CheckEqual(l.AddFromJson('{ /* JSON5 */ Seven: "Septieme", }'), 1, 'json5');
+    CheckEqual(t, RawUtf8('Sixi') + _uE8 + 'me');
+    CheckEqual(l.AddFromJson(RawUtf8('{ /* JSON5 */ Seven: "Septi') + _uE8 + 'me", }'), 1, 'json5');
     t := 'Seven';
     Check(l.Translate(t));
-    CheckEqual(t, 'Septieme');
+    CheckEqual(t, RawUtf8('Septi') + _uE8 + 'me');
     CheckEqual(l.AddFromJson('invalid'), -1, 'invalid JSON');
     CheckEqual(l.AddFromJson(''), -1, 'void JSON');
     CheckEqual(l.AddFromJson('["Hello"]'), -1, 'JSON array is no table');
@@ -10406,20 +10413,37 @@ begin
   // TSynLanguages.LoadFromFolder() with several extensions
   folder := EnsureDirectoryExists([WorkDir, 'i18n']);
   Check(folder <> '', 'folder');
-  Check(FileFromString('msgid "Hello"'#10'msgstr "Bonjour"'#10, folder + 'fr.po'));
+  Check(FileFromString(RawUtf8('msgid "Hello"'#10'msgstr "Bonjour"'#10 +
+    'msgid "Resume"'#10'msgstr "R') + _uE9 + 'sum' + _uE9 + '"'#10 +
+    'msgid "Cafe"'#10'msgstr "Caf' + _uE9 + '"'#10, folder + 'fr.po'));
+  Check(FileFromString(RawUtf8('{"Facade":"Fa') + _uE7 + 'ade","Elephant":"' + _uC9 + 'l' + _uE9 + 'phant"}', folder + 'fr.json'));
   Check(FileFromString('Hello=' + cha + #10, folder + 'zh.ini'));
   Check(FileFromString('ignored', folder + 'en.txt'), 'unknown extension');
   Check(FileFromString('ignored', folder + 'nolang.json'), 'unknown iso');
   langs := TSynLanguages.Create;
   try
-    CheckEqual(langs.LoadFromFolder(folder), 2, 'fr.po + zh.ini');
+    CheckEqual(langs.LoadFromFolder(folder), 3, 'fr.po + fr.json + zh.ini');
     Check(langs.Find(lngEnglish) = nil, '.txt is not a translation file');
     Check(langs.Find(lngFrench) <> nil);
-    CheckEqual(langs.Find(lngFrench).Count, 1);
+    CheckEqual(langs.Find(lngFrench).Count, 5);
     t := 'Hello';
     TSynLanguages.SetThreadLanguage(lngFrench);
     Check(langs.Translate(t), 'from fr.po');
     CheckEqual(t, 'Bonjour');
+
+    t := 'Resume';
+    Check(langs.Translate(t));
+    CheckEqual(t, RawUtf8('R') + _uE9 + 'sum' + _uE9);
+    t := 'Cafe';
+    Check(langs.Translate(t));
+    CheckEqual(t, RawUtf8('Caf') + _uE9);
+    t := 'Facade';
+    Check(langs.Translate(t));
+    CheckEqual(t, RawUtf8('Fa') + _uE7 + 'ade');
+    t := 'Elephant';
+    Check(langs.Translate(t));
+    CheckEqual(t, _uC9 + 'l' + _uE9 + 'phant');
+
     Check(langs.Find(lngChinese) <> nil);
     CheckEqual(langs.Find(lngChinese).Count, 1);
     t := 'Hello';
@@ -11334,6 +11358,11 @@ end;
 
 
 initialization
+  _uC9 := WinAnsiToUtf8(@UTF8_ACCENTS[0], 1);
+  _uE7 := WinAnsiToUtf8(@UTF8_ACCENTS[1], 1);
+  _uE8 := WinAnsiToUtf8(@UTF8_ACCENTS[2], 1);
+  _uE9 := WinAnsiToUtf8(@UTF8_ACCENTS[3], 1);
+
   {$ifndef HASDYNARRAYTYPE}
   Rtti.RegisterObjArray(TypeInfo(TSimpleExampleObjArray), TSimpleExample);
   {$endif HASDYNARRAYTYPE}


### PR DESCRIPTION
Follows the discussion in https://synopse.info/forum/viewtopic.php?id=7592 — this is PR-B of that proposal, PR #506 having wired the MVC side.

**`TSynLanguage`** — one translation table per language, keyed on the original English text, so a missing key naturally falls back to it. Loaders: `.po` as the main format (its msgid *is* the English text, and translators get the whole gettext tooling), `.ini` / `.msg` on top of the existing `FindSectionFirstLine`, `.yaml` and `.json` with its relaxed JSON5 / JSONC / HJson variants — those two came almost for free from our own parsers. `AddFromFile` dispatches on the file extension.

**`TSynLanguages`** — a registry indexed by the existing `TLanguage` enum (not duplicated), with per-thread language selection for web use, `LoadFromFolder` over `<iso>.<ext>` files, and `LoadedLanguages` to fill a language selection list.

**Three wiring channels**, all fed by the same table:

- the Mustache translate tag, via `TMvcViewsMustache.OnTranslate` from #506;
- the `LoadResStringTranslate` slot consumed by `GetCaptionFrom*`;
- on FPC only, the whole executable resourcestring table, through the `objpas.SetResourceStrings()` official API — the per-unit writable table is the only official hook there (the enumeration-style API is gone in 3.x). Delphi keeps its resourcestrings in the executable resources with no such writable runtime table, so `TranslateResourceStrings` is a documented no-op there.

Per-language date/time patterns are rendered through our own `TFormatSettings`, so the `/` and `:` pattern characters are no longer rewritten by the process-wide locale separators — that was silently defeating the whole point of a per-language pattern on a POSIX-locale Linux box.

Deliberately out of scope: VCL/LCL form translation (the v1 part), plurals, and msgctxt.

**Tests**: new `TTestCoreI18n` suite — 201 assertions on FPC, 192 on Delphi (the difference being the FPC-only resourcestring part). Green on FPC 3.2.3 i386-win32, FPC 3.2.3 aarch64-linux on Rockchip RK3588 hardware, Delphi 37.0 Win32 and Win64.

The accented-translation coverage comes from @flydev-fr: the original assertions were all pure ASCII, so the multi-byte UTF-8 path through the `.po` and `.json` loaders was never actually exercised. The branch has since been rebased onto current master, so the diff is purely additive against it.


