### PR TITLE
core: fix large allocation capacity at exact boundaries

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -1449,7 +1449,7 @@ end;
 
 function ComputeLargeBlockSize(size: PtrUInt): PtrUInt; inline;
 begin
-  inc(size, LargeBlockHeaderSize - 1 + BlockHeaderSize);
+  inc(size, LargeBlockHeaderSize + BlockHeaderSize);
   // aligned_size := ((size + align - 1) AND (NOT (align - 1)))
   {$ifdef FPCMM_LARGEBIGALIGN}
   // on Linux, mremap() on PMD_SIZE=2MB aligned data make a huge speedup

--- a/test/test.core.base.pas
+++ b/test/test.core.base.pas
@@ -218,6 +218,10 @@ type
     procedure _TSynNameValue;
     /// test TRawUtf8Interning process
     procedure _TRawUtf8Interning;
+    {$ifdef FPC_X64MM}
+    /// validate the FPC x86_64 memory manager allocation capacity
+    procedure FpcX64MemoryManager;
+    {$endif FPC_X64MM}
     /// test T*ObjArray types and the ObjArray*() wrappers
     procedure _TObjArray;
     /// validate our optimized MoveFast/FillCharFast functions
@@ -352,6 +356,33 @@ procedure TTestCoreBase.Setup;
 begin
   RandomLecuyer(rnd);
 end;
+
+{$ifdef FPC_X64MM}
+
+procedure TTestCoreBase.FpcX64MemoryManager;
+const
+  Sizes: array[0 .. 13] of PtrUInt = (
+    264744, 264745,
+    327640, 327641, 327642,
+    655320, 655321, 655322,
+    4194264, 4194265, 4194266,
+    6291416, 6291417, 6291418);
+var
+  i: PtrInt;
+  p: pointer;
+begin
+  for i := 0 to high(Sizes) do
+  begin
+    p := GetMem(Sizes[i]);
+    try
+      Check(MemSize(p) >= Sizes[i], 'MemSize');
+    finally
+      FreeMem(p);
+    end;
+  end;
+end;
+
+{$endif FPC_X64MM}
 
 procedure TTestCoreBase._CamelCase;
 var


### PR DESCRIPTION
ComputeLargeBlockSize may allocate one byte less than requested at exact granularity boundaries.

The calculation subtracts one byte before adding the block header. Removing that subtraction preserves the requested capacity.

A regression test covering the affected boundaries is included.

Full mORMot suite: 197,086,543 assertions, zero failures.