### PR TITLE
core: fix AddXmlEscape() letting #31 through, and its outdated documentation

### DIFF
--- a/src/core/mormot.core.fmt.pas
+++ b/src/core/mormot.core.fmt.pas
@@ -135,8 +135,10 @@ function JsonToXml(const Json: RawUtf8; const Header: RawUtf8 = XMLUTF8_HEADER;
   const NameSpace: RawUtf8 = ''): RawUtf8;
 
 /// append some chars, escaping all XML special chars as expected
-// - i.e.   < > & " '  as   &lt; &gt; &amp; &quote; &apos;
-// - and all control chars (i.e. #1..#31) as &#..;
+// - i.e.   < > & " '  as   &lt; &gt; &amp; &quot; &apos;
+// - TAB, LF and CR are escaped as &#x09; &#x0a; &#x0d;
+// - the other control chars are just ignored, since #1..#8 #11 #12 #14..#31
+// are not allowed in any XML 1.0 document
 // - see @http://www.w3.org/TR/xml/#syntax
 procedure AddXmlEscape(W: TTextWriter; Text: PUtf8Char);
 
@@ -6922,7 +6924,7 @@ begin
   esc['"'] := 4;
   _AddHtmlEscape := __AddHtmlEscape;
   // XML Efficient Parsing
-  FillCharFast(XML_ESC, 31, 9); // ignore invalid #1 .. #31 control char
+  FillCharFast(XML_ESC, 32, 9); // ignore the invalid #0 .. #31 control chars
   esc := @XML_ESC; // XML_ESCAPED[] = &#x09 &#x0a &#x0d &lt &gt &amp &quot &apos
   esc[#0]   := 1;   // go out of loop to abort
   esc[#9]   := 1;

--- a/test/test.core.data.pas
+++ b/test/test.core.data.pas
@@ -8461,6 +8461,20 @@ begin
   CheckEqual(XmlEscape('& some'), '&amp; some');
   CheckEqual(XmlEscape('<&>'), '&lt;&amp;&gt;');
   CheckEqual(XmlEscape('a<b&c>d'), 'a&lt;b&amp;c&gt;d');
+  CheckEqual(XmlEscape('"'), '&quot;');
+  CheckEqual(XmlEscape(''''), '&apos;');
+  CheckEqual(XmlEscape('a"b''c'), 'a&quot;b&apos;c');
+  CheckEqual(XmlEscape(#9), '&#x09;');
+  CheckEqual(XmlEscape(#10), '&#x0a;');
+  CheckEqual(XmlEscape(#13), '&#x0d;');
+  CheckEqual(XmlEscape('a'#9'b'#10'c'#13'd'), 'a&#x09;b&#x0a;c&#x0d;d');
+  for i := 1 to 31 do
+    if not (i in [9, 10, 13]) then
+    begin
+      FastSetString(s, PAnsiChar('a b'), 3); // allocated, so writable below
+      PByteArray(s)[1] := i; // #1..#31 are not allowed in any XML 1.0 document
+      CheckEqual(XmlEscape(s), 'ab', 'ignored control char');
+    end;
 end;
 
 procedure TTestCoreProcess._TSelectStatement;


### PR DESCRIPTION
`FillCharFast(XML_ESC, 31, 9)` only fills the #0..#30 entries, so #31 was left at 0 and passed through verbatim - emitting a character which is not allowed in any XML 1.0 document. Filling 32 entries covers #0..#31 as the comment already claimed; `esc[#0]` is explicitly re-assigned just below, so the one extra entry is harmless.

The `AddXmlEscape()` documentation did not match the implementation either: the control chars are ignored, not emitted as `&#..;` - and `&quote;` was a typo for `&quot;`.

The escaping tests so far only covered `& < >`: this PR extends them with the two quotes, the TAB/LF/CR numeric escapes, and every #1..#31 control char. Without the one-character fix above, that new loop fails on #31 - and only on #31.

Verified on i386-win32 (FPC 3.2.3): red on the unpatched code with exactly one failure (`'a'#31'b'` instead of `'ab'`), then `Url encoding` 3,308 / 3,308 assertions passed and the whole `TTestCoreProcess` 0 / 14,930,942 failed, rebased onto current master (`e858c1da7`).
