### PR TITLE
core: detach pending small frees during shutdown

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -3661,15 +3661,19 @@ begin
   {$ifdef FPCMM_REPORTMEMORYLEAKS}
   leaks := 0;
   {$endif FPCMM_REPORTMEMORYLEAKS}
+  p := @SmallBlockInfo;
   for i := 0 to high(SmallBlockInfo.SmallLastFree) do
   begin
     list := SmallBlockInfo.SmallLastFree[i];
+    SmallBlockInfo.SmallLastFree[i] := nil;
+    p^.LastFreeCount := 0;
     while list <> nil do
     begin
       next := list^;
       _FreeMem(list); // not a leak, just an unexpected context
       list := next;
     end;
+    inc(p);
   end;
   p := @SmallBlockInfo;
   for i := 1 to NumSmallInfoBlock do


### PR DESCRIPTION
This is separate from #522. That PR fixed `TMediumBlockInfo.LastFree`; this one fixes `SmallBlockInfo.SmallLastFree`.

`FreeAllMemory` saves each `SmallLastFree[i]` head locally but leaves the shared head and the matching `LastFreeCount` unchanged.

When the saved node is passed to `_FreeMem`, the allocator may pop the same node again from the unchanged shared list. The node is then processed twice, and its small pool may be recycled while the finalizer still has pointers into it. This ends in an access violation or a spin inside `_FreeMem` during shutdown.

The fix detaches the shared head and clears its count before draining the saved list.

Deterministic reproduction with one pending small free:

- before: `count=1`, `EAccessViolation`, exit 217;
- after: 100/100 runs on Linux and Win64.

The natural 32-thread reproduction and the leak-report build also pass. Full mORMot suite: 197,182,220 assertions, zero failures.