### PR TITLE
openapi: generate boolean parameters as true/false

### DIFF
--- a/src/net/mormot.net.openapi.pas
+++ b/src/net/mormot.net.openapi.pas
@@ -2103,6 +2103,8 @@ begin
       end
     else
       case fBuiltInType of
+        obtBoolean:
+          func := 'mormot.core.os.BOOL_UTF8[%]'; // 'true'/'false' as in JSON
         obtDate:
           func := 'DateToIso8601(%, true)';
         obtDateTime:
@@ -3138,6 +3140,7 @@ begin
       '  classes,', LineEnd,
       '  sysutils,', LineEnd,
       '  mormot.core.base,', LineEnd,
+      '  mormot.core.os,', LineEnd,
       '  mormot.core.unicode,', LineEnd,
       '  mormot.core.text,', LineEnd,
       '  mormot.core.buffers,', LineEnd,


### PR DESCRIPTION
A `type: boolean` query parameter ends up as `?onlyDeleted=0` in the request: the boolean is passed as a raw varrec into `UrlEncodeFull()`, and `VarRecToUtf8()` writes it via `AddU()` (`// normalize as 0 or 1`).

ASP.NET Core rejects that with a 400 before the controller runs, since `Boolean.Parse` only accepts `true`/`false`. OAS primitives follow JSON Schema (https://spec.openapis.org/oas/v3.0.3.html#data-types), where a boolean is the literal `true` or `false` (https://www.rfc-editor.org/rfc/rfc8259#section-3).

`TPascalType.ToFormatUtf8Arg` normalizes GUIDs and dates but has no `obtBoolean` branch, although `ToDefaultParameterValue` right below it already uses `BOOL_UTF8` for boolean defaults. Added it there, plus `mormot.core.os` in the generated uses clause for the constant.
