### PR TITLE
core: fix XmlToVariant() xpoVariantGuessType corrupting text values

### DIFF
--- a/src/core/mormot.core.fmt.pas
+++ b/src/core/mormot.core.fmt.pas
@@ -245,7 +245,10 @@ type
   // which are silently skipped by default
   // - xpoKeepWhiteSpace would return xtText tokens made only of whitespace,
   // which are silently skipped by default
-  // - xpoVariantGuessType let XmlToVariant() recognize booleans and numbers
+  // - xpoVariantGuessType let XmlToVariant() recognize booleans and numbers,
+  // matching only exact JSON literals: anything else is kept as text, e.g.
+  // '1.2.3' '192.168.0.1' '007' or integers out of Int64 range (a 20-digit
+  // decimal identifier should not become an approximate double)
   TXmlParserOption = (
     xpoNoException,
     xpoStripNamespacePrefix,
@@ -2459,6 +2462,21 @@ begin
   ValueAppendToUtf8(RawUtf8(v^.VAny));
 end;
 
+function CanGuessType(txt: PUtf8Char): boolean;
+var
+  len: PtrInt;
+  i64: Int64;
+begin // keep e.g. '1.2.3' '192.168.0.1' '007' or 20-digit identifiers as text
+  len := PStrLen(txt - _STRLEN)^;
+  if IsInt64(txt, len) then
+    // ToInt64() fails on Int64 overflow (as in GetI): out-of-range integers
+    // should remain lossless text, not become an approximate double
+    result := ToInt64(RawUtf8(pointer(txt)), i64)
+  else
+    result := IsConstantJson(txt, len) or // exact null/true/false
+              IsNumberJson(txt);          // strict JSON number lexing
+end;
+
 procedure TXmlParser.ToDocVariant(Dest: PDocVariantData);
 var
   txt, v: pointer;
@@ -2492,6 +2510,8 @@ begin
     else
       Dest := pointer(Dest^.NewItem('#text'));
   if (xpoVariantGuessType in Options) and
+     ((txt = nil) or // void element -> null
+      CanGuessType(txt)) and
      GetVariantFromNotStringJson(txt, PVarData(Dest)^,
        dvoAllowDoubleValue in Dest^.Options) then
   begin

--- a/test/test.core.data.pas
+++ b/test/test.core.data.pas
@@ -9838,6 +9838,21 @@ begin
   CheckEqual(XmlToJson('<a/>', [xpoVariantGuessType]), '{"a":null}');
   CheckEqual(XmlToJson('<a>007</a>', [xpoVariantGuessType]), '{"a":"007"}');
   CheckEqual(XmlToJson('<a>H265</a>', [xpoVariantGuessType]), '{"a":"H265"}');
+  // dotted identifiers and IP addresses are no numbers
+  CheckEqual(XmlToJson('<a>1.2.3</a>', [xpoVariantGuessType]),
+    '{"a":"1.2.3"}');
+  CheckEqual(XmlToJson('<a>10.0.0.1</a>', [xpoVariantGuessType]),
+    '{"a":"10.0.0.1"}');
+  // integers out of Int64 range should remain lossless text
+  CheckEqual(XmlToJson('<a>1234567890123456789</a>', [xpoVariantGuessType]),
+    '{"a":1234567890123456789}');
+  CheckEqual(XmlToJson('<a>9223372036854775808</a>', [xpoVariantGuessType]),
+    '{"a":"9223372036854775808"}');
+  CheckEqual(XmlToJson('<a>-9223372036854775809</a>', [xpoVariantGuessType]),
+    '{"a":"-9223372036854775809"}');
+  CheckEqual(XmlToJson('<c><sipId>34020000001320000001</sipId>' +
+    '<port>5060</port></c>', [xpoVariantGuessType]),
+    '{"c":{"sipId":"34020000001320000001","port":5060}}');
   // TryXmlToVariant
   Check(TryXmlToVariant('<a><b>1</b></a>', doc) = xpeNone, 'try ok');
   CheckEqual(VariantSaveJson(doc), '{"a":{"b":"1"}}');

--- a/test/test.core.data.pas
+++ b/test/test.core.data.pas
@@ -9833,6 +9833,11 @@ begin
   CheckEqual(XmlToJson('<a>false</a>', [xpoVariantGuessType]), '{"a":false}');
   CheckEqual(XmlToJson('<a>false</a><a>7</a><a>hello</a>',
     [xpoVariantGuessType]), '{"a":[false,7,"hello"]}');
+  CheckEqual(XmlToJson('<a>5060</a>', [xpoVariantGuessType]), '{"a":5060}');
+  CheckEqual(XmlToJson('<a>12.79</a>', [xpoVariantGuessType]), '{"a":12.79}');
+  CheckEqual(XmlToJson('<a/>', [xpoVariantGuessType]), '{"a":null}');
+  CheckEqual(XmlToJson('<a>007</a>', [xpoVariantGuessType]), '{"a":"007"}');
+  CheckEqual(XmlToJson('<a>H265</a>', [xpoVariantGuessType]), '{"a":"H265"}');
   // TryXmlToVariant
   Check(TryXmlToVariant('<a><b>1</b></a>', doc) = xpeNone, 'try ok');
   CheckEqual(VariantSaveJson(doc), '{"a":{"b":"1"}}');


### PR DESCRIPTION
Following up on the #487 discussion about `xpoVariantGuessType` ("may be used only for some very proven data input"): even proven input can contain dotted identifiers or long decimal IDs, and the relaxed number parsing then corrupts them silently:

| input | guessed as |
|---|---|
| `1.2.3` | `0.123` |
| `10.0.0.1` | `0.10001` |
| `9223372036854775808` | `-9223372036854775808` (Int64 wrap) |
| `-9223372036854775809` | `9223372036854775807` (sign flip) |
| `34020000001320000001` (GB28181 SIP ID) | `3.4020000001320002E19` (lossy double) |

This PR adds a small `CanGuessType()` gate before `GetVariantFromNotStringJson()` in `TXmlParser.ToDocVariant`, reusing existing primitives only (`IsInt64` + `ToInt64` + `IsConstantJson` + `IsNumberJson`): only exact JSON literals are converted, and integer-looking text out of Int64 range remains lossless text rather than an approximate double - a 20-digit decimal is an identifier, not a measurement. `GetVariantFromNotStringJson()` itself is untouched, so JSON parsing is unaffected.

Two commits: the first only adds tests locking the agreed-safe envelope (green on current master), the second is the fix with 6 more tests - red before it on exactly the 5 corruptions above, green after. One deliberate consequence, documented in the interface comment: text with leading/trailing blanks is not guessed any more, as a side effect of the strict JSON lexing.

Verified on i386-win32 (FPC 3.2.3): whole `TTestCoreProcess` 0 / 14,929,618 failed, based on current master (`95127a13d`).
