### PR TITLE
core: hook DispInvoke via the variant manager on FPC only

### DIFF
--- a/src/core/mormot.core.variants.pas
+++ b/src/core/mormot.core.variants.pas
@@ -13429,11 +13429,11 @@ const
 
 procedure InitializeUnit;
 var
-  vm: TVariantManager; // available since Delphi 7
   vt: cardinal;
   ins: boolean;
   i: PtrUInt;
   {$ifdef FPC}
+  vm: TVariantManager;
   test: variant;
   {$endif FPC}
 begin
@@ -13481,11 +13481,14 @@ begin
   _VARDATACMP[varUString, false] := 17;
   _VARDATACMP[varUString, true]  := 18;
   {$endif HASVARUSTRING}
+  {$ifdef FPC}
   // patch DispInvoke for performance and to circumvent RTL inconsistencies
+  // - FPC only: Delphi deprecated its variant manager and made it a no-op
+  // (System.GetVariantManager just zeroes the record and SetVariantManager has
+  // an empty body), so Delphi relies on TSynInvokeableVariantType.DispInvoke
   GetVariantManager(vm);
   vm.DispInvoke := NewDispInvoke;
   SetVariantManager(vm);
-  {$ifdef FPC}
   // circumvent FPC 3.2+ inverted parameters order - may be fixed in later FPC
   test := _ObjFast([]);
   try


### PR DESCRIPTION
### What

`mormot.core.variants.InitializeUnit` patches `DispInvoke` through the System variant manager:

```pascal
GetVariantManager(vm);
vm.DispInvoke := NewDispInvoke;
SetVariantManager(vm);
```

This moves those three lines (and the `vm` local) inside the existing `{$ifdef FPC}` block.

### Why

On Delphi the variant manager has been a no-op stub for a long time. From `System.pas` (Delphi 13.1, compiler 37.0, build 37.0.59082.6021):

```pascal
{ Variant manager support procedures and functions (obsolete - see Variants.pas) }
procedure GetVariantManager(var VarMgr: TVariantManager); deprecated;
procedure SetVariantManager(const VarMgr: TVariantManager); deprecated;
...
procedure GetVariantManager(var VarMgr: TVariantManager);
begin
  FillChar(VarMgr, sizeof(VarMgr), 0);
end;

procedure SetVariantManager(const VarMgr: TVariantManager);
begin
end;
```

So on Delphi the assignment cannot take effect: `NewDispInvoke` is written into a zeroed local record that `SetVariantManager` then discards. `NewDispInvoke` has no other reference in the unit, so on Delphi it is dead code, and late binding is served by the `TSynInvokeableVariantType.DispInvoke` override instead — which is the documented Delphi mechanism.

Guarding it makes that explicit and removes four `W1000` deprecation warnings.

### Question for the maintainer

I could only check the Delphi 13.1 RTL sources. If `GetVariantManager` / `SetVariantManager` were still functional on the older Delphi versions mORMot supports (7, 2007–2010), then this should be a compiler-version guard rather than `{$ifdef FPC}`, so those versions keep the faster path. Happy to change it to whatever cutoff you know to be right.

### Verified

- Compiles clean on Delphi 13.1 Win32 + Win64; the four `TVariantManager` / `GetVariantManager` / `SetVariantManager` deprecation warnings are gone. FPC behaviour is untouched — the same three calls run, just from inside the existing `{$ifdef FPC}`.
- **Not** run: the `mormot2tests` regression suite, in particular the late-binding tests, which are the ones that matter here (the machine this was prepared on blocks launching freshly built executables). Worth running on FPC and Delphi before merging.

---

One of three independent PRs that each stand alone and can be merged in any order (they touch different units, and none depends on another): #513 file attribute constants, #514 variant manager, #515 `GetMemoryManagerState`.
