### PR TITLE
core: fix the GetmemDualAccessPages release address

### DIFF
--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -13016,7 +13016,10 @@ begin
   end;
   ObjArrayClear(CurrentFakeStubBuffers);
   if __GetmemDualAccessPages <> nil then // need VirtualFree() or unmap()
+  begin
+    dec(PByte(__GetmemDualAccessPages), SystemInfo.dwPageSize); // was base + 1 page
     _FreeLargeMem(__GetmemDualAccessPages, SystemInfo.dwPageSize * 2);
+  end;
   Executable.Version.Free;
   Executable.Command.Free;
   FinalizeSpecificUnit; // in mormot.core.os.posix/windows.inc files


### PR DESCRIPTION
The new dual-access pages are a great addition — the boundary tests now get the same guard-page coverage on POSIX that was previously Windows-only, and on aarch64 they run the full 410 assertions.

While re-running the suite on aarch64-linux hardware I hit a SIGSEGV at process finalization, after every assertion had passed (3/3 runs). It comes from the release address rather than from the pages themselves.

`_GetmemDualAccessPages()` returns the guard page start, so `__GetmemDualAccessPages` holds *base + one page*. Finalization passes that value to `_FreeLargeMem()`, which therefore covers `[base + 1 page, base + 3 pages)` instead of `[base, base + 2 pages)`.

On POSIX `munmap()` silently succeeds over the part that is not mapped, so the page immediately after the mapping is released even though it belongs to someone else. `/proc/self/maps` taken just before finalization shows an unrelated 416 KB mapping starting exactly at `base + 2 pages`, which is why the crash is reproducible. On Windows the effect is milder: `MEM_RELEASE` requires the exact `VirtualAlloc()` base, so the call simply returns FALSE with `ERROR_INVALID_ADDRESS` (verified) and the two pages leak.

`TTestCoreXml.SaxBoundaries` is a caller, so the regression test binary itself is affected on POSIX — it exits 139 after reporting all tests as passed.

The fix keeps the returned pointer as it is and only adjusts it at release time, mirroring the `inc(PByte(result), s)` in `_GetmemDualAccessPages()`.

Verified after the fix: 3/3 clean exits on aarch64-linux, and `TTestCoreXml` still green at 633 assertions / 0 failed on both FPC i386-win32 and FPC aarch64-linux. No test is added — the failure only shows at process finalization, which the test framework cannot observe from inside.
