### PR TITLE
core: fix TXmlParser duplicate method declarations

### DIFF
--- a/src/core/mormot.core.fmt.pas
+++ b/src/core/mormot.core.fmt.pas
@@ -334,12 +334,6 @@ type
     /// append the current Value as into a UTF-8 string
     // - on decoding error, raise EXmlException or returns false if xpoNoException
     function ValueAppendToUtf8(var Dest: RawUtf8): boolean;
-    /// append the current Name/Value attribute into a TDocVariant object
-    procedure AttributeToDocVariant(Dest: PDocVariantData);
-    /// raw recursive conversion of the current level into a TDocVariant object
-    // - fill from attributes and content, until the matching xtElementEnd
-    // - the supplied Dest^ should have been just allocated or ZeroClear()
-    procedure ToDocVariant(Dest: PDocVariantData);
     /// the offset of the current token in the input buffer
     // - could be used to store a position, then resume a scan from it
     function Position: PtrInt;


### PR DESCRIPTION
`1f4f2e2` ("core: some TXmlParser refactoring - no functional change, just code cleaning") moved `AttributeToDocVariant` and `ToDocVariant` into the `private` section of `TXmlParser`, but the public declarations added in `a525904` were left in place. The record therefore declares both methods twice, and `mormot.core.fmt.pas` no longer compiles:

```
mormot.core.fmt.pas(338) Error: E2254 Overloaded procedure 'AttributeToDocVariant' must be marked with the 'overload' directive
mormot.core.fmt.pas(342) Error: E2252 Method 'AttributeToDocVariant' with identical parameters already exists
mormot.core.fmt.pas(345) Error: E2252 Method 'ToDocVariant' with identical parameters already exists
mormot.core.fmt.pas(3966) Error: E2134 Type 'TEmoji' has no type info
mormot.core.fmt.pas(3967) Error: E2134 Type 'TEmoji' has no type info
mormot.core.fmt.pas(288) Error: E2065 Unsatisfied forward or external declaration: 'TXmlParser.AttributeToDocVariant'
mormot.core.fmt.pas(292) Error: E2065 Unsatisfied forward or external declaration: 'TXmlParser.ToDocVariant'
TSE.mORMot2.dpk(40) Fatal: F2063 Could not compile used unit 'mormot.core.fmt.pas'
```

The two `E2134` on `TEmoji` are collateral rather than a second defect — `TEmoji` is a plain contiguous enumeration, the unit sets no RTTI directives, and neither the type nor its `TypeInfo()` calls have changed since `ba1b221`. Clearing the duplication clears all seven errors.

## What this changes

Removes the public pair and keeps the `private` one the refactoring introduced. That looks like the intended direction: both methods take a raw `PDocVariantData`, and the only call sites are inside the record itself — `ConvertToVariant` and the `ToDocVariant` recursion — with no caller anywhere in `src` or `test`, so nothing outside is affected.

If they were meant to stay public instead, dropping the newly added `private` block compiles equally well; happy to switch this PR over if you prefer that resolution.

## Verification

Delphi 13.1 (dcc32 compiler version 37.0), Win32:

- `mormot.core.fmt.pas` compiles clean on its own (153319 lines, 0 errors, 0 hints — the `H2219 Private symbol ... declared but never used` hints reported for the duplicated declarations are gone too).
- The package that pulls the unit in builds and installs, Debug and Release, as does the rest of the library depending on it. The same build failed at `F2063` before this change.
