### PR TITLE
New THttpServerGeneric.OnBodyDownload event to stream a request body

### DIFF
--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -193,6 +193,8 @@ const
   HTTP_GATEWAYTIMEOUT = 504;
   /// HTTP Status Code for "HTTP Version Not Supported"
   HTTP_HTTPVERSIONNONSUPPORTED = 505;
+  /// HTTP Status Code for "Insufficient Storage"
+  HTTP_INSUFFICIENTSTORAGE = 507;
 
   /// a fake response code, generated for client side panic failure/exception
   // - for it is the number of a man, and that number is 666

--- a/src/core/mormot.core.text.pas
+++ b/src/core/mormot.core.text.pas
@@ -10536,7 +10536,7 @@ end;
 
 const
   // last item is fake HTTP status 513 = 'Invalid Request'
-  INDEX_HTTP_INVALID = 46;
+  INDEX_HTTP_INVALID = 47;
   // sorted by actual usage order for WordScanIndex() in matching HTTP_CODE[]
   HTTP_REASON: array[0 .. INDEX_HTTP_INVALID] of RawUtf8 = (
    'OK',                                // HTTP_SUCCESS - should be first
@@ -10583,6 +10583,7 @@ const
    'Service Unavailable',               // HTTP_UNAVAILABLE
    'Gateway Timeout',                   // HTTP_GATEWAYTIMEOUT
    'HTTP Version Not Supported',        // HTTP_HTTPVERSIONNONSUPPORTED
+   'Insufficient Storage',              // HTTP_INSUFFICIENTSTORAGE
    'Network Authentication Required',   // 511
    'Client Side Connection Error',      // HTTP_CLIENTERROR = 666
    'Invalid Request');                  // last INDEX_HTTP_INVALID = 513
@@ -10631,6 +10632,7 @@ const
     HTTP_UNAVAILABLE,
     HTTP_GATEWAYTIMEOUT,
     HTTP_HTTPVERSIONNONSUPPORTED,
+    HTTP_INSUFFICIENTSTORAGE,
     511,
     HTTP_CLIENTERROR,
     513); // last INDEX_HTTP_INVALID = fake 'Invalid Request' fallback code

--- a/src/net/mormot.net.async.pas
+++ b/src/net/mormot.net.async.pas
@@ -1002,7 +1002,8 @@ type
     // handle ifProcessing flag
     procedure OnClose; override;
     // quickly reject incorrect requests (payload/timeout/OnBeforeBody)
-    function DoReject(status: integer): TPollAsyncSocketOnReadWrite;
+    function DoReject(status: integer;
+      const ExtraHeader: RawUtf8 = ''): TPollAsyncSocketOnReadWrite;
     function DecodeHeaders: integer; virtual; // e.g. hfConnectionUpgrade override
     function DoHeaders: TPollAsyncSocketOnReadWrite;
     function DoRequest: TPollAsyncSocketOnReadWrite;
@@ -4934,8 +4935,8 @@ begin
       fRemoteIP, fHttp.BearerToken, fHttp.ContentLength, fRequestFlags);
 end;
 
-function THttpAsyncServerConnection.DoReject(
-  status: integer): TPollAsyncSocketOnReadWrite;
+function THttpAsyncServerConnection.DoReject(status: integer;
+  const ExtraHeader: RawUtf8): TPollAsyncSocketOnReadWrite;
 var
   len: integer; // should not be PtrInt
 begin
@@ -4947,7 +4948,8 @@ begin
   end
   else
   begin
-    if fServer.ComputeRejectBody(fHttp.Content, fConnectionID, status) then
+    if fServer.ComputeRejectBody(
+         fHttp.Content, fConnectionID, status, ExtraHeader) then
       result := soContinue; // for grWwwAuthenticate
     len := length(fHttp.Content);
     Send(pointer(fHttp.Content), len); // no polling nor ProcessWrite
@@ -4975,6 +4977,8 @@ end;
 function THttpAsyncServerConnection.DoHeaders: TPollAsyncSocketOnReadWrite;
 var
   status: integer;
+  strm: TStream;
+  fn: TFileName;
 begin
   // finalize the headers
   result := soClose;
@@ -5006,7 +5010,41 @@ begin
     result := DoRequest;
   end
   else
