### PR TITLE
core: fix invalid pointer on medium prefetch lock contention

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -1475,11 +1475,13 @@ asm
         xor     edx, edx
         mov     eax, $100
   lock  cmpxchg byte ptr [rcx].TMediumBlockInfo.PrefetchLocked, ah
-        jne     @ok
+        jne     @busy
         // just get the memory chunk - no need to call mmap/VirtualAlloc
         mov     rax, [rcx].TMediumBlockInfo.Prefetch
         mov     [rcx].TMediumBlockInfo.Prefetch, rdx
         mov     [rcx].TMediumBlockInfo.PrefetchLocked, dl
+        ret
+@busy:  xor     eax, eax
 @ok:
 end;
 


### PR DESCRIPTION
While investigating the remaining Medium sleep counter mentioned in #527, a concentrated contention test exposed a separate correctness bug in `TryAllocMediumPrefetch`.

## Cause

The byte `cmpxchg` starts with `EAX=$100`: `AL=0` is the expected lock value and `AH=1` is the desired value.

If another thread already owns `PrefetchLocked`, the failed `cmpxchg` writes the actual byte value 1 into `AL`, while `AH` remains 1. This leaves `RAX=$101`. The current `jne @ok` path returns that value as a pointer.

The caller sees a non-nil result, treats `$101` as a medium pool, and faults on the first header write.

The fix only returns nil when the lock attempt fails. The successful path and the existing ownership protocol are unchanged.

## Reproduction and validation

On a clean upstream checkout, without diagnostic instrumentation:

- 32 threads, 100,500-byte blocks, ring size 64, 100,000 rounds;
- reproduced under GDB on attempt 7;
- `R13=$101` in `AllocNewSequentialFeedMediumPool`.

A deterministic test of the actual internal function gives:

```text
old:   PREFETCH_LOCK_CONTRACT_FAIL result=0000000000000101
fixed: PREFETCH_LOCK_CONTRACT_PASS
```

After the fix:

- 20/20 focused runs passed with `FPCMM_BOOST`;
- 20/20 focused runs passed with `FPCMM_BOOSTER`;
- two complete mORMot gates passed: 18 classes and more than 128 million assertions each;
- the heavy MM qualification passed, including 12 million randomized operations, cross-thread ownership transfers, and a 30-second all-core phase;
- generated code was checked for both Linux x86-64 and Win64 x86-64.

## Follow-up on the Medium sleep counter

I also instrumented the four callers of `LockMediumBlocks` and ran `mormot2tests -t multithread` 12 times per variant:

| Variant | Median test time | Median user-medium OS waits |
|---|---:|---:|
| 4 arenas | 2.115 s | 4.5 |
| 8 arenas | 2.105 s | 0 |
| 4 arenas + `FPCMM_OSYIELD` | 2.115 s | 5 |
| 4 arenas + `FPCMM_CMPBEFORELOCK` | 2.110 s | 0.5 |

Eight arenas made the user-medium wait count zero in all 12 runs, but did not improve total test time. `FPCMM_OSYIELD` and `FPCMM_CMPBEFORELOCK` also showed no repeatable speed gain. So four arenas still look like the reasonable default.

P.S. And yes - without modern frontier agentic models this bug would have taken a little longer to find. The agents write tests, run them, and adjust them based on the results.

These days the temptation to make life easier is strong: first you stop writing code yourself, and then you risk stopping thinking as well. We try to enjoy the first without reaching the second. :)