### PR TITLE
core: replace the unsupported GetHeapStatus with GetMemoryManagerState

### DIFF
--- a/src/core/mormot.core.log.pas
+++ b/src/core/mormot.core.log.pas
@@ -4199,9 +4199,42 @@ begin
 end;
 {$else}
 function RetrieveMemoryManagerInfo: RawUtf8;
+{$if defined(OSWINDOWS) and defined(ISDELPHI2007ANDUP)}
+var
+  i: PtrInt;
+  small, alloc, reserved, blocks: QWord;
+  state: TMemoryManagerState;
+{$ifend}
 begin
+  result := '';
   {$ifdef OSWINDOWS}
-  // standard Delphi memory manager
+  {$ifdef ISDELPHI2007ANDUP}
+  // standard Delphi memory manager - note: don't use the older GetHeapStatus,
+  // which the RTL declares as deprecated and unsupported
+  GetMemoryManagerState(state);
+  small := 0;
+  blocks := QWord(state.AllocatedMediumBlockCount) +
+            QWord(state.AllocatedLargeBlockCount);
+  reserved := QWord(state.ReservedMediumBlockAddressSpace) +
+              QWord(state.ReservedLargeBlockAddressSpace);
+  for i := 0 to high(state.SmallBlockTypeStates) do
+    with state.SmallBlockTypeStates[i] do
+    begin
+      inc(small, QWord(AllocatedBlockCount) * UseableBlockSize);
+      inc(reserved, ReservedAddressSpace);
+      inc(blocks, AllocatedBlockCount);
+    end;
+  alloc := small + QWord(state.TotalAllocatedMediumBlockSize) +
+           QWord(state.TotalAllocatedLargeBlockSize);
+  if reserved <> 0 then
+    FormatUtf8(' - Heap: Allocated=% Reserved=% ' +
+       'Small=% Medium=% Large=% Blocks=% ',
+      [KBNoSpace(alloc), KBNoSpace(reserved), KBNoSpace(small),
+       KBNoSpace(state.TotalAllocatedMediumBlockSize),
+       KBNoSpace(state.TotalAllocatedLargeBlockSize), blocks], result);
+  {$else}
+  // TMemoryManagerState needs Delphi 2007+: older compilers keep GetHeapStatus,
+  // which is not flagged as deprecated on them anyway
   with GetHeapStatus do
     if TotalAddrSpace <> 0 then
       FormatUtf8(' - Heap: AddrSpace=% Uncommitted=% Committed=% Allocated=% '+
@@ -4210,10 +4243,9 @@ begin
          KBNoSpace(TotalCommitted), KBNoSpace(TotalAllocated),
          KBNoSpace(TotalFree),      KBNoSpace(FreeSmall),
          KBNoSpace(FreeBig),        KBNoSpace(Unused),
-         KBNoSpace(Overhead)], result)
-    else
+         KBNoSpace(Overhead)], result);
+  {$endif ISDELPHI2007ANDUP}
   {$endif OSWINDOWS}
-      result := '';
 end;
 {$endif FPC}
 


### PR DESCRIPTION
### What

`RetrieveMemoryManagerInfo` (Delphi branch) reads the heap through `GetHeapStatus`. This switches it to `GetMemoryManagerState`.

### Why

`System.pas` (Delphi 13.1, compiler 37.0, build 37.0.59082.6021) declares the old API as unsupported:

```pascal
function GetHeapStatus: THeapStatus; platform; deprecated; {Unsupported}

{Returns information about the current state of the memory manager}
procedure GetMemoryManagerState(var AMemoryManagerState: TMemoryManagerState); platform;
```

The existing code is already written defensively around that (`if TotalAddrSpace <> 0 then … else result := ''`), which suggests the record has been coming back empty — with the FastMM-derived RTL manager there is nothing behind `GetHeapStatus` to fill it. If so, the Delphi heap line has silently been absent from `TSynLog` headers rather than wrong. **I could not confirm that at runtime** (the machine this was prepared on blocks launching freshly built executables), so treat it as the likely reading of the guard, not a measurement.

`GetMemoryManagerState` is the supported replacement and returns real numbers.

### Behaviour change

The reported fields change, because the two records expose different things. Small blocks are only available per size class, so they are summed over `SmallBlockTypeStates`:

```
 - Heap: Allocated=<n> Reserved=<n> Small=<n> Medium=<n> Large=<n> Blocks=<n>
```

instead of the old `AddrSpace/Uncommitted/Committed/Allocated/Free/FreeSmall/FreeBig/Unused/Overheap`. The guard becomes `if reserved <> 0`, so a replacement memory manager that reports nothing still yields `''` and no heap line, as before.

Sums are accumulated in `QWord`, so the small-block `count × size` products cannot overflow on Win32.

### Note

`GetMemoryManagerState` is itself marked `platform`, so this removes the `W1000` deprecation but not the `W1002` platform hint — there is no non-platform RTL API for memory-manager introspection. The FPC branch (`GetFPCHeapStatus`) is untouched.

### Verified

- Compiles clean on Delphi 13.1 Win32 + Win64.
- **Not** run: the `mormot2tests` regression suite, and the emitted line has not been eyeballed in a real log for the same reason as above. If you would rather see the numbers first, I can hand the diff to someone who can run it, or drop this PR and keep the other two.

---

One of three independent PRs that each stand alone and can be merged in any order (they touch different units, and none depends on another): #513 file attribute constants, #514 variant manager, #515 `GetMemoryManagerState`.