+  begin
+    // allow OnBodyDownload callback to supply a stream for the body
+    if (fHttp.State in
+         [hrsGetBodyChunkedHexFirst, hrsGetBodyContentLengthFirst]) and
+       Assigned(fServer.fOnBodyDownload) then
+    begin
+      strm := fServer.fOnBodyDownload(fHttp.CommandUri, fHttp.CommandMethod,
+        fHttp.Headers, fHttp.ContentType, fRemoteIP, fHttp.ContentLength);
+      if strm <> nil then
+        if fHttp.ContentEncoding <> nil then
+        begin
+          // a streamed body does not support Content-Encoding: compression
+          fn := '';
+          if strm.InheritsFrom(TFileStreamEx) then
+            fn := TFileStreamEx(strm).FileName;
+          strm.Free;
+          if fn <> '' then
+            DeleteFile(fn); // remove the (void) spool file
+          result := DoReject(HTTP_UNSUPPORTEDMEDIATYPE,
+            'Accept-Encoding: identity'#13#10);
+          exit;
+        end
+        else
+        begin
+          // ProcessRead will download the body into this stream
+          fHttp.ContentStream := strm; // freed by ProcessDone/Reset on abort
+          include(fHttp.ResponseFlags, rfContentStreamNeedFree);
+          if strm.InheritsFrom(TFileStreamEx) then
+            fHttp.ContentInputName := TFileStreamEx(strm).FileName;
+          // needed to track and limit the cumulated chunked body size
+          fHttp.ContentMaxSize := fServer.MaximumAllowedContentLength;
+        end;
+    end;
     result := soContinue;
+  end;
 end;
 
 function THttpAsyncServerConnection.DoRequest: TPollAsyncSocketOnReadWrite;
@@ -5022,6 +5060,15 @@ begin
          (fHttp.State in [hrsGetCommand, hrsUpgraded]) then
         exit; // rejected or upgraded to WebSockets
     end;
+  // close any body stream supplied by OnBodyDownload before the response
+  // process could reuse the ContentStream field - a spooled file remains
+  // available (as InContent file name) during the request processing
+  if (fHttp.ContentStream <> nil) and
+     (rfContentStreamNeedFree in fHttp.ResponseFlags) then
+  begin
+    FreeAndNilSafe(fHttp.ContentStream);
+    exclude(fHttp.ResponseFlags, rfContentStreamNeedFree);
+  end;
   // optionaly uncompress content
   if fHttp.ContentEncoding <> nil then
     fHttp.UncompressData;

--- a/src/net/mormot.net.async.pas
+++ b/src/net/mormot.net.async.pas
@@ -1004,6 +1004,8 @@ type
     // quickly reject incorrect requests (payload/timeout/OnBeforeBody)
     function DoReject(status: integer;
       const ExtraHeader: RawUtf8 = ''): TPollAsyncSocketOnReadWrite;
+    // implement fServer.OnBodyDownload event - may reject as 415
+    function DoBodyDownload: TPollAsyncSocketOnReadWrite; virtual;
     function DecodeHeaders: integer; virtual; // e.g. hfConnectionUpgrade override
     function DoHeaders: TPollAsyncSocketOnReadWrite;
     function DoRequest: TPollAsyncSocketOnReadWrite;
@@ -4974,11 +4976,43 @@ begin
   end;
 end;
 
+function THttpAsyncServerConnection.DoBodyDownload: TPollAsyncSocketOnReadWrite;
+var
+  strm: TStream;
+  fn: TFileName; // managed local variables are on purpose in this sub-method
+begin
+  result := soContinue;
+  strm := fServer.fOnBodyDownload(fHttp.CommandUri, fHttp.CommandMethod,
+    fHttp.Headers, fHttp.ContentType, fRemoteIP, fHttp.ContentLength);
+  if strm = nil then
+    exit; // in-memory Content buffering
+  if fHttp.ContentEncoding <> nil then
+  begin
+    // a streamed body does not support Content-Encoding: compression
+    fn := '';
+    if strm.InheritsFrom(TFileStreamEx) then
+      fn := TFileStreamEx(strm).FileName;
+    strm.Free;
+    if fn <> '' then
+      DeleteFile(fn); // remove the (void) spool file
+    result := DoReject(HTTP_UNSUPPORTEDMEDIATYPE,
+      'Accept-Encoding: identity'#13#10);
+  end
+  else
+  begin
+    // ProcessRead will download the body into this stream
+    fHttp.ContentStream := strm; // freed by ProcessDone/Reset on abort
+    include(fHttp.ResponseFlags, rfContentStreamNeedFree);
+    if strm.InheritsFrom(TFileStreamEx) then
+      fHttp.ContentInputName := TFileStreamEx(strm).FileName;
+    // needed to track and limit the cumulated chunked body size
+    fHttp.ContentMaxSize := fServer.MaximumAllowedContentLength;
+  end;
+end;
+
 function THttpAsyncServerConnection.DoHeaders: TPollAsyncSocketOnReadWrite;
 var
   status: integer;
-  strm: TStream;
-  fn: TFileName;
 begin
   // finalize the headers
   result := soClose;
@@ -5012,38 +5046,11 @@ begin
   else
   begin
     // allow OnBodyDownload callback to supply a stream for the body
+    result := soContinue;
     if (fHttp.State in
          [hrsGetBodyChunkedHexFirst, hrsGetBodyContentLengthFirst]) and
        Assigned(fServer.fOnBodyDownload) then
-    begin
-      strm := fServer.fOnBodyDownload(fHttp.CommandUri, fHttp.CommandMethod,
-        fHttp.Headers, fHttp.ContentType, fRemoteIP, fHttp.ContentLength);
-      if strm <> nil then
-        if fHttp.ContentEncoding <> nil then
-        begin
-          // a streamed body does not support Content-Encoding: compression
-          fn := '';
-          if strm.InheritsFrom(TFileStreamEx) then
-            fn := TFileStreamEx(strm).FileName;
-          strm.Free;
-          if fn <> '' then
-            DeleteFile(fn); // remove the (void) spool file
-          result := DoReject(HTTP_UNSUPPORTEDMEDIATYPE,
-            'Accept-Encoding: identity'#13#10);
-          exit;
-        end
-        else
-        begin
-          // ProcessRead will download the body into this stream
-          fHttp.ContentStream := strm; // freed by ProcessDone/Reset on abort
-          include(fHttp.ResponseFlags, rfContentStreamNeedFree);
-          if strm.InheritsFrom(TFileStreamEx) then
-            fHttp.ContentInputName := TFileStreamEx(strm).FileName;
-          // needed to track and limit the cumulated chunked body size
-          fHttp.ContentMaxSize := fServer.MaximumAllowedContentLength;
-        end;
-    end;
-    result := soContinue;
+      result := DoBodyDownload;
   end;
 end;
 

--- a/src/net/mormot.net.async.pas
+++ b/src/net/mormot.net.async.pas
@@ -4748,71 +4748,58 @@ begin
     st.P := fRd.Buffer;
     st.Len := fRd.Len;
     // process one request (or several in case of pipelined input/output)
-    try
-      while fHttp.ProcessRead(st, {returnOnStateChange=}false) do
-      begin
-        // handle main steps change
-        case fHttp.State of
-          hrsGetBodyChunkedHexFirst,
-          hrsGetBodyContentLengthFirst:
-            // received command + all headers
-            if not (nfHeadersParsed in fHttp.HeaderFlags) then
-              result := DoHeaders;
-          hrsWaitProcessing:
-            // received command + all headers + body (if any)
-            begin
-              // detect pipelined GET input
-              if st.Len <> 0 then // there are still data in the input read buffer
-                if (fPipelineState = [pEnabled]) and // no pWrite yet
-                   (fKeepAliveMaxSec > 0) and
-                   not (hfConnectionClose in fHttp.HeaderFlags) then
-                  // DoRequest should gather output in fWr
-                  include(fPipelineState, pWrite);
-                  // note: if hsoEnablePipelining is not set, will continue
-              // = DoHeader (if needed) + call fServer.DoRequest() callback
-              result := DoRequest;
-            end
-        else
+    while fHttp.ProcessRead(st, {returnOnStateChange=}false) do
+    begin
+      // handle main steps change
+      case fHttp.State of
+        hrsGetBodyChunkedHexFirst,
+        hrsGetBodyContentLengthFirst:
+          // received command + all headers
+          if not (nfHeadersParsed in fHttp.HeaderFlags) then
+            result := DoHeaders;
+        hrsWaitProcessing:
+          // received command + all headers + body (if any)
           begin
-            fOwner.DoLog(sllWarning, 'OnRead: close connection after % (before=%)',
-              [HTTP_STATE[fHttp.State], HTTP_STATE[previous]], self);
-            if fHttp.State = hrsErrorPayloadTooLarge then
-              DoReject(HTTP_PAYLOADTOOLARGE) // e.g. chunked over ContentMaxSize
-            else
-              DoReject(HTTP_BADREQUEST);
-            result := soClose;
+            // detect pipelined GET input
+            if st.Len <> 0 then // there are still data in the input read buffer
+              if (fPipelineState = [pEnabled]) and // no pWrite yet
+                 (fKeepAliveMaxSec > 0) and
+                 not (hfConnectionClose in fHttp.HeaderFlags) then
+                // DoRequest should gather output in fWr
+                include(fPipelineState, pWrite);
+                // note: if hsoEnablePipelining is not set, will continue
+            // = DoHeader (if needed) + call fServer.DoRequest() callback
+            result := DoRequest;
+          end
+      else
+        begin
+          fOwner.DoLog(sllWarning, 'OnRead: close connection after % (before=%)',
+            [HTTP_STATE[fHttp.State], HTTP_STATE[previous]], self);
+          case fHttp.State of
+            hrsErrorPayloadTooLarge:
+              DoReject(HTTP_PAYLOADTOOLARGE); // e.g. chunked over ContentMaxSize
+            hrsErrorContentStreamWrite:
+              DoReject(HTTP_INSUFFICIENTSTORAGE); // e.g. ENOSPC on spool file
+          else
+            DoReject(HTTP_BADREQUEST);
           end;
-        end;
-        if pWrite in fPipelineState then
-        begin
-          if fWr.Len > 128 shl 10 then
-            // flush when got more than 128KB of pending output
-            if FlushPipelinedWrite <> soContinue then
-              result := soClose;
-          if (result <> soContinue) or
-             (fHttp.State in [hrsWaitAsyncProcessing, hrsUpgraded]) then
-            break; // rejected, async or upgraded
-        end
-        else if (result <> soContinue) or
-                (fHttp.State in [hrsGetCommand, hrsWaitAsyncProcessing, hrsUpgraded]) then
-          break; // rejected, authenticated, async or upgraded
-        previous := fHttp.State;
-      end;
-    except
-      on E: EStreamError do
-        if (fHttp.State in HTTP_REQUEST_READ) and
-           (fHttp.ContentStream <> nil) and
-           (rfContentStreamNeedFree in fHttp.ResponseFlags) then
-        begin
-          // e.g. ENOSPC when spooling into a TOnHttpServerBodyDownload stream:
-          // notify the client - as best effort - before closing the connection
-          fOwner.DoLog(sllWarning, 'OnRead: % when downloading the body',
-            [PClass(E)^], self);
-          DoReject(HTTP_INSUFFICIENTSTORAGE);
           result := soClose;
-        end
-        else
-          raise; // e.g. from the response process: close the connection
+        end;
+      end;
+      if pWrite in fPipelineState then
+      begin
+        if fWr.Len > 128 shl 10 then
+          // flush when got more than 128KB of pending output
+          if FlushPipelinedWrite <> soContinue then
+            result := soClose;
+        if (result <> soContinue) or
+           (fHttp.State in [hrsWaitAsyncProcessing, hrsUpgraded]) then
+          break; // rejected, async or upgraded
+      end
+      else if (result <> soContinue) or
+              (fHttp.State in [hrsGetCommand, hrsWaitAsyncProcessing, hrsUpgraded]) then
+        break; // rejected, authenticated, async or upgraded
+      previous := fHttp.State;
     end;
     // no more available input
     if pWrite in fPipelineState then // time to flush the pipelined responses

--- a/src/net/mormot.net.async.pas
+++ b/src/net/mormot.net.async.pas
@@ -4776,7 +4776,10 @@ begin
           begin
             fOwner.DoLog(sllWarning, 'OnRead: close connection after % (before=%)',
               [HTTP_STATE[fHttp.State], HTTP_STATE[previous]], self);
-            DoReject(HTTP_BADREQUEST);
+            if fHttp.State = hrsErrorPayloadTooLarge then
+              DoReject(HTTP_PAYLOADTOOLARGE) // e.g. chunked over ContentMaxSize
+            else
+              DoReject(HTTP_BADREQUEST);
             result := soClose;
           end;
         end;
@@ -4997,10 +5000,14 @@ function THttpAsyncServerConnection.DoBodyDownload: TPollAsyncSocketOnReadWrite;
 var
   strm: TStream;
   fn: TFileName; // managed local variables are on purpose in this sub-method
+  len: Int64;
 begin
   result := soContinue;
+  len := fHttp.ContentLength;
+  if hfTransferChunked in fHttp.HeaderFlags then
+    len := -1; // a chunked body size is not known in advance
   strm := fServer.fOnBodyDownload(fHttp.CommandUri, fHttp.CommandMethod,
-    fHttp.Headers, fHttp.ContentType, fRemoteIP, fHttp.ContentLength);
+    fHttp.Headers, fHttp.ContentType, fRemoteIP, len);
   if strm = nil then
     exit; // in-memory Content buffering
   if fHttp.ContentEncoding <> nil then

--- a/src/net/mormot.net.async.pas
+++ b/src/net/mormot.net.async.pas
@@ -4748,51 +4748,63 @@ begin
     st.P := fRd.Buffer;
     st.Len := fRd.Len;
     // process one request (or several in case of pipelined input/output)
-    while fHttp.ProcessRead(st, {returnOnStateChange=}false) do
-    begin
-      // handle main steps change
-      case fHttp.State of
-        hrsGetBodyChunkedHexFirst,
-        hrsGetBodyContentLengthFirst:
-          // received command + all headers
-          if not (nfHeadersParsed in fHttp.HeaderFlags) then
-            result := DoHeaders;
-        hrsWaitProcessing:
-          // received command + all headers + body (if any)
-          begin
-            // detect pipelined GET input
-            if st.Len <> 0 then // there are still data in the input read buffer
-              if (fPipelineState = [pEnabled]) and // no pWrite yet
-                 (fKeepAliveMaxSec > 0) and
-                 not (hfConnectionClose in fHttp.HeaderFlags) then
-                // DoRequest should gather output in fWr
-                include(fPipelineState, pWrite);
-                // note: if hsoEnablePipelining is not set, will continue
-            // = DoHeader (if needed) + call fServer.DoRequest() callback
-            result := DoRequest;
-          end
-      else
-        begin
-          fOwner.DoLog(sllWarning, 'OnRead: close connection after % (before=%)',
-            [HTTP_STATE[fHttp.State], HTTP_STATE[previous]], self);
-          DoReject(HTTP_BADREQUEST);
-          result := soClose;
-        end;
-      end;
-      if pWrite in fPipelineState then
+    try
+      while fHttp.ProcessRead(st, {returnOnStateChange=}false) do
       begin
-        if fWr.Len > 128 shl 10 then
-          // flush when got more than 128KB of pending output
-          if FlushPipelinedWrite <> soContinue then
+        // handle main steps change
+        case fHttp.State of
+          hrsGetBodyChunkedHexFirst,
+          hrsGetBodyContentLengthFirst:
+            // received command + all headers
+            if not (nfHeadersParsed in fHttp.HeaderFlags) then
+              result := DoHeaders;
+          hrsWaitProcessing:
+            // received command + all headers + body (if any)
+            begin
+              // detect pipelined GET input
+              if st.Len <> 0 then // there are still data in the input read buffer
+                if (fPipelineState = [pEnabled]) and // no pWrite yet
+                   (fKeepAliveMaxSec > 0) and
+                   not (hfConnectionClose in fHttp.HeaderFlags) then
+                  // DoRequest should gather output in fWr
+                  include(fPipelineState, pWrite);
+                  // note: if hsoEnablePipelining is not set, will continue
+              // = DoHeader (if needed) + call fServer.DoRequest() callback
+              result := DoRequest;
+            end
+        else
+          begin
+            fOwner.DoLog(sllWarning, 'OnRead: close connection after % (before=%)',
+              [HTTP_STATE[fHttp.State], HTTP_STATE[previous]], self);
+            DoReject(HTTP_BADREQUEST);
             result := soClose;
-        if (result <> soContinue) or
-           (fHttp.State in [hrsWaitAsyncProcessing, hrsUpgraded]) then
-          break; // rejected, async or upgraded
-      end
-      else if (result <> soContinue) or
-              (fHttp.State in [hrsGetCommand, hrsWaitAsyncProcessing, hrsUpgraded]) then
-        break; // rejected, authenticated, async or upgraded
-      previous := fHttp.State;
+          end;
+        end;
+        if pWrite in fPipelineState then
+        begin
+          if fWr.Len > 128 shl 10 then
+            // flush when got more than 128KB of pending output
+            if FlushPipelinedWrite <> soContinue then
+              result := soClose;
+          if (result <> soContinue) or
+             (fHttp.State in [hrsWaitAsyncProcessing, hrsUpgraded]) then
+            break; // rejected, async or upgraded
+        end
+        else if (result <> soContinue) or
+                (fHttp.State in [hrsGetCommand, hrsWaitAsyncProcessing, hrsUpgraded]) then
+          break; // rejected, authenticated, async or upgraded
+        previous := fHttp.State;
+      end;
+    except
+      on E: EStreamError do
+      begin
+        // e.g. ENOSPC when spooling into a TOnHttpServerBodyDownload stream:
+        // notify the client - as best effort - before closing the connection
+        fOwner.DoLog(sllWarning, 'OnRead: % when downloading the body',
+          [PClass(E)^], self);
+        DoReject(HTTP_INSUFFICIENTSTORAGE);
+        result := soClose;
+      end;
     end;
     // no more available input
     if pWrite in fPipelineState then // time to flush the pipelined responses

--- a/src/net/mormot.net.async.pas
+++ b/src/net/mormot.net.async.pas
@@ -4797,14 +4797,19 @@ begin
       end;
     except
       on E: EStreamError do
-      begin
-        // e.g. ENOSPC when spooling into a TOnHttpServerBodyDownload stream:
-        // notify the client - as best effort - before closing the connection
-        fOwner.DoLog(sllWarning, 'OnRead: % when downloading the body',
-          [PClass(E)^], self);
-        DoReject(HTTP_INSUFFICIENTSTORAGE);
-        result := soClose;
-      end;
+        if (fHttp.State in HTTP_REQUEST_READ) and
+           (fHttp.ContentStream <> nil) and
+           (rfContentStreamNeedFree in fHttp.ResponseFlags) then
+        begin
+          // e.g. ENOSPC when spooling into a TOnHttpServerBodyDownload stream:
+          // notify the client - as best effort - before closing the connection
+          fOwner.DoLog(sllWarning, 'OnRead: % when downloading the body',
+            [PClass(E)^], self);
+          DoReject(HTTP_INSUFFICIENTSTORAGE);
+          result := soClose;
+        end
+        else
+          raise; // e.g. from the response process: close the connection
     end;
     // no more available input
     if pWrite in fPipelineState then // time to flush the pipelined responses

--- a/src/net/mormot.net.async.pas
+++ b/src/net/mormot.net.async.pas
@@ -4777,7 +4777,10 @@ begin
             [HTTP_STATE[fHttp.State], HTTP_STATE[previous]], self);
           case fHttp.State of
             hrsErrorPayloadTooLarge:
-              DoReject(HTTP_PAYLOADTOOLARGE); // e.g. chunked over ContentMaxSize
+              begin
+                fServer.IncStat(grOversizedPayload); // e.g. over ContentMaxSize
+                DoReject(HTTP_PAYLOADTOOLARGE);
+              end;
             hrsErrorContentStreamWrite:
               DoReject(HTTP_INSUFFICIENTSTORAGE); // e.g. ENOSPC on spool file
           else
@@ -5060,6 +5063,7 @@ begin
     result := soContinue;
     if (fHttp.State in
          [hrsGetBodyChunkedHexFirst, hrsGetBodyContentLengthFirst]) and
+       not (hfConnectionUpgrade in fHttp.HeaderFlags) and
        Assigned(fServer.fOnBodyDownload) then
       result := DoBodyDownload;
   end;

--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -808,6 +808,12 @@ type
   // registered compression algorithm - can not be streamed, and is rejected
   // as HTTP_UNSUPPORTEDMEDIATYPE = 415; an unknown/unregistered encoding is
   // spooled verbatim, exactly as the in-memory process would supply it
+  // - if writing to the stream fails (e.g. on a full disk), the request is
+  // aborted as HTTP_INSUFFICIENTSTORAGE = 507 - notified as best effort,
+  // since the client may still be sending - and the connection is closed
+  // - on a broken connection, the stream is released and any spool file
+  // deleted, but maybe deferred until the connection instance is actually
+  // released (e.g. after the THttpAsyncServer connections GC)
   TOnHttpServerBodyDownload = function(const aUrl, aMethod, aInHeaders,
     aInContentType, aRemoteIP: RawUtf8; aContentLength: Int64): TStream of object;
 

--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -809,8 +809,12 @@ type
   // STATICFILE_CONTENT_TYPE and InContent set to the local file name (mirroring
   // the response process), and the file is deleted once the request has been
   // processed - a handler can rename/move the file to take data ownership
-  // - for any other TStream class, the callback should keep its own reference
-  // to the instance to access the received data (InContent remains void)
+  // - any other TStream class is freed once the body has been received, i.e.
+  // before OnRequest is called: such a stream should therefore write into
+  // some independently owned storage (e.g. a database or a memory mapped
+  // file), and the instance itself should not be accessed after the download
+  // - aInHeaders is the raw headers text, which also includes the 'RemoteIP:'
+  // header on THttpServer, but not (yet) on THttpAsyncServer: use aRemoteIP
   // - the original Content-Type header is still available from InHeaders
   // - a compressed body - i.e. with a Content-Encoding: header matching a
   // registered compression algorithm - can not be streamed, and is rejected
@@ -3459,6 +3463,8 @@ begin
   ProgressiveID := 0;
   ProgressiveTix := 0;
   fProgressivePosition := 0;
+  fContentLeft := 0; // paranoid: a rejected body may have left it <> 0
+  fContentPos := nil;
 end;
 
 procedure THttpRequestContext.GetTrimmed(P, P2: PUtf8Char; L: PtrInt;
@@ -3912,6 +3918,8 @@ procedure THttpRequestContext.ProcessInit;
 begin // all other fields are expected to be filled with 0/nil/''
   RangeLength := -1;
   ContentLength := -1; // not yet parsed
+  fContentLeft := 0;   // e.g. if a previous body was rejected in the middle
+  fContentPos := nil;
   State := hrsGetCommand;
 end;
 
@@ -3997,8 +4005,11 @@ begin
           else
             // void line: we reached end of headers
             if hfTransferChunked in HeaderFlags then
+            begin
               // process chunked body
-              State := hrsGetBodyChunkedHexFirst
+              ContentLength := 0; // any Content-Length: is ignored when chunked
+              State := hrsGetBodyChunkedHexFirst;
+            end
             else if ContentLength > 0 then // -1 = no Content-Length: header
               // regular process with explicit content-length
               State := hrsGetBodyContentLengthFirst
@@ -4772,7 +4783,12 @@ begin
       // keep the original type: only 'application/json' is not in the headers
       AppendLine(fInHeaders, ['Content-Type: ', fInContentType]);
     fInContentType := STATICFILE_CONTENT_TYPE;
-  end;
+  end
+  else if PropNameEquals(fInContentType, STATICFILE_CONTENT_TYPE) then
+    // paranoid: '!' is a valid token char, so a client could have sent this
+    // content type by itself - never let InContent be seen as a local file
+    // name by a callback expecting a TOnHttpServerBodyDownload spooled body
+    FastAssignNew(fInContentType);
 end;
 
 procedure THttpServerRequestAbstract.PrepareDirect(

--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -612,6 +612,10 @@ type
   /// exception class raised during HTTP process
   EHttpSocket = class(ESynException);
 
+  /// exception raised when an incoming request body overflows a size limit
+  // - so that the server could return 413 "Payload Too Large" before closing
+  EHttpSocketOverflow = class(EHttpSocket);
+
   /// parent of THttpClientSocket and THttpServerSocket classes
   // - contain properties for implementing HTTP/1.1 using the Socket API
   // - handle chunking of body content
@@ -789,10 +793,13 @@ type
   // - should return a stream instance to receive the incoming request body,
   // e.g. a TFileStreamEx spooling into a local temporary file, or nil to
   // fallback to the default in-memory Content buffering
+  // - aContentLength is the incoming Content-Length: header value, or -1 for
+  // a chunked body, whose final size is not known in advance
   // - returning a stream disables the 1GB in-memory body size limit, so that
   // huge file uploads can be processed with a constant memory usage: only
   // THttpServerGeneric.MaximumAllowedContentLength applies (0 = no limit),
-  // which is also enforced on the cumulated size of a chunked body
+  // which is also enforced on the cumulated size of a chunked body,
+  // rejected as HTTP_PAYLOADTOOLARGE = 413 while it is received
   // - only a body with a Content-Length: header or chunked Transfer-Encoding
   // is streamed: the deprecated HTTP/1.0 close-delimited body is not
   // - the stream is owned by the server, and will be freed once the body has
@@ -4588,10 +4595,10 @@ begin
         break;      // reached the end of input stream
       end;
       if len > MaxHttpChunkSize then // allow up to 256 MB chunk
-        EHttpSocket.RaiseUtf8('%.GetBody: chunk size=% overflow', [self, len]);
+        EHttpSocketOverflow.RaiseUtf8('%.GetBody: chunk size=% overflow', [self, len]);
       if (Http.ContentMaxSize > 0) and
          (Http.ContentLength + len > Http.ContentMaxSize) then
-        EHttpSocket.RaiseUtf8('%.GetBody: chunked size overflow', [self]);
+        EHttpSocketOverflow.RaiseUtf8('%.GetBody: chunked size overflow', [self]);
       if DestStream <> nil then
       begin
         if length({%H-}chunk) < len then

--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -3463,8 +3463,8 @@ begin
   ProgressiveID := 0;
   ProgressiveTix := 0;
   fProgressivePosition := 0;
-  fContentLeft := 0; // paranoid: a rejected body may have left it <> 0
-  fContentPos := nil;
+  fContentLeft := 0; // a body rejected in the middle may have left it <> 0
+  fContentPos := nil; // ProcessInit expects those fields to be 0/nil
 end;
 
 procedure THttpRequestContext.GetTrimmed(P, P2: PUtf8Char; L: PtrInt;
@@ -3918,8 +3918,6 @@ procedure THttpRequestContext.ProcessInit;
 begin // all other fields are expected to be filled with 0/nil/''
   RangeLength := -1;
   ContentLength := -1; // not yet parsed
-  fContentLeft := 0;   // e.g. if a previous body was rejected in the middle
-  fContentPos := nil;
   State := hrsGetCommand;
 end;
 

--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -306,6 +306,7 @@ type
     hrsConnect,
     hrsSendHeaders,
     hrsErrorPayloadTooLarge,
+    hrsErrorContentStreamWrite,
     hrsErrorRejected,
     hrsErrorMisuse,
     hrsErrorUnsupportedRange,
@@ -4051,7 +4052,15 @@ begin
           else
             st.LineLen := fContentLeft;
           if ContentStream <> nil then
-            ContentStream.WriteBuffer(st.P^, st.LineLen)
+            try
+              ContentStream.WriteBuffer(st.P^, st.LineLen);
+            except
+              on EStreamError do
+              begin
+                State := hrsErrorContentStreamWrite; // e.g. ENOSPC -> 507
+                break;
+              end;
+            end
           else
           begin
             MoveFast(st.P^, fContentPos^, st.LineLen);
@@ -4099,7 +4108,15 @@ begin
             inc(fContentPos, st.LineLen);
           end
           else
-            ContentStream.WriteBuffer(st.P^, st.LineLen);
+            try
+              ContentStream.WriteBuffer(st.P^, st.LineLen);
+            except
+              on EStreamError do
+              begin
+                State := hrsErrorContentStreamWrite; // e.g. ENOSPC -> 507
+                break;
+              end;
+            end;
           State := hrsGetBodyContentLengthNext;
           inc(st.P, st.LineLen); // consume the body bytes (e.g. for pipelining)
           dec(st.Len, st.LineLen);

--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -459,6 +459,17 @@ type
     /// stream-oriented alternative to the Content in-memory buffer
     // - is typically a TFileStreamEx
     ContentStream: TStream;
+    /// local file name of a request body spooled by TOnHttpServerBodyDownload
+    // - this file is deleted by ProcessDone or Reset, i.e. once the request
+    // has been processed, unless the handler did rename/move it meanwhile
+    ContentInputName: TFileName;
+    /// maximum cumulated size of a chunked body written into ContentStream
+    // - as set e.g. from THttpServerGeneric.MaximumAllowedContentLength when
+    // TOnHttpServerBodyDownload supplied a stream, since - in contrast to a
+    // Content-Length - the final size of a chunked body is not known in
+    // advance, so can not be checked from the headers
+    // - 0 (the default) means no limit
+    ContentMaxSize: Int64;
     /// same as HeaderGetValue('SERVER-INTERNALSTATE'), but retrieved by ParseHeader()
     // - proprietary header, used with our RESTful ORM access
     ServerInternalState: integer;
@@ -616,6 +627,9 @@ type
   public
     /// the whole context of the HTTP/1.0 or HTTP/1.1 request
     Http: THttpRequestContext;
+    /// finalize this instance and its Http state
+    // - e.g. free any pending TOnHttpServerBodyDownload stream and spool file
+    destructor Destroy; override;
     /// retrieve the HTTP headers into Headers[] and fill most properties below
     // - with default HeadersUnFiltered=false, only relevant headers are retrieved:
     // use directly the ContentLength/ContentType/ServerInternalState/Upgrade
@@ -768,6 +782,34 @@ type
   TOnHttpServerBeforeBody = function(var aUrl, aMethod, aInHeaders,
     aInContentType, aRemoteIP, aBearerToken: RawUtf8; aContentLength: Int64;
     aFlags: THttpServerRequestFlags): cardinal of object;
+
+  /// event handler used by THttpServerGeneric.OnBodyDownload property
+  // - called once the request headers have been parsed (and OnBeforeBody
+  // accepted the request), just before the body is downloaded from the client
+  // - should return a stream instance to receive the incoming request body,
+  // e.g. a TFileStreamEx spooling into a local temporary file, or nil to
+  // fallback to the default in-memory Content buffering
+  // - returning a stream disables the 1GB in-memory body size limit, so that
+  // huge file uploads can be processed with a constant memory usage: only
+  // THttpServerGeneric.MaximumAllowedContentLength applies (0 = no limit),
+  // which is also enforced on the cumulated size of a chunked body
+  // - only a body with a Content-Length: header or chunked Transfer-Encoding
+  // is streamed: the deprecated HTTP/1.0 close-delimited body is not
+  // - the stream is owned by the server, and will be freed once the body has
+  // been fully received; if the stream is a TFileStreamEx, the request is
+  // then supplied to the OnRequest callback with InContentType set to
+  // STATICFILE_CONTENT_TYPE and InContent set to the local file name (mirroring
+  // the response process), and the file is deleted once the request has been
+  // processed - a handler can rename/move the file to take data ownership
+  // - for any other TStream class, the callback should keep its own reference
+  // to the instance to access the received data (InContent remains void)
+  // - the original Content-Type header is still available from InHeaders
+  // - a compressed body - i.e. with a Content-Encoding: header matching a
+  // registered compression algorithm - can not be streamed, and is rejected
+  // as HTTP_UNSUPPORTEDMEDIATYPE = 415; an unknown/unregistered encoding is
+  // spooled verbatim, exactly as the in-memory process would supply it
+  TOnHttpServerBodyDownload = function(const aUrl, aMethod, aInHeaders,
+    aInContentType, aRemoteIP: RawUtf8; aContentLength: Int64): TStream of object;
 
   /// event handler used by THttpServer.Process to send a local file
   // when STATICFILE_CONTENT_TYPE content-type is returned by the service
@@ -3370,6 +3412,11 @@ begin
   HeaderFlags := [];
   if rfContentStreamNeedFree in ResponseFlags then
     ContentStream.Free; // ensure no leak on (reused) broken connection
+  if ContentInputName <> '' then
+  begin
+    DeleteFile(ContentInputName); // remove any pending spooled body file
+    ContentInputName := '';
+  end;
   ResponseFlags := [];
   Options := [];
   HeadCustom := [];
@@ -3390,6 +3437,7 @@ begin
   RangeLength := -1;
   ContentLength := -1; // -1 = no Content-Length: header
   ContentLastModified := 0;
+  ContentMaxSize := 0;
   ContentStream := nil;
   ServerInternalState := 0;
   ContentEncoding := nil;
@@ -3875,6 +3923,8 @@ begin
     State := hrsErrorRejected;
     exit;
   end;
+  if Len + 1 >= st.Len then
+    exit; // half-received #13#10 delimiter: wait for more input
   P := st.P;
   P[Len] := #0;                // replace ending #13 by #0
   if (P[Len + 1] <> #10) or    // HTTP requires #13#10 not #10
@@ -3955,6 +4005,12 @@ begin
               State := hrsErrorPayloadTooLarge
             else
             begin
+              if (ContentMaxSize > 0) and
+                 (ContentLength + fContentLeft > ContentMaxSize) then
+              begin
+                State := hrsErrorPayloadTooLarge; // e.g. spool disk overflow
+                break;
+              end;
               if ContentStream = nil then
               begin
                 // reserve appended chunk size to Content memory buffer
@@ -3988,6 +4044,8 @@ begin
             MoveFast(st.P^, fContentPos^, st.LineLen);
             inc(fContentPos, st.LineLen);
           end;
+          inc(st.P, st.LineLen); // consume the chunk data bytes
+          dec(st.Len, st.LineLen);
           dec(fContentLeft, st.LineLen);
           if fContentLeft = 0 then
             State := hrsGetBodyChunkedDataVoidLine
@@ -4030,6 +4088,7 @@ begin
           else
             ContentStream.WriteBuffer(st.P^, st.LineLen);
           State := hrsGetBodyContentLengthNext;
+          inc(st.P, st.LineLen); // consume the body bytes (e.g. for pipelining)
           dec(st.Len, st.LineLen);
           dec(fContentLeft, st.LineLen);
           if fContentLeft = 0 then     // reached end of Content-Length body
@@ -4294,10 +4353,16 @@ end;
 
 procedure THttpRequestContext.ProcessDone;
 begin
-  if not (rfContentStreamNeedFree in ResponseFlags) then
-    exit;
-  FreeAndNilSafe(ContentStream);
-  exclude(ResponseFlags, rfContentStreamNeedFree);
+  if rfContentStreamNeedFree in ResponseFlags then
+  begin
+    FreeAndNilSafe(ContentStream);
+    exclude(ResponseFlags, rfContentStreamNeedFree);
+  end;
+  if ContentInputName <> '' then
+  begin
+    DeleteFile(ContentInputName); // this request spooled body file is done
+    ContentInputName := '';
+  end;
 end;
 
 function THttpRequestContext.ContentFromFile(const FileName: TFileName;
@@ -4518,6 +4583,9 @@ begin
       end;
       if len > MaxHttpChunkSize then // allow up to 256 MB chunk
         EHttpSocket.RaiseUtf8('%.GetBody: chunk size=% overflow', [self, len]);
+      if (Http.ContentMaxSize > 0) and
+         (Http.ContentLength + len > Http.ContentMaxSize) then
+        EHttpSocket.RaiseUtf8('%.GetBody: chunked size overflow', [self]);
       if DestStream <> nil then
       begin
         if length({%H-}chunk) < len then
@@ -4611,6 +4679,12 @@ begin
     AppendLine(Http.Headers, ['Content-Type: ', aForcedContentType]);
 end;
 
+destructor THttpSocket.Destroy;
+begin
+  Http.ProcessDone; // e.g. free any pending body download stream / spool file
+  inherited Destroy;
+end;
+
 procedure THttpSocket.HeadersPrepare(const aRemoteIP: RawUtf8);
 begin
   if (aRemoteIP = '') or
@@ -4658,6 +4732,17 @@ begin
     FastAssign(fAuthBearer, aHttp.BearerToken);
   fUserAgent := aHttp.UserAgent;
   fInContent := aHttp.Content;
+  if aHttp.ContentInputName <> '' then
+  begin
+    // the body was spooled into a local file by TOnHttpServerBodyDownload:
+    // supply its name in InContent, mirroring the STATICFILE response trick
+    StringToUtf8(aHttp.ContentInputName, RawUtf8(fInContent));
+    if (fInContentType <> '') and // note: aHttp.ContentType was moved above
+       (FindNameValue(pointer(fInHeaders), 'CONTENT-TYPE:') = nil) then
+      // keep the original type: only 'application/json' is not in the headers
+      AppendLine(fInHeaders, ['Content-Type: ', fInContentType]);
+    fInContentType := STATICFILE_CONTENT_TYPE;
+  end;
 end;
 
 procedure THttpServerRequestAbstract.PrepareDirect(

--- a/src/net/mormot.net.server.pas
+++ b/src/net/mormot.net.server.pas
@@ -529,6 +529,7 @@ type
     /// optional event handlers for process interception
     fOnRequest: TOnHttpServerRequest;
     fOnBeforeBody: TOnHttpServerBeforeBody;
+    fOnBodyDownload: TOnHttpServerBodyDownload;
     fOnBeforeRequest: TOnHttpServerRequest;
     fOnAfterRequest: TOnHttpServerRequest;
     fOnAfterResponse: TOnHttpServerAfterResponse;
@@ -554,6 +555,7 @@ type
     procedure SetOptions(opt: THttpServerOptions);
     procedure SetOnRequest(const aRequest: TOnHttpServerRequest); virtual;
     procedure SetOnBeforeBody(const aEvent: TOnHttpServerBeforeBody); virtual;
+    procedure SetOnBodyDownload(const aEvent: TOnHttpServerBodyDownload); virtual;
     procedure SetOnBeforeRequest(const aEvent: TOnHttpServerRequest); virtual;
     procedure SetOnAfterRequest(const aEvent: TOnHttpServerRequest); virtual;
     procedure SetOnAfterResponse(const aEvent: TOnHttpServerAfterResponse); virtual;
@@ -685,6 +687,16 @@ type
     // error code to reject the request immediately, and close the connection
     property OnBeforeBody: TOnHttpServerBeforeBody
       read fOnBeforeBody write SetOnBeforeBody;
+    /// event handler called just before the body is downloaded from the client
+    // - could return a TStream instance (e.g. a TFileStreamEx spooling into a
+    // local temporary file) to receive the incoming request body with a fixed
+    // memory usage, whatever its size - see TOnHttpServerBodyDownload
+    // - only implemented by socket-based servers, i.e. THttpServer and
+    // THttpAsyncServer classes, not by THttpApiServer
+    // - warning: this handler must be thread-safe (can be called by several
+    // threads simultaneously)
+    property OnBodyDownload: TOnHttpServerBodyDownload
+      read fOnBodyDownload write SetOnBodyDownload;
     /// event handler called after HTTP body has been retrieved, before OnRequest
     // - may be used e.g. to return a HTTP_ACCEPTED (202) status to client and
     // continue a long-term job inside the OnRequest handler in the same thread;
@@ -910,6 +922,8 @@ type
     procedure TaskProcess(aCaller: TSynThreadPoolWorkThread); virtual;
     function TaskProcessBody(aCaller: TSynThreadPoolWorkThread;
       aHeaderResult: THttpServerSocketGetRequestResult): boolean;
+    // GetBody into Http.Content, or the OnBodyDownload event stream
+    procedure DownloadBody;
   public
     /// create the socket according to a server
     // - will register the THttpSocketCompress functions from the server
@@ -1091,7 +1105,8 @@ type
     procedure SetRegisterCompressGzStatic(Value: boolean);
     function ComputeWwwAuthenticate(Opaque: Int64): RawUtf8;
     function ComputeRejectBody(var Body: RawByteString; Opaque: Int64;
-      Status: integer): boolean; virtual; // return true for grWwwAuthenticate
+      Status: integer; const ExtraHeader: RawUtf8 = ''): boolean;
+      virtual; // return true for grWwwAuthenticate - ExtraHeader needs #13#10
     function Authorization(var Http: THttpRequestContext;
       Opaque: Int64): TAuthServerResult;
     procedure SetBlackListUri(const Uri: RawUtf8);
@@ -3821,6 +3836,12 @@ begin
   fOnBeforeBody := aEvent;
 end;
 
+procedure THttpServerGeneric.SetOnBodyDownload(
+  const aEvent: TOnHttpServerBodyDownload);
+begin
+  fOnBodyDownload := aEvent;
+end;
+
 procedure THttpServerGeneric.SetOnBeforeRequest(
   const aEvent: TOnHttpServerRequest);
 begin
@@ -4668,7 +4689,8 @@ begin
 end;
 
 function THttpServerSocketGeneric.ComputeRejectBody(
-  var Body: RawByteString; Opaque: Int64; Status: integer): boolean;
+  var Body: RawByteString; Opaque: Int64; Status: integer;
+  const ExtraHeader: RawUtf8): boolean;
 var
   reason: PRawUtf8;
   auth, html: RawUtf8;
@@ -4682,9 +4704,9 @@ begin
             (fAuthorize <> hraNone);
   if result then // don't close the connection but set grWwwAuthenticate
     auth := ComputeWwwAuthenticate(Opaque); // includes #13#10 trailer
-  FormatUtf8('HTTP/1.% % %'#13#10'%' + HTML_CONTENT_TYPE_HEADER +
+  FormatUtf8('HTTP/1.% % %'#13#10'%%' + HTML_CONTENT_TYPE_HEADER +
     #13#10'Content-Length: %'#13#10#13#10'%', [ord(result), status, reason^,
-    auth, length(html), html], RawUtf8(Body));
+    auth, ExtraHeader, length(html), html], RawUtf8(Body));
 end;
 
 
@@ -5199,7 +5221,7 @@ begin
             if not (hfConnectionUpgrade in Http.HeaderFlags) and
                not HttpMethodWithNoBody(Method) then
             begin
-              GetBody; // we need to get it now
+              DownloadBody; // we need to get it now
               fServer.IncStat(grBodyReceived);
             end;
             // multi-connection -> process now
@@ -5252,6 +5274,8 @@ var
   status, tix32, max: cardinal;
   startTix, pendingMaxTix, tix: Int64;
   pending: integer;
+  strm: TStream;
+  fn: TFileName;
 begin
   try
     if Http.CommandUri <> '' then
@@ -5428,6 +5452,43 @@ begin
           exit;
         end;
       end;
+      // allow OnBodyDownload callback to supply a stream for the body
+      if Assigned(fServer.fOnBodyDownload) and
+         not (hfConnectionUpgrade in Http.HeaderFlags) and
+         not HttpMethodWithNoBody(Http.CommandMethod) and
+         ((Http.ContentLength > 0) or
+          (hfTransferChunked in Http.HeaderFlags)) then
+      begin
+        HeadersPrepare(fRemoteIP); // will include remote IP to Http.Headers
+        strm := fServer.fOnBodyDownload(Http.CommandUri, Http.CommandMethod,
+          Http.Headers, Http.ContentType, fRemoteIP, Http.ContentLength);
+        if strm <> nil then
+          if Http.ContentEncoding <> nil then
+          begin
+            // a streamed body does not support Content-Encoding: compression
+            fn := '';
+            if strm.InheritsFrom(TFileStreamEx) then
+              fn := TFileStreamEx(strm).FileName;
+            strm.Free;
+            if fn <> '' then
+              DeleteFile(fn); // remove the (void) spool file
+            fServer.ComputeRejectBody(Http.Content, 0,
+              HTTP_UNSUPPORTEDMEDIATYPE, 'Accept-Encoding: identity'#13#10);
+            SockSendFlush(Http.Content);
+            result := grRejected;
+            exit;
+          end
+          else
+          begin
+            // the (maybe deferred) DownloadBody will fill this stream
+            Http.ContentStream := strm; // freed by Reset on broken connection
+            include(Http.ResponseFlags, rfContentStreamNeedFree);
+            if strm.InheritsFrom(TFileStreamEx) then
+              Http.ContentInputName := TFileStreamEx(strm).FileName;
+            // needed to track and limit the cumulated chunked body size
+            Http.ContentMaxSize := fServer.MaximumAllowedContentLength;
+          end;
+      end;
     end;
     // implement 'Expect: 100-Continue' Header
     if hfExpect100 in Http.HeaderFlags then
@@ -5439,7 +5500,7 @@ begin
        not (hfConnectionUpgrade in Http.HeaderFlags) then
     begin
       if not HttpMethodWithNoBody(Http.CommandMethod) then
-        GetBody;
+        DownloadBody;
       result := grBodyReceived;
     end
     else
@@ -5447,6 +5508,31 @@ begin
   except
     on E: Exception do
       result := grException;
+  end;
+end;
+
+procedure THttpServerSocket.DownloadBody;
+var
+  strm: TStream;
+begin
+  strm := Http.ContentStream;
+  if strm = nil then
+  begin
+    GetBody; // default in-memory download into Http.Content
+    exit;
+  end;
+  // download into the stream supplied by the OnBodyDownload event
+  Http.ContentStream := nil; // input only: don't interfere with the response
+  exclude(Http.ResponseFlags, rfContentStreamNeedFree);
+  try
+    try
+      GetBody(strm);
+    finally
+      strm.Free; // any spooled file remains during the request processing
+    end;
+  except
+    Http.ProcessDone; // delete any partially spooled file
+    raise;
   end;
 end;
 
@@ -5595,7 +5681,7 @@ begin
         // call from TSynThreadPoolTHttpServer -> handle first request
         if not (fBodyRetrieved in fServerSock.fFlags) and
            not HttpMethodWithNoBody(fServerSock.Http.CommandMethod) then
-          fServerSock.GetBody;
+          fServerSock.DownloadBody;
         fServer.Process(fServerSock, ConnectionID, self);
         if (fServer <> nil) and
            fServerSock.KeepAliveClient then

--- a/src/net/mormot.net.server.pas
+++ b/src/net/mormot.net.server.pas
@@ -924,6 +924,8 @@ type
       aHeaderResult: THttpServerSocketGetRequestResult): boolean;
     // GetBody into Http.Content, or the OnBodyDownload event stream
     procedure DownloadBody;
+    // implement fServer.OnBodyDownload in GetRequest - false if rejected as 415
+    function DoBodyDownload: boolean; virtual;
   public
     /// create the socket according to a server
     // - will register the THttpSocketCompress functions from the server
@@ -5274,8 +5276,6 @@ var
   status, tix32, max: cardinal;
   startTix, pendingMaxTix, tix: Int64;
   pending: integer;
-  strm: TStream;
-  fn: TFileName;
 begin
   try
     if Http.CommandUri <> '' then
@@ -5458,37 +5458,11 @@ begin
          not HttpMethodWithNoBody(Http.CommandMethod) and
          ((Http.ContentLength > 0) or
           (hfTransferChunked in Http.HeaderFlags)) then
-      begin
-        HeadersPrepare(fRemoteIP); // will include remote IP to Http.Headers
-        strm := fServer.fOnBodyDownload(Http.CommandUri, Http.CommandMethod,
-          Http.Headers, Http.ContentType, fRemoteIP, Http.ContentLength);
-        if strm <> nil then
-          if Http.ContentEncoding <> nil then
-          begin
-            // a streamed body does not support Content-Encoding: compression
-            fn := '';
-            if strm.InheritsFrom(TFileStreamEx) then
-              fn := TFileStreamEx(strm).FileName;
-            strm.Free;
-            if fn <> '' then
-              DeleteFile(fn); // remove the (void) spool file
-            fServer.ComputeRejectBody(Http.Content, 0,
-              HTTP_UNSUPPORTEDMEDIATYPE, 'Accept-Encoding: identity'#13#10);
-            SockSendFlush(Http.Content);
-            result := grRejected;
-            exit;
-          end
-          else
-          begin
-            // the (maybe deferred) DownloadBody will fill this stream
-            Http.ContentStream := strm; // freed by Reset on broken connection
-            include(Http.ResponseFlags, rfContentStreamNeedFree);
-            if strm.InheritsFrom(TFileStreamEx) then
-              Http.ContentInputName := TFileStreamEx(strm).FileName;
-            // needed to track and limit the cumulated chunked body size
-            Http.ContentMaxSize := fServer.MaximumAllowedContentLength;
-          end;
-      end;
+        if not DoBodyDownload then
+        begin
+          result := grRejected;
+          exit;
+        end;
     end;
     // implement 'Expect: 100-Continue' Header
     if hfExpect100 in Http.HeaderFlags then
@@ -5508,6 +5482,43 @@ begin
   except
     on E: Exception do
       result := grException;
+  end;
+end;
+
+function THttpServerSocket.DoBodyDownload: boolean;
+var
+  strm: TStream;
+  fn: TFileName; // managed local variables are on purpose in this sub-method
+begin
+  result := true;
+  HeadersPrepare(fRemoteIP); // will include remote IP to Http.Headers
+  strm := fServer.fOnBodyDownload(Http.CommandUri, Http.CommandMethod,
+    Http.Headers, Http.ContentType, fRemoteIP, Http.ContentLength);
+  if strm = nil then
+    exit; // in-memory Content buffering
+  if Http.ContentEncoding <> nil then
+  begin
+    // a streamed body does not support Content-Encoding: compression
+    fn := '';
+    if strm.InheritsFrom(TFileStreamEx) then
+      fn := TFileStreamEx(strm).FileName;
+    strm.Free;
+    if fn <> '' then
+      DeleteFile(fn); // remove the (void) spool file
+    fServer.ComputeRejectBody(Http.Content, 0,
+      HTTP_UNSUPPORTEDMEDIATYPE, 'Accept-Encoding: identity'#13#10);
+    SockSendFlush(Http.Content);
+    result := false;
+  end
+  else
+  begin
+    // the (maybe deferred) DownloadBody will fill this stream
+    Http.ContentStream := strm; // freed by Reset on broken connection
+    include(Http.ResponseFlags, rfContentStreamNeedFree);
+    if strm.InheritsFrom(TFileStreamEx) then
+      Http.ContentInputName := TFileStreamEx(strm).FileName;
+    // needed to track and limit the cumulated chunked body size
+    Http.ContentMaxSize := fServer.MaximumAllowedContentLength;
   end;
 end;
 

--- a/src/net/mormot.net.server.pas
+++ b/src/net/mormot.net.server.pas
@@ -5489,11 +5489,15 @@ function THttpServerSocket.DoBodyDownload: boolean;
 var
   strm: TStream;
   fn: TFileName; // managed local variables are on purpose in this sub-method
+  len: Int64;
 begin
   result := true;
   HeadersPrepare(fRemoteIP); // will include remote IP to Http.Headers
+  len := Http.ContentLength;
+  if hfTransferChunked in Http.HeaderFlags then
+    len := -1; // a chunked body size is not known in advance
   strm := fServer.fOnBodyDownload(Http.CommandUri, Http.CommandMethod,
-    Http.Headers, Http.ContentType, fRemoteIP, Http.ContentLength);
+    Http.Headers, Http.ContentType, fRemoteIP, len);
   if strm = nil then
     exit; // in-memory Content buffering
   if Http.ContentEncoding <> nil then
@@ -5542,6 +5546,14 @@ begin
       strm.Free; // any spooled file remains during the request processing
     end;
   except
+    on EHttpSocketOverflow do
+    begin
+      // e.g. a chunked body over ContentMaxSize: report 413 before closing
+      Http.ProcessDone; // delete any partially spooled file
+      fServer.ComputeRejectBody(Http.Content, 0, HTTP_PAYLOADTOOLARGE);
+      SockSendFlush(Http.Content);
+      raise; // the caller will close the connection
+    end;
     on EStreamError do
     begin
       // e.g. ENOSPC when spooling the body: report it before closing

--- a/src/net/mormot.net.server.pas
+++ b/src/net/mormot.net.server.pas
@@ -5480,6 +5480,8 @@ begin
     else
       result := grHeaderReceived;
   except
+    on EHttpSocketOverflow do
+      result := grOversizedPayload; // e.g. chunked body over ContentMaxSize
     on E: Exception do
       result := grException;
   end;

--- a/src/net/mormot.net.server.pas
+++ b/src/net/mormot.net.server.pas
@@ -5542,8 +5542,19 @@ begin
       strm.Free; // any spooled file remains during the request processing
     end;
   except
-    Http.ProcessDone; // delete any partially spooled file
-    raise;
+    on EStreamError do
+    begin
+      // e.g. ENOSPC when spooling the body: report it before closing
+      Http.ProcessDone; // delete any partially spooled file
+      fServer.ComputeRejectBody(Http.Content, 0, HTTP_INSUFFICIENTSTORAGE);
+      SockSendFlush(Http.Content);
+      raise; // the caller will close the connection
+    end;
+    on Exception do
+    begin
+      Http.ProcessDone; // delete any partially spooled file
+      raise;
+    end;
   end;
 end;
 

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -4332,14 +4332,14 @@ begin
   bodyeventlen := aContentLength;
   if aUrl = '/mem' then
     exit; // in-memory Content fallback
-  inc(bodystreamed);
   if aUrl = '/fail' then
+    result := TFailingStream.Create
+  else
   begin
-    result := TFailingStream.Create;
-    exit;
+    bodyfile := TemporaryFileName;
+    result := TFileStreamEx.Create(bodyfile, fmCreate);
   end;
-  bodyfile := TemporaryFileName;
-  result := TFileStreamEx.Create(bodyfile, fmCreate);
+  inc(bodystreamed); // increment last: the tests poll on this counter
 end;
 
 function TNetworkProtocols.DoBodyRequest(Ctxt: THttpServerRequestAbstract): cardinal;
@@ -4425,7 +4425,7 @@ begin
   // (SockSend() of a non-ASCII AnsiString may involve codepage conversion)
   mptext := RandomTextParagraph(5000);
   while length(mptext) < 20000 do
-    Append(mptext, mptext);
+    mptext := mptext + mptext; // note: no Append() self-reference here
   SetLength(mptext, 20000);
   mpa := nil;
   Check(MultiPartFormDataAddField('field', mptext, mpa), 'mp add');
@@ -4540,16 +4540,21 @@ begin
         raw.SockSend([]); // void line: end of headers
         for status := 1 to 10 do
           raw.SockSendRaw([mptext]); // = the announced 200000 bytes
-        raw.SockSendFlush;
-        if fam = 0 then
-        begin
-          // the blocking server reads the whole body before the failing
-          // write, so the 507 response is deterministic here
-          raw.SockRecvLn(line);
-          CheckUtf8(PosEx(' 507 ', line) > 0, 'enospc %', [line]);
+        // both the send and the response read may fail with a connection
+        // reset, since the server closes as soon as the write did fail
+        line := '';
+        try
+          raw.SockSendFlush;
+          if fam = 0 then
+            // the blocking server reads the whole body before the failing
+            // write, so it usually could send back its 507 response
+            raw.SockRecvLn(line);
+        except
+          on ENetSock do
+            line := ''; // the reset did win the race: nothing to check
         end;
-        // on the async family the failure occurs in the middle of the body,
-        // so the 507 is best effort: the reset may reach the client first
+        if line <> '' then
+          CheckUtf8(PosEx(' 507 ', line) > 0, 'enospc %', [line]);
       finally
         raw.Free;
       end;
@@ -4560,6 +4565,46 @@ begin
       CheckEqual(bodystreamed, prev + 1, 'enospc streamed');
       // a chunked body over MaximumAllowedContentLength should get a 413
       // on both families (its cumulated size is only known while receiving)
+      // - first check the exact boundary: 2 x 20000 bytes = 40000, so a
+      // 39999 limit should reject it, and a 40000 limit should accept it
+      bodyhash := Sha256(mptext + mptext); // the two chunks below
+      for status := 0 to 1 do
+      begin
+        srv.MaximumAllowedContentLength := 39999 + status;
+        raw := TCrtSocket.Open('127.0.0.1', port);
+        try
+          raw.SockSend(['POST /big HTTP/1.1']);
+          raw.SockSend(['Host: 127.0.0.1:', port]);
+          raw.SockSend(['Transfer-Encoding: chunked']);
+          raw.SockSend(['Content-Type: application/dummy']);
+          raw.SockSend([]); // void line: end of headers
+          raw.SockSend(['4e20']);
+          raw.SockSend([mptext]);
+          raw.SockSend(['4e20']);
+          raw.SockSend([mptext]);
+          raw.SockSend(['0']);
+          raw.SockSend([]); // final void line
+          line := '';
+          try
+            raw.SockSendFlush;
+            raw.SockRecvLn(line);
+          except
+            on ENetSock do
+              line := ''; // rejected and closed before we did send it all
+          end;
+          if status = 0 then
+          begin
+            if line <> '' then
+              CheckUtf8(PosEx(' 413 ', line) > 0, 'chunked limit %', [line]);
+          end
+          else
+            CheckUtf8(PosEx(' 200 ', line) > 0, 'chunked in limit %', [line]);
+        finally
+          raw.Free;
+        end;
+        if status <> 0 then
+          WaitDeleted('chunked limit');
+      end;
       srv.MaximumAllowedContentLength := 100000;
       raw := TCrtSocket.Open('127.0.0.1', port);
       try
@@ -4575,44 +4620,55 @@ begin
         end;
         raw.SockSend(['0']);
         raw.SockSend([]); // final void line
-        raw.SockSendFlush;
-        raw.SockRecvLn(line);
-        CheckUtf8(PosEx(' 413 ', line) > 0, 'chunked 413 %', [line]);
+        line := '';
+        try
+          raw.SockSendFlush; // as above: the server may reject and close
+          raw.SockRecvLn(line);
+        except
+          on ENetSock do
+            line := '';
+        end;
+        if line <> '' then
+          CheckUtf8(PosEx(' 413 ', line) > 0, 'chunked 413 %', [line]);
       finally
         raw.Free;
         srv.MaximumAllowedContentLength := 0; // restore no limit
       end;
-      // the server must still serve further requests after the disk error
-      clt := THttpClientSocket.Open('127.0.0.1', port);
-      try
-        bodytype := 'application/dummy';
-        bodyhash := Sha256(mptext);
-        status := clt.Post('/big', mptext, bodytype);
-        CheckEqual(status, HTTP_SUCCESS, 'alive after enospc');
-        WaitDeleted('after enospc');
-      finally
-        clt.Free;
-      end;
+      // the server must still serve further requests after those rejections,
+      // with no stale body state left from the aborted requests (e.g. on a
+      // recycled THttpAsyncServer connection instance)
+      bodytype := 'application/dummy';
+      for status := 1 to 3 do
       begin
-        // on abort, the server should delete the truncated spool file
-        prev := bodystreamed;
-        raw := TCrtSocket.Open('127.0.0.1', port);
+        clt := THttpClientSocket.Open('127.0.0.1', port);
         try
-          raw.SockSend(['POST /big HTTP/1.1']);
-          raw.SockSend(['Host: 127.0.0.1:', port]);
-          raw.SockSend(['Content-Length: 100000']);
-          raw.SockSend(['Content-Type: application/dummy']);
-          raw.SockSend([]); // void line: end of headers
-          raw.SockSendRaw(['truncated body']);
-          raw.SockSendFlush;
-          endtix := GetTickCount64 + 5000;
-          while (bodystreamed = prev) and
-                (GetTickCount64 < endtix) do
-            SleepHiRes(5); // wait until OnBodyDownload created the spool file
-          CheckEqual(bodystreamed, prev + 1, 'abort streamed');
+          bodyhash := Sha256(copy(mptext, 1, status * 5000));
+          CheckEqual(clt.Post('/big', copy(mptext, 1, status * 5000), bodytype),
+            HTTP_SUCCESS, 'alive after reject');
+          CheckEqual(clt.Content, 'ok ' + bodyhash, 'resp after reject');
+          WaitDeleted('after reject');
         finally
-          raw.Free; // close the socket in the middle of the body
+          clt.Free;
         end;
+      end;
+      // on abort, the server should delete the truncated spool file
+      prev := bodystreamed;
+      raw := TCrtSocket.Open('127.0.0.1', port);
+      try
+        raw.SockSend(['POST /big HTTP/1.1']);
+        raw.SockSend(['Host: 127.0.0.1:', port]);
+        raw.SockSend(['Content-Length: 100000']);
+        raw.SockSend(['Content-Type: application/dummy']);
+        raw.SockSend([]); // void line: end of headers
+        raw.SockSendRaw(['truncated body']);
+        raw.SockSendFlush;
+        endtix := GetTickCount64 + 5000;
+        while (bodystreamed = prev) and
+              (GetTickCount64 < endtix) do
+          SleepHiRes(5); // wait until OnBodyDownload created the spool file
+        CheckEqual(bodystreamed, prev + 1, 'abort streamed');
+      finally
+        raw.Free; // close the socket in the middle of the body
       end;
     finally
       srv.Free;

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -9,6 +9,7 @@ interface
 
 uses
   sysutils,
+  classes,
   mormot.core.base,
   mormot.core.os,
   mormot.core.os.security,
@@ -71,6 +72,10 @@ type
     request: integer;
     reqthree: boolean;
     reqfour: Int64;
+    // for BodyDownload
+    bodyfile: TFileName;
+    bodyhash, bodytype: RawUtf8;
+    bodystreamed: integer;
     // for _TTunnelLocal
     tunnelappsec: RawUtf8;
     tunneloptions: TTunnelOptions;
@@ -91,6 +96,10 @@ type
     function OnPeerCacheDirect(var aUri: TUri; var aHeader: RawUtf8;
       var aOptions: THttpRequestExtendedOptions): integer;
     function OnPeerCacheRequest(Ctxt: THttpServerRequestAbstract): cardinal;
+    // both events used by BodyDownload
+    function DoBodyDownload(const aUrl, aMethod, aInHeaders, aInContentType,
+      aRemoteIP: RawUtf8; aContentLength: Int64): TStream;
+    function DoBodyRequest(Ctxt: THttpServerRequestAbstract): cardinal;
     // several methods used by _TUriTree
     function DoRequest_(Ctxt: THttpServerRequestAbstract): cardinal;
     function DoRequest0(Ctxt: THttpServerRequestAbstract): cardinal;
@@ -113,6 +122,8 @@ type
     procedure _THttpPeerCache;
     /// some HTTP shared/low-level process
     procedure HTTP;
+    /// validate THttpServerGeneric.OnBodyDownload streamed body upload
+    procedure BodyDownload;
     /// validate THttpProxyCache process
     procedure _THttpProxyCache;
     /// validate TUriTree high-level structure
@@ -4282,6 +4293,232 @@ begin
   checkEqual(U.Address, 'toto/titi#ignore=10');
   Check(HttpRequestHashBase32(U, @s32, nil));
   CheckEqualShort(s32, 'na3q2n4gw6cly5fvf5da4frmek667zk2');
+end;
+
+function TNetworkProtocols.DoBodyDownload(const aUrl, aMethod, aInHeaders,
+  aInContentType, aRemoteIP: RawUtf8; aContentLength: Int64): TStream;
+begin
+  result := nil;
+  if aUrl = '/mem' then
+    exit; // in-memory Content fallback
+  bodyfile := TemporaryFileName;
+  result := TFileStreamEx.Create(bodyfile, fmCreate);
+  inc(bodystreamed);
+end;
+
+function TNetworkProtocols.DoBodyRequest(Ctxt: THttpServerRequestAbstract): cardinal;
+var
+  ct: RawUtf8;
+  fn: TFileName;
+  fs: TFileStreamEx;
+  dec: THttpMultiPartDecoder;
+  ms: TRawByteStringStream;
+begin
+  result := HTTP_SUCCESS;
+  if Ctxt.Url = '/mem' then
+  begin
+    // default in-memory process, since DoBodyDownload returned nil
+    CheckEqual(Ctxt.InContentType, bodytype, 'mem typ');
+    CheckEqual(Sha256(Ctxt.InContent), bodyhash, 'mem hash');
+  end
+  else
+  begin
+    // the body has been spooled into a local temporary file
+    CheckEqual(Ctxt.InContentType, STATICFILE_CONTENT_TYPE, 'static typ');
+    Check(FindNameValue(Ctxt.InHeaders, 'CONTENT-TYPE:', ct), 'headers typ');
+    CheckEqual(ct, bodytype, 'original typ');
+    fn := Utf8ToString(Ctxt.InContent); // as ProcessStaticFile does
+    Check(fn = bodyfile, 'spool name');
+    Check(FileExists(fn), 'spool exists');
+    if Ctxt.Url = '/mp' then
+    begin
+      // decode a multipart body directly from the spooled file - see #292
+      fs := TFileStreamEx.CreateRead(fn);
+      try
+        dec := THttpMultiPartDecoder.CreateFromContentType(fs, ct);
+        try
+          Check(dec.NextPart, 'mp part');
+          CheckEqual(dec.Name, 'field', 'mp name');
+          ms := TRawByteStringStream.Create;
+          try
+            StreamCopyUntilEnd(dec.Content, ms);
+            CheckEqual(Sha256(ms.DataString), bodyhash, 'mp hash');
+          finally
+            ms.Free;
+          end;
+          Check(dec.Close, 'mp close');
+        finally
+          dec.Free;
+        end;
+      finally
+        fs.Free;
+      end;
+    end
+    else
+      CheckEqual(Sha256(StringFromFile(fn)), bodyhash, 'spool hash');
+  end;
+  Ctxt.OutContent := 'ok ' + bodyhash;
+  Ctxt.OutContentType := TEXT_CONTENT_TYPE;
+end;
+
+procedure TNetworkProtocols.BodyDownload;
+var
+  srv: THttpServerSocketGeneric;
+  clt: THttpClientSocket;
+  raw: TCrtSocket;
+  fam, status, prev: integer;
+  port: RawUtf8;
+  body, mp: RawByteString;
+  mpct, mptext, line: RawUtf8;
+  mpa: TMultiPartDynArray;
+  endtix: Int64;
+
+  procedure WaitDeleted(const ctxt: RawUtf8);
+  begin
+    // the spool file should be deleted just after the request processing
+    endtix := GetTickCount64 + 5000; // never wait forever
+    while FileExists(bodyfile) and
+          (GetTickCount64 < endtix) do
+      SleepHiRes(5);
+    CheckUtf8(not FileExists(bodyfile), 'no spool left %', [ctxt]);
+  end;
+
+begin
+  body := RandomString(8 shl 20); // 8MB, way above any socket buffer
+  // some pure ASCII-7 text of exactly $4e20 bytes for the chunked request
+  // (SockSend() of a non-ASCII AnsiString may involve codepage conversion)
+  mptext := RandomTextParagraph(5000);
+  while length(mptext) < 20000 do
+    Append(mptext, mptext);
+  SetLength(mptext, 20000);
+  mpa := nil;
+  Check(MultiPartFormDataAddField('field', mptext, mpa), 'mp add');
+  Check(MultiPartFormDataEncode(mpa, mpct, RawUtf8(mp)), 'mp encode');
+  for fam := 0 to 1 do
+  begin
+    // validate both socket server families with the very same steps
+    if fam = 0 then
+    begin
+      port := '8891';
+      srv := THttpServer.Create(port, nil, nil, 'bodydl', 2);
+    end
+    else
+    begin
+      port := '8892';
+      srv := THttpAsyncServer.Create(port, nil, nil, 'bodydl', 2, 30000, [], nil);
+    end;
+    try
+      srv.OnBodyDownload := DoBodyDownload;
+      srv.OnRequest := DoBodyRequest;
+      srv.RegisterCompress(CompressGZip); // detect Content-Encoding: gzip
+      srv.WaitStarted(10);
+      clt := THttpClientSocket.Open('127.0.0.1', port);
+      try
+        // spool a huge body into a temporary file
+        prev := bodystreamed;
+        bodytype := 'application/dummy';
+        bodyhash := Sha256(body);
+        status := clt.Post('/big', body, bodytype);
+        CheckEqual(status, HTTP_SUCCESS, 'big status');
+        CheckEqual(clt.Content, 'ok ' + bodyhash, 'big resp');
+        CheckEqual(bodystreamed, prev + 1, 'big streamed');
+        WaitDeleted('big');
+        // in-memory fallback when the event returns nil
+        status := clt.Post('/mem', body, bodytype);
+        CheckEqual(status, HTTP_SUCCESS, 'mem status');
+        CheckEqual(clt.Content, 'ok ' + bodyhash, 'mem resp');
+        CheckEqual(bodystreamed, prev + 1, 'mem not streamed');
+        // a spooled JSON body should keep its Content-Type: in InHeaders
+        // (this is the single content type not stored as header text)
+        bodytype := JSON_CONTENT_TYPE;
+        bodyhash := Sha256(mptext);
+        status := clt.Post('/big', mptext, bodytype);
+        CheckEqual(status, HTTP_SUCCESS, 'json status');
+        CheckEqual(clt.Content, 'ok ' + bodyhash, 'json resp');
+        WaitDeleted('json');
+        // decode a multipart body directly from the spooled file
+        bodytype := mpct;
+        bodyhash := Sha256(mptext);
+        status := clt.Post('/mp', mp, mpct);
+        CheckEqual(status, HTTP_SUCCESS, 'mp status');
+        CheckEqual(clt.Content, 'ok ' + bodyhash, 'mp resp');
+        WaitDeleted('mp');
+        // spool a chunked body, i.e. with no Content-Length
+        bodytype := 'application/dummy';
+        bodyhash := Sha256(mptext);
+        raw := TCrtSocket.Open('127.0.0.1', port);
+        try
+          raw.SockSend(['POST /big HTTP/1.1']);
+          raw.SockSend(['Host: 127.0.0.1:', port]);
+          raw.SockSend(['Transfer-Encoding: chunked']);
+          raw.SockSend(['Content-Type: application/dummy']);
+          raw.SockSend(['Connection: close']);
+          raw.SockSend([]); // void line: end of headers
+          raw.SockSend(['4e20']); // = length(mptext) as an hexadecimal chunk
+          raw.SockSend([mptext]);
+          raw.SockSend(['0']);
+          raw.SockSend([]); // final void line
+          raw.SockSendFlush;
+          raw.SockRecvLn(line);
+          CheckUtf8(PosEx(' 200 ', line) > 0, 'chunked %', [line]);
+        finally
+          raw.Free;
+        end;
+        WaitDeleted('chunked');
+      finally
+        clt.Free;
+      end;
+      // a compressed body can not be streamed -> rejected as 415 (before any
+      // body byte is sent, so use a raw socket and no actual body here)
+      raw := TCrtSocket.Open('127.0.0.1', port);
+      try
+        raw.SockSend(['POST /big HTTP/1.1']);
+        raw.SockSend(['Host: 127.0.0.1:', port]);
+        raw.SockSend(['Content-Length: 100000']);
+        raw.SockSend(['Content-Type: application/dummy']);
+        raw.SockSend(['Content-Encoding: gzip']);
+        raw.SockSend([]); // void line: end of headers
+        raw.SockSendFlush;
+        raw.SockRecvLn(line);
+        CheckUtf8(PosEx(' 415 ', line) > 0, '415 %', [line]);
+        status := 0;
+        repeat
+          raw.SockRecvLn(line);
+          if line = 'Accept-Encoding: identity' then
+            inc(status);
+        until line = '';
+        CheckEqual(status, 1, '415 identity');
+      finally
+        raw.Free;
+      end;
+      begin
+        // on abort, the server should delete the truncated spool file
+        prev := bodystreamed;
+        raw := TCrtSocket.Open('127.0.0.1', port);
+        try
+          raw.SockSend(['POST /big HTTP/1.1']);
+          raw.SockSend(['Host: 127.0.0.1:', port]);
+          raw.SockSend(['Content-Length: 100000']);
+          raw.SockSend(['Content-Type: application/dummy']);
+          raw.SockSend([]); // void line: end of headers
+          raw.SockSendRaw(['truncated body']);
+          raw.SockSendFlush;
+          endtix := GetTickCount64 + 5000;
+          while (bodystreamed = prev) and
+                (GetTickCount64 < endtix) do
+            SleepHiRes(5); // wait until OnBodyDownload created the spool file
+          CheckEqual(bodystreamed, prev + 1, 'abort streamed');
+        finally
+          raw.Free; // close the socket in the middle of the body
+        end;
+      end;
+    finally
+      srv.Free;
+    end;
+    // the server shutdown should have deleted the truncated spool file
+    // (maybe with a delay on THttpAsyncServer due to its connections GC)
+    WaitDeleted('abort');
+  end;
 end;
 
 procedure TNetworkProtocols._THttpProxyCache;

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -4295,15 +4295,43 @@ begin
   CheckEqualShort(s32, 'na3q2n4gw6cly5fvf5da4frmek667zk2');
 end;
 
+type
+  // simulate e.g. a full disk: raise EWriteError after 64KB
+  TFailingStream = class(TStream)
+  protected
+    fWritten: Int64;
+  public
+    function Write(const Buffer; Count: Longint): Longint; override;
+    function Seek(const Offset: Int64; Origin: TSeekOrigin): Int64; override;
+  end;
+
+function TFailingStream.Write(const Buffer; Count: Longint): Longint;
+begin
+  inc(fWritten, Count);
+  if fWritten > 65536 then
+    raise EWriteError.Create('TFailingStream: simulated full disk');
+  result := Count;
+end;
+
+function TFailingStream.Seek(const Offset: Int64; Origin: TSeekOrigin): Int64;
+begin
+  result := 0;
+end;
+
 function TNetworkProtocols.DoBodyDownload(const aUrl, aMethod, aInHeaders,
   aInContentType, aRemoteIP: RawUtf8; aContentLength: Int64): TStream;
 begin
   result := nil;
   if aUrl = '/mem' then
     exit; // in-memory Content fallback
+  inc(bodystreamed);
+  if aUrl = '/fail' then
+  begin
+    result := TFailingStream.Create;
+    exit;
+  end;
   bodyfile := TemporaryFileName;
   result := TFileStreamEx.Create(bodyfile, fmCreate);
-  inc(bodystreamed);
 end;
 
 function TNetworkProtocols.DoBodyRequest(Ctxt: THttpServerRequestAbstract): cardinal;
@@ -4490,6 +4518,46 @@ begin
         CheckEqual(status, 1, '415 identity');
       finally
         raw.Free;
+      end;
+      // simulate a full disk while spooling: EStreamError -> 507 + close
+      prev := bodystreamed;
+      raw := TCrtSocket.Open('127.0.0.1', port);
+      try
+        raw.SockSend(['POST /fail HTTP/1.1']);
+        raw.SockSend(['Host: 127.0.0.1:', port]);
+        raw.SockSend(['Content-Length: 200000']);
+        raw.SockSend(['Content-Type: application/dummy']);
+        raw.SockSend([]); // void line: end of headers
+        for status := 1 to 10 do
+          raw.SockSendRaw([mptext]); // = the announced 200000 bytes
+        raw.SockSendFlush;
+        if fam = 0 then
+        begin
+          // the blocking server reads the whole body before the failing
+          // write, so the 507 response is deterministic here
+          raw.SockRecvLn(line);
+          CheckUtf8(PosEx(' 507 ', line) > 0, 'enospc %', [line]);
+        end;
+        // on the async family the failure occurs in the middle of the body,
+        // so the 507 is best effort: the reset may reach the client first
+      finally
+        raw.Free;
+      end;
+      endtix := GetTickCount64 + 5000;
+      while (bodystreamed = prev) and
+            (GetTickCount64 < endtix) do
+        SleepHiRes(5); // the event fires in a server thread
+      CheckEqual(bodystreamed, prev + 1, 'enospc streamed');
+      // the server must still serve further requests after the disk error
+      clt := THttpClientSocket.Open('127.0.0.1', port);
+      try
+        bodytype := 'application/dummy';
+        bodyhash := Sha256(mptext);
+        status := clt.Post('/big', mptext, bodytype);
+        CheckEqual(status, HTTP_SUCCESS, 'alive after enospc');
+        WaitDeleted('after enospc');
+      finally
+        clt.Free;
       end;
       begin
         // on abort, the server should delete the truncated spool file

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -4301,9 +4301,15 @@ type
   protected
     fWritten: Int64;
   public
+    function Read(var Buffer; Count: Longint): Longint; override;
     function Write(const Buffer; Count: Longint): Longint; override;
     function Seek(const Offset: Int64; Origin: TSeekOrigin): Int64; override;
   end;
+
+function TFailingStream.Read(var Buffer; Count: Longint): Longint;
+begin
+  result := 0; // never read from, but avoid an abstract method
+end;
 
 function TFailingStream.Write(const Buffer; Count: Longint): Longint;
 begin

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -76,6 +76,7 @@ type
     bodyfile: TFileName;
     bodyhash, bodytype: RawUtf8;
     bodystreamed: integer;
+    bodyeventlen: Int64;
     // for _TTunnelLocal
     tunnelappsec: RawUtf8;
     tunneloptions: TTunnelOptions;
@@ -4328,6 +4329,7 @@ function TNetworkProtocols.DoBodyDownload(const aUrl, aMethod, aInHeaders,
   aInContentType, aRemoteIP: RawUtf8; aContentLength: Int64): TStream;
 begin
   result := nil;
+  bodyeventlen := aContentLength;
   if aUrl = '/mem' then
     exit; // in-memory Content fallback
   inc(bodystreamed);
@@ -4456,6 +4458,7 @@ begin
         CheckEqual(status, HTTP_SUCCESS, 'big status');
         CheckEqual(clt.Content, 'ok ' + bodyhash, 'big resp');
         CheckEqual(bodystreamed, prev + 1, 'big streamed');
+        CheckEqual(bodyeventlen, length(body), 'big event len');
         WaitDeleted('big');
         // in-memory fallback when the event returns nil
         status := clt.Post('/mem', body, bodytype);
@@ -4498,6 +4501,7 @@ begin
         finally
           raw.Free;
         end;
+        CheckEqual(bodyeventlen, -1, 'chunked event len');
         WaitDeleted('chunked');
       finally
         clt.Free;
@@ -4554,6 +4558,30 @@ begin
             (GetTickCount64 < endtix) do
         SleepHiRes(5); // the event fires in a server thread
       CheckEqual(bodystreamed, prev + 1, 'enospc streamed');
+      // a chunked body over MaximumAllowedContentLength should get a 413
+      // on both families (its cumulated size is only known while receiving)
+      srv.MaximumAllowedContentLength := 100000;
+      raw := TCrtSocket.Open('127.0.0.1', port);
+      try
+        raw.SockSend(['POST /big HTTP/1.1']);
+        raw.SockSend(['Host: 127.0.0.1:', port]);
+        raw.SockSend(['Transfer-Encoding: chunked']);
+        raw.SockSend(['Content-Type: application/dummy']);
+        raw.SockSend([]); // void line: end of headers
+        for status := 1 to 6 do // 6 x 20000 = 120000 > 100000
+        begin
+          raw.SockSend(['4e20']);
+          raw.SockSend([mptext]);
+        end;
+        raw.SockSend(['0']);
+        raw.SockSend([]); // final void line
+        raw.SockSendFlush;
+        raw.SockRecvLn(line);
+        CheckUtf8(PosEx(' 413 ', line) > 0, 'chunked 413 %', [line]);
+      finally
+        raw.Free;
+        srv.MaximumAllowedContentLength := 0; // restore no limit
+      end;
       // the server must still serve further requests after the disk error
       clt := THttpClientSocket.Open('127.0.0.1', port);
       try


### PR DESCRIPTION
Server-side counterpart of #505, and a first step for #292: let a handler
receive a huge upload without buffering it in memory.

A new `THttpServerGeneric.OnBodyDownload` event is called once the headers
are parsed (and `OnBeforeBody` accepted the request), and can return a
`TStream` - typically a `TFileStreamEx` spooling into a temporary file - to
receive the incoming body. Returning `nil` keeps the current in-memory
behavior. Implemented for both socket-based families, `THttpServer` and
`THttpAsyncServer`, so memory usage stays constant whatever the body size.

The request then reaches the callbacks with `InContentType =
STATICFILE_CONTENT_TYPE` and `InContent` = the local file name, mirroring
the response process; the file is deleted once the request has been
processed, unless the handler renamed or moved it to take ownership. The
original `Content-Type` remains available from `InHeaders`.

Error paths:
- a compressed body (`Content-Encoding:` matching a registered algorithm)
  can not be streamed: 415 + `Accept-Encoding: identity`
- a chunked body over `MaximumAllowedContentLength`: 413 while receiving,
  since its final size is not known in advance
- a failing write into the stream (e.g. a full disk): 507, as best effort -
  the client may still be sending - through the new
  `HTTP_INSUFFICIENTSTORAGE` constant and a `hrsErrorContentStreamWrite`
  state

Two pre-existing bugs showed up while testing this, fixed in the same
branch (both only reachable on `THttpAsyncServer`, and unrelated to the
event itself):
- `THttpRequestContext.ProcessRead` never consumed the chunk data bytes
  from its input buffer in `hrsGetBodyChunkedData` (neither `st.P` nor
  `st.Len`), so the following lines were parsed out of the chunk payload -
  any chunked request body stalled or was rejected
- `DoProcessParseLine` read `P[Len + 1]` without checking the buffer end,
  so a packet ending exactly on the `#13` of a CRLF caused a one byte
  out-of-bounds read, and a stray `#10` there made `st.Len` go negative

Tested by a new `TNetworkProtocols.BodyDownload` method (179 assertions,
both families): spooling and integrity, in-memory fallback, multipart
decoded straight from the spooled file with `THttpMultiPartDecoder`,
chunked bodies, exact `MaximumAllowedContentLength` boundary, 415/413/507,
aborted uploads and spool cleanup. Green with FPC on aarch64-linux and
Delphi Win32/Win64. @zen010101 also ran an extensive matrix on a Rockchip
RK3588 (aarch64, FPC 3.2.3): 111 MB and 4.5 GB uploads, concurrent, rate
limited, real disk-full, keep-alive - all byte-identical by SHA-256, with
no spool leftovers.

Still open, from your first-pass feedback: the stream lifetime. My
suggestion was a `TFileStreamEventuallyDelete = class(TFileStreamEx)` with
a `DeleteFileOnDestroy` property, which would drop `ContentInputName`
entirely - the deletion policy would live in the class, like nginx's
`client_body_in_file_only clean` vs. `on` - plus a
`THttpServerRequestAbstract.InContentStream` property handing the already
open instance to the request instead of reopening it by name.