### PR TITLE
core: fix memory corruption on small-block contention

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -945,7 +945,6 @@ const
   {$endif FPCMM_BOOSTER}
 
   NumSmallBlockTypes       = 46;
-  NumSmallBlockTypesUnique = NumSmallBlockTypes - 2; // last 2 are redundant
   MaximumSmallBlockSize    = 2608;
   NumTinyBlockTypes        =
      1 shl NumTinyBlockTypesPO2; // 8 (128B) or 16 (256B)
@@ -960,6 +959,9 @@ const
     MaximumSmallBlockSize, MaximumSmallBlockSize, MaximumSmallBlockSize);
 
   SmallBlockGranularity        = 16;
+  NumSmallBlockGranularitySlots =
+    (MaximumSmallBlockSize + SmallBlockGranularity - 1) div
+      SmallBlockGranularity;
   TargetSmallBlocksPerPool     = 48;
   MinimumSmallBlocksPerPool    = 12;
   SmallBlockDownsizeCheckAdder = 64;
@@ -1057,14 +1059,15 @@ type
   TSmallBlockInfo = record
     Small: TSmallBlockTypes;
     Tiny: array[0..NumTinyBlockArenas - 1] of TTinyBlockTypes;
-    GetmemLookup: array[0..
-      (MaximumSmallBlockSize - 1) div SmallBlockGranularity] of byte;
+    GetmemLookup: array[0..NumSmallBlockGranularitySlots - 1] of byte;
     // safe access to IsMultiThread global variable - accessed via GOT sub-call
     IsMultiThreadPtr: PBoolean;
     {$ifndef FPCMM_TINYPERTHREAD}
     TinyCurrentArena: integer;
     {$endif FPCMM_TINYPERTHREAD}
-    GetmemSleepCount: array[0..NumSmallBlockTypesUnique - 1] of cardinal;
+    // assembly indexes by BlockSize div SmallBlockGranularity,
+    // not by the irregular class ordinal
+    GetmemSleepCount: array[0..NumSmallBlockGranularitySlots - 1] of cardinal;
     // some fiedls here because there was no room in TSmallBlockType
     {$ifdef FPCMM_MULTIPLESMALLNOTWITHMEDIUM} // PMediumBlockInfo lookup
     SmallMediumBlockInfo: array[0..NumSmallInfoBlock - 1] of pointer;
@@ -3571,6 +3574,8 @@ begin
   SmallBlockInfo.IsMultiThreadPtr := @IsMultiThread; // call GOT if needed
   small := @SmallBlockInfo;
   assert(SizeOf(small^) = 1 shl SmallBlockTypePO2);  // exactly 64 bytes
+  assert(length(SmallBlockInfo.GetmemSleepCount) =
+    length(SmallBlockInfo.GetmemLookup));
   for a := 0 to NumTinyBlockArenas do
     for i := 0 to NumSmallBlockTypes - 1 do
     begin


### PR DESCRIPTION
## Cause

`GetmemSleepCount` has 44 entries, one per irregular unique small-block class, but both contention paths index it as `(BlockSize div 16) - 1`. For the 2608-byte class this is index 162, so the rare sleep-after-contention path writes into the following `TSmallBlockInfo` fields.

The mismatch was introduced when the former per-class counter was moved to the shared array in `0f23b9fcf9`.

## Fix

Use one `NumSmallBlockGranularitySlots` constant for both `GetmemLookup` and `GetmemSleepCount`, remove the now-unused unique-class count, and assert their shared index-domain invariant during MM initialization.

The allocator assembly and allocation hot path are unchanged. Static metadata grows by 476 bytes.

## Reproduction

With `FPCMM_SERVER` and `FPCMM_NOPAUSE`, 32 threads repeatedly execute `GetMem(2600)` / `FreeMem` and then read `CurrentHeapStatus` / `GetSmallBlockContention`.

- current master: 20/20 runs terminate with exit 217 after `small-sleeps=0 entries=0`
- fixed: 20/20 runs pass and report a non-zero counter for block size 2608

The same A/B result was reproduced on Win64 and Linux.

## Validation

- layout invariant: old source fails at initialization; fixed source passes O-, O2 and O3 on Win64
- focused contention regression: 20/20 passes on Win64 and 20/20 on Linux
- `TTestCoreBase._fpcx64mm`: 14/14 on Win64 (FPC 3.2.2) and Linux
- full Linux suite on the immediate pre-refactor parent: 202,489,279 assertions, 0 assertion failures; the existing `TTestCoreBase.Debugging` exception still leaves the process with exit 1
- current master full-suite compilation is independently blocked before tests by the unrelated missing `cvCrlFailed` identifier in today's crypt refactor
