### PR TITLE
core: make the USEPACKAGES conditional functional

### DIFF
--- a/src/mormot.defines.inc
+++ b/src/mormot.defines.inc
@@ -14,8 +14,12 @@
 
 {.$define USEPACKAGES}
 // define this if you compile the unit within a Delphi package
-// - it will avoid error like "[DCC Error] E2201 Need imported data reference
-// ($G) to access 'VarCopyProc'"
+// - it will enable {$IMPORTEDDATA ON} ($G+) for all our units at once, as
+// older Delphi compilers required it to access data from another package, e.g.
+// "[DCC Error] E2201 Need imported data reference ($G) to access 'VarCopyProc'"
+// - note: $G+ is the compiler default, and on Delphi 13.1 (compiler 37.0) this
+// error is not affected by the switch any more, so defining this conditional
+// has no observable effect on such a recent compiler
 // - shall be set at the package options level, and left untouched by default
 // - note: you should probably also set "Generate DCUs only" in Project Options
 // -> Delphi Compiler -> Output C/C++ -> C/C++ output file generation
@@ -534,6 +538,10 @@
   // -- global code generation conditionals
 
   {$A+} // force normal alignment, as expected by our units
+
+  {$ifdef USEPACKAGES}
+    {$IMPORTEDDATA ON} // $G+ is needed when compiled within a Delphi package
+  {$endif USEPACKAGES}
 
   {$ifdef UNICODE}
     {$define HASVARUSTRING}


### PR DESCRIPTION
### What

Makes the `USEPACKAGES` conditional do what it documents, as suggested in review.

Previously it documented itself as the fix for `E2201 Need imported data reference ($G) to access 'VarCopyProc'`, but nothing had read it since `77645ca93` (2020-03-29) removed its only reader (`{$ifdef USEPACKAGES}{$undef DOPATCHTRTL}{$endif}`) — so defining it could not have any effect. This PR originally proposed deleting the block; per review it now emits the switch instead.

### Change

`mormot.defines.inc`, in the Delphi *global code generation* section next to `{$A+}`:

```pascal
  {$ifdef USEPACKAGES}
    {$IMPORTEDDATA ON} // $G+ is needed when compiled within a Delphi package
  {$endif USEPACKAGES}
```

Placed inside the Delphi branch, so FPC never sees the directive. Defining `USEPACKAGES` now applies `$G+` to every mORMot unit at once, instead of relying on the package-level IDE option.

### Verified

Delphi 13.1 (compiler 37.0, build 37.0.59082.6021):

- `test/mormot2tests.dpr` full build, Win32 and Win64, with and without `USEPACKAGES`: 0 errors, byte-identical output (8,610,260 and 11,523,376 bytes code respectively).

### Important: on Delphi 13.1 this is inert

The conditional now genuinely emits the switch, but the switch does not affect E2201 on a current compiler. Tested against a real package boundary — `pkgdata.dcp` providing a global var, with its source and `.dcu` moved off the unit path so the `.dcp` is the only provider:

| access pattern | `$G-` | `$G+` | no directive | `{$IMPORTEDDATA ON}` |
| --- | --- | --- | --- | --- |
| plain read / write / `@Var` / var-param / `AtomicIncrement` | clean | clean | clean | clean |
| inline asm — `mov eax, GlobalVar` | **E2201** | **E2201** | **E2201** | **E2201** |
| statically initialized global — `var P: PInteger = @GlobalVar` | **E2201** | **E2201** | **E2201** | **E2201** |

The matrix is invariant across the switch state.

The mechanism: an imported data reference is an indirection through the import table, resolved at load time. Inline asm operands and statically initialized globals need a direct link-time address, which a package boundary cannot provide — so E2201 there reports a property of the construct, not of the switch, and `$G+` cannot help. Plain Pascal access on 37.0 always emits the indirection regardless of `$G`, so it can no longer fail.

This is consistent with the original comment's `VarCopyProc`: `VarCopyProc(Dest^, Source^)` in `mormot.core.rtti` is plain Pascal access, which older compilers did fail under `$G-` and which `$G+` did fix. Only Delphi 13.1 is installed here, so the older behaviour is not something I can verify.

The in-tree comment states this rather than implying the switch avoids the error:

```pascal
// - it will enable {$IMPORTEDDATA ON} ($G+) for all our units at once, as
// older Delphi compilers required it to access data from another package, e.g.
// "[DCC Error] E2201 Need imported data reference ($G) to access 'VarCopyProc'"
// - note: $G+ is the compiler default, and on Delphi 13.1 (compiler 37.0) this
// error is not affected by the switch any more, so defining this conditional
// has no observable effect on such a recent compiler
```

So this is an improvement over a comment prescribing a remedy with no reader, but it is not a fix for anything on a recent compiler. If you know which Delphi versions actually needed `$G+` here, that would settle whether the knob earns its place — dropping it, or bounding the note to a version range, are both reasonable and I am happy to reshape once more.

For context on the original motivation: we hit the misleading comment while configuring a build that compiles mORMot inside a BPL, enabled the conditional expecting it to act, and had to work out that it had no reader.
