### PR TITLE
core: avoid the deprecated vmtDestroy/vmtFreeInstance RTL constants

### DIFF
--- a/src/core/mormot.core.interfaces.pas
+++ b/src/core/mormot.core.interfaces.pas
@@ -7899,13 +7899,21 @@ begin
   next();
 end;
 
+const
+  // = the deprecated System.vmtFreeInstance, which Delphi replaced by the
+  // asm-only VMTOFFSET operator - verified to match the RTL value on 32/64-bit
+  // - CPP_ABI_ADJUST was introduced with Delphi XE2, and the RTL constant is
+  // not deprecated on older compilers, so it is used as-is there and on FPC
+  VMT_FREEINSTANCE = {$ifdef ISDELPHIXE2} -2 * SizeOf(pointer) - CPP_ABI_ADJUST
+                     {$else} vmtFreeInstance {$endif ISDELPHIXE2};
+
 constructor TSetWeakZero.Create(aClass: TClass);
 var
   P: PPtrUInt;
 begin
   // key = instance TObject, value = dynarray field(s) to be zeroed
   inherited Create(TypeInfo(TPointerDynArray), TypeInfo(TPointerDynArrayDynArray));
-  P := pointer(PAnsiChar(aClass) + vmtFreeInstance);
+  P := pointer(PAnsiChar(aClass) + VMT_FREEINSTANCE);
   if PPointer(P)^ = @TSetWeakZero.HookedFreeInstance then
     // hook once - Create may be done twice in GetWeakZero() for SetPrivateSlot
     exit;

--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -9235,6 +9235,14 @@ begin
   FreeMem(p);
 end;
 
+const
+  // = the deprecated System.vmtDestroy, which Delphi replaced by the asm-only
+  // VMTOFFSET operator - verified to match the RTL value on 32-bit and 64-bit
+  // - CPP_ABI_ADJUST was introduced with Delphi XE2, and the RTL constant is
+  // not deprecated on older compilers, so it is used as-is there and on FPC
+  VMT_DESTROY = {$ifdef ISDELPHIXE2} -SizeOf(pointer) - CPP_ABI_ADJUST
+                {$else} vmtDestroy {$endif ISDELPHIXE2};
+
 function SeemsRealObject(p: pointer): boolean;
 var
   i: PtrInt;
@@ -9245,7 +9253,7 @@ begin
     p := PPointer(p)^; // p = vmt
     if (not SeemsRealPointer(p)) or
        (PPtrInt(PAnsiChar(p) + vmtInstanceSize)^ < sizeof(pointer)) or
-       (PPtrInt(PAnsiChar(p) + vmtDestroy)^ = 0) then
+       (PPtrInt(PAnsiChar(p) + VMT_DESTROY)^ = 0) then
       exit;
     p := PPointer(PAnsiChar(p) + vmtClassName)^; // p = ClassName: PShortString
     if (not SeemsRealPointer(p)) or


### PR DESCRIPTION
### What

Two uses of the deprecated `vmt*` method-slot constants, replaced by the same offset computed from public constants:

| Unit | Site | Was |
| --- | --- | --- |
| `mormot.core.os` | `SeemsRealObject` | `vmtDestroy` |
| `mormot.core.interfaces` | `TSetWeakZero.Create` | `vmtFreeInstance` |

```pascal
VMT_DESTROY      = {$ifdef ISDELPHI} -SizeOf(pointer) - CPP_ABI_ADJUST     {$else} vmtDestroy      {$endif}
VMT_FREEINSTANCE = {$ifdef ISDELPHI} -2 * SizeOf(pointer) - CPP_ABI_ADJUST {$else} vmtFreeInstance {$endif}
```

Both are private to their unit's implementation section, so there is no new public API. FPC keeps using the RTL constants, which raise no hint there.

### Why

Delphi marks every `vmt*` *method*-slot constant as `deprecated 'Use VMTOFFSET in asm code'` — but `VMTOFFSET` only exists in `asm`, so Pascal code that walks a VMT has nothing to migrate to. The *data* slots this code also reads (`vmtInstanceSize`, `vmtClassName`, `vmtParent`) are **not** deprecated, so these two were the odd ones out.

The point is not the two warnings by themselves: it is that they are the last deprecated-symbol uses in the library outside the ones already in review. With #514 and #515 merged, the only one left is `Resume{%H-}` in `mormot.net.server` — after which `{$warn SYMBOL_DEPRECATED OFF}` in `mormot.defines.inc` could be dropped, and with it the risk of a genuinely deprecated RTL call going unnoticed. That directive's comment is also stale: it reads `// for faVolumeID`, and #513 removed the last `faVolumeID` use.

I left `Resume` alone deliberately — `Start` is its replacement, but the intent there is forcing `Execute` on a suspended thread, and that is a threading-semantics call for you rather than a mechanical substitution.

### Verified

- The arithmetic is asserted against the RTL at compile time, on Delphi 13.1 (compiler 37.0, build 37.0.59082.6021) for **both** Win32 and Win64:

  ```pascal
  {$if (-SizeOf(pointer) - CPP_ABI_ADJUST) <> vmtDestroy}
    {$message error 'vmtDestroy arithmetic mismatch'}
  {$ifend}
  {$if (-2 * SizeOf(pointer) - CPP_ABI_ADJUST) <> vmtFreeInstance}
    {$message error 'vmtFreeInstance arithmetic mismatch'}
  {$ifend}
  ```

  Both report a match. `CPP_ABI_ADJUST` is a public `System.pas` constant and carries no hint, so the expression stays correct under `CPP_ABI_SUPPORT` too.

- `mormot.core.os` and `mormot.core.interfaces` both compile clean on Win32 and Win64 with `SYMBOL_DEPRECATED` warnings deliberately re-enabled; the two `W1000` diagnostics are gone.
- **Not** run: the `mormot2tests` regression suite (this machine blocks launching freshly built executables). `TSetWeakZero` is the interface weak-reference hook, so its tests are the ones worth running before merging — happy to wait on that.
