### PR TITLE
core: allocate medium prefetch lazily

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -3351,7 +3351,7 @@ begin
     medium.NextFreeBlock := medium;
   end;
   {$ifdef FPCMM_MEDIUMPREFETCH}
-  Info.Prefetch := OsAllocMedium(MediumBlockPoolSizeMem);
+  Info.Prefetch := nil;
   {$endif FPCMM_MEDIUMPREFETCH}
 end;
 


### PR DESCRIPTION
InitializeMediumPool currently allocates one 1.25 MiB prefetch mapping for every medium pool before that pool is used.

With FPCMM_BOOSTER this reserves 40 MiB of virtual address space during startup.

The existing refill path already allocates a medium pool when Prefetch is nil, and the cache and finalization paths already handle nil correctly. Initializing Prefetch to nil therefore makes the allocation lazy without adding a new path.

Empty process with FPCMM_BOOSTER:

- VmSize: 45,080 KiB -> 4,120 KiB
- VmRSS: unchanged at 2,480 KiB

Full mORMot suite: 197,300,621 assertions, zero failures.