### PR TITLE
core: use plain values for the platform-specific RTL file attributes

### DIFF
--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -79,9 +79,25 @@ const
   /// human-friendly alias to open a file for exclusive writing ($20)
   fmShareRead      = fmShareDenyWrite;
   /// human-friendly alias to open a file for exclusive reading ($30)
-  fmShareWrite     = {$ifdef DELPHIPOSIX} fmShareDenyNone {$else} fmShareDenyRead {$endif};
+  // - $0030 is the value of the RTL fmShareDenyRead, inlined here because that
+  // constant does not exist on POSIX - where write-only sharing is unsupported,
+  // so Delphi flags it as platform-specific
+  fmShareWrite     = {$ifdef DELPHIPOSIX} fmShareDenyNone {$else} $0030 {$endif};
   /// human-friendly alias to open a file with no read/write exclusion ($40)
   fmShareReadWrite = fmShareDenyNone;
+
+  /// hidden file attribute ($02) - i.e. the RTL faHidden value
+  // - the RTL constant is flagged as platform-specific because on POSIX it is
+  // just the initial '.' naming convention, but its value is fixed everywhere
+  faHiddenFile     = $00000002;
+  /// system file attribute ($04) - i.e. the RTL faSysFile value
+  // - the RTL constant is flagged as platform-specific because on POSIX system
+  // files are neither regular files nor directories
+  faSystemFile     = $00000004;
+  /// DOS volume label attribute ($08) - i.e. the RTL faVolumeID value
+  // - the RTL constant is deprecated since it is never returned by FindFirst()
+  // on Win32, but it is still excluded by SearchRecValidFile() for safety
+  faVolumeLabel    = $00000008;
 
   /// execute FileOpen/TFileStreamEx.Create for reading without exclusion
   fmOpenReadShared = fmOpenRead or fmShareReadWrite;
@@ -7766,22 +7782,22 @@ begin
 end;
 
 const
-  // faHidden is supported by the FPC RTL on POSIX, by checking an initial '.'
-  faInvalid = faDirectory + {$ifdef OSWINDOWS} faVolumeID{%H-} + {$endif} faSysFile{%H-};
+  // faHiddenFile is supported by the FPC RTL on POSIX, by checking an initial '.'
+  faInvalid = faDirectory + {$ifdef OSWINDOWS} faVolumeLabel + {$endif} faSystemFile;
 
 function SearchRecValidFile(const F: TSearchRec; IncludeHidden: boolean): boolean;
 begin
   result := (F.Name <> '') and
             (F.Attr and faInvalid = 0) and
             (IncludeHidden or
-             (F.Attr and faHidden{%H-} = 0));
+             (F.Attr and faHiddenFile = 0));
 end;
 
 function SearchRecValidFolder(const F: TSearchRec; IncludeHidden: boolean): boolean;
 begin
   result := (F.Attr and faDirectory <> 0) and
             (IncludeHidden or
-             (F.Attr and faHidden{%H-} = 0)) and
+             (F.Attr and faHiddenFile = 0)) and
             (F.Name <> '') and
             (F.Name <> '.') and
             (F.Name <> '..');
@@ -7792,7 +7808,7 @@ function FindFirstDirectory(const Path: TFileName; IncludeHidden: boolean;
 begin
   result := faDirectory;
   if IncludeHidden then
-    result := result or faHidden{%H-};
+    result := result or faHiddenFile;
   result := FindFirst(Path, result, F);
 end;
 


### PR DESCRIPTION
### What

`mormot.core.os` uses four RTL constants that Delphi marks as platform-specific, one of them also deprecated:

| RTL symbol | Declared in `System.SysUtils` |
| --- | --- |
| `fmShareDenyRead` | `= $0030 platform;` (does not exist on POSIX) |
| `faHidden` | `= $00000002 platform;` |
| `faSysFile` | `= $00000004 platform;` |
| `faVolumeID` | `= $00000008 platform deprecated;` |

This replaces them with framework constants of identical value — `faHiddenFile`, `faSystemFile`, `faVolumeLabel`, and the literal `$0030` for `fmShareWrite` — so no hinted RTL symbol is referenced any more.

### Why

These four are the only reason `mormot.core.os` needs `{$warn SYMBOL_PLATFORM OFF}` / `{$warn SYMBOL_DEPRECATED OFF}` from `mormot.defines.inc` (the latter is even commented `// for faVolumeID`). The values are frozen Win32 file-attribute bits, identical on FPC and Delphi and on every supported target, so nothing is lost by naming them ourselves — and the units then compile clean for anyone who does not inherit those blanket directives.

It also lets three `{%H-}` FPC hint markers go away, since the new constants raise no hint on FPC either.

### No behaviour change

Same values, same expressions. `faInvalid` still resolves to `faDirectory + faVolumeLabel + faSystemFile` on Windows and `faDirectory + faSystemFile` elsewhere.

### Verified

- Values asserted at compile time against the RTL on Delphi 13.1 (compiler 37.0, build 37.0.59082.6021), both Win32 and Win64:

  ```pascal
  {$if (faHidden <> $02) or (faSysFile <> $04) or (faVolumeID <> $08) or (fmShareDenyRead <> $30)}
    {$message error 'attribute value mismatch'}
  {$ifend}
  ```

- Compiles clean on Delphi 13.1 Win32 + Win64 over `mormot.core.*`, `mormot.crypt.*`, `mormot.db.*`, `mormot.lib.*`, `mormot.net.*`, with `SYMBOL_PLATFORM` and `SYMBOL_DEPRECATED` warnings deliberately re-enabled; the seven diagnostics these symbols produced are gone.
- **Not** run: the `mormot2tests` regression suite (the machine this was prepared on blocks launching freshly built executables). Happy to add results if you want them before merging.

---

One of three independent PRs that each stand alone and can be merged in any order (they touch different units, and none depends on another): #513 file attribute constants, #514 variant manager, #515 `GetMemoryManagerState`.
