### PR TITLE
core: advance to the next per-thread tiny arena

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -1659,7 +1659,7 @@ asm
         sub     rbx, r8
         sub     rbx, rcx
         jz      @Sml    // from Small[rcx] to Tiny[0][rcx]
-        lea     rax, [rax + rbx - TSmallBlockInfo.Tiny] // Tiny[+1][rcx]
+        lea     rax, [rax * 2 + rbx - TSmallBlockInfo.Tiny] // Tiny[+1][rcx]
 @Sml:   {$else}
         // fair distribution among calls to reduce thread contention
         {$ifdef FPCMM_BOOST}


### PR DESCRIPTION
When a thread's preferred tiny arena is busy, the retry calculation rebuilds the same arena address on every iteration.

As a result, the allocator tries the same arena 31 times and then falls back to a larger size class instead of checking the other arenas.

The one-instruction fix advances to the next arena while keeping the existing wrap-around mask.

Forced collision test:

- before: requested class capacity 136, returned capacity 152
- after: requested and returned capacity 136
- median allocation time: about 747 ns -> 41 ns

Full mORMot suite: 197,316,725 assertions, zero failures.