### PR TITLE
core: fix pending medium frees during shutdown

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -3600,15 +3600,26 @@ var
   medium, nextmedium: PMediumBlockPoolHeader;
   bin: PMediumFreeBlock;
   i: PtrInt;
+  {$ifdef FPCMM_REPORTMEMORYLEAKS}
   list, next: PPointer;
+  {$endif FPCMM_REPORTMEMORYLEAKS}
 begin
+  {$ifdef FPCMM_REPORTMEMORYLEAKS}
   list := Info.LastFree;
+  {$endif FPCMM_REPORTMEMORYLEAKS}
+  Info.LastFree := nil;
+  // All blocks in this list belong to pools released just below. A pending
+  // small-block pool has the same flag value as a large block, so the generic
+  // dispatcher would wrongly send it to FreeLargeBlock.
+  {$ifdef FPCMM_REPORTMEMORYLEAKS}
   while list <> nil do
   begin
     next := list^;
-    _FreeMem(list); // not a leak, just an unexpected context
+    PPtrUInt(PByte(list) - BlockHeaderSize)^ :=
+      PPtrUInt(PByte(list) - BlockHeaderSize)^ or IsFreeBlockFlag;
     list := next;
   end;
+  {$endif FPCMM_REPORTMEMORYLEAKS}
   medium := Info.PoolsCircularList.NextMediumBlockPoolHeader;
   while medium <> @Info.PoolsCircularList do
   begin


### PR DESCRIPTION
FreeMediumPool drains Info.LastFree through _FreeMem during shutdown.

A pending small-pool backing block has the same flag value as IsLargeBlockFlag, so _FreeMem may send it to FreeLargeBlock and crash with EAccessViolation.

At this point all medium pools are about to be released anyway. The fix detaches the pending list instead of freeing those blocks individually. Leak-reporting builds still mark them free before the final pool scan.

The affected queue, flag dispatch, and pool teardown are shared by Linux and Win64. Linux is only where the failure was reproduced.

Before: deterministic exit 217 in FreeLargeBlock.
After: clean exit.

Full mORMot suite: 196,813,598 assertions, zero failures.