### PR TITLE
net: OnBodyDownload stream lifetime - TFileStreamEventuallyDelete, rfContentFileNameNeedDelete, InContentStream

### DIFF
--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -3451,6 +3451,31 @@ type
     function Write(const Buffer; Count: Longint): Longint; override;
   end;
 
+  /// file stream which deletes its own file once the instance is released
+  // - the temporary file lifetime is therefore bound to this instance, with no
+  // additional tracking needed by the caller
+  // - used e.g. as TOnHttpServerBodyDownload spool file: the request body is
+  // written into it, is available during the request process, then vanishes
+  // with the stream - this is the equivalent of nginx
+  // "client_body_in_file_only clean" (whereas "on" would keep the file)
+  // - set DeleteFileOnDestroy := false e.g. once the file has been renamed or
+  // moved by the process, so should not be deleted any more
+  TFileStreamEventuallyDelete = class(TFileStreamEx)
+  protected
+    fDeleteFileOnDestroy: boolean;
+  public
+    /// open or create the file, which will be deleted by Destroy
+    // - Mode is typically fmCreate, but a spooled file meant to be read back
+    // by its name while this instance is still open needs a sharing mode, e.g.
+    // fmCreate or fmShareRead (which is mandatory on Windows)
+    constructor Create(const aFileName: TFileName; Mode: cardinal); reintroduce;
+    /// close the handle, then delete the file unless DeleteFileOnDestroy=false
+    destructor Destroy; override;
+    /// set to false to keep the file after this instance is released
+    property DeleteFileOnDestroy: boolean
+      read fDeleteFileOnDestroy write fDeleteFileOnDestroy;
+  end;
+
 /// a wrapper around FileRead() to ensure a whole memory buffer is retrieved
 // - expects Size to be up to 2GB (seems like a big enough memory buffer)
 // - on Windows, will read by 16MB chunks max to avoid ERROR_NO_SYSTEM_RESOURCES
@@ -7881,6 +7906,24 @@ end;
 function TFileStreamEx.GetSize: Int64;
 begin
   result := FileSize(Handle); // faster than 3 FileSeek() calls - and threadsafe
+end;
+
+
+{ TFileStreamEventuallyDelete }
+
+constructor TFileStreamEventuallyDelete.Create(
+  const aFileName: TFileName; Mode: cardinal);
+begin
+  inherited Create(aFileName, Mode); // raise EOSException on invalid handle
+  fDeleteFileOnDestroy := true;
+end;
+
+destructor TFileStreamEventuallyDelete.Destroy;
+begin
+  inherited Destroy; // close the handle first, as required on Windows
+  if fDeleteFileOnDestroy and
+     (fFileName <> '') then
+    DeleteFile(fFileName);
 end;
 
 

--- a/src/net/mormot.net.async.pas
+++ b/src/net/mormot.net.async.pas
@@ -5018,7 +5018,7 @@ begin
     fHttp.ContentStream := strm; // freed by ProcessDone/Reset on abort
     include(fHttp.ResponseFlags, rfContentStreamNeedFree);
     if strm.InheritsFrom(TFileStreamEx) then
-      fHttp.ContentInputName := TFileStreamEx(strm).FileName;
+      fHttp.SetContentInputName(TFileStreamEx(strm));
     // needed to track and limit the cumulated chunked body size
     fHttp.ContentMaxSize := fServer.MaximumAllowedContentLength;
   end;
@@ -5082,15 +5082,11 @@ begin
          (fHttp.State in [hrsGetCommand, hrsUpgraded]) then
         exit; // rejected or upgraded to WebSockets
     end;
-  // close any body stream supplied by OnBodyDownload before the response
-  // process could reuse the ContentStream field - a spooled file remains
-  // available (as InContent file name) during the request processing
-  if (fHttp.ContentStream <> nil) and
-     (rfContentStreamNeedFree in fHttp.ResponseFlags) then
-  begin
-    FreeAndNilSafe(fHttp.ContentStream);
-    exclude(fHttp.ResponseFlags, rfContentStreamNeedFree);
-  end;
+  // move any body stream supplied by OnBodyDownload aside, before the response
+  // process could reuse the ContentStream field - it remains available to the
+  // request as InContentStream, and is released by ProcessDone afterwards
+  if fHttp.ContentStream <> nil then
+    fHttp.ContentInputDone;
   // optionaly uncompress content
   if fHttp.ContentEncoding <> nil then
     fHttp.UncompressData;

--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -346,6 +346,7 @@ type
     rfRange,
     rfHttp10,
     rfContentStreamNeedFree,
+    rfContentFileNameNeedDelete,
     rfAsynchronous,
     rfProgressiveStatic);
 
@@ -461,9 +462,20 @@ type
     /// stream-oriented alternative to the Content in-memory buffer
     // - is typically a TFileStreamEx
     ContentStream: TStream;
+    /// the request body stream supplied by TOnHttpServerBodyDownload
+    // - kept aside from ContentStream (which is reused for the response) once
+    // the body has been received, and released by ProcessDone or Reset, i.e.
+    // once the request has been processed - so is available to the handler as
+    // THttpServerRequestAbstract.InContentStream, rewinded if seekable
+    ContentInputStream: TStream;
     /// local file name of a request body spooled by TOnHttpServerBodyDownload
-    // - this file is deleted by ProcessDone or Reset, i.e. once the request
-    // has been processed, unless the handler did rename/move it meanwhile
+    // - is set from ContentInputStream if it is a TFileStreamEx, and supplied
+    // to the handler as InContent, mirroring the STATICFILE response trick
+    // - if rfContentFileNameNeedDelete is set in ResponseFlags, this file is
+    // deleted by ProcessDone or Reset, i.e. once the request has been
+    // processed, unless the handler did rename/move it meanwhile
+    // - a TFileStreamEventuallyDelete does delete the file by itself, so the
+    // rfContentFileNameNeedDelete flag is not set for such a stream
     ContentInputName: TFileName;
     /// maximum cumulated size of a chunked body written into ContentStream
     // - as set e.g. from THttpServerGeneric.MaximumAllowedContentLength when
@@ -561,6 +573,13 @@ type
     // Content/ContentStream/ContentLength/ContentEncoding are manually set
     // - used by THttpClientSocket.Request on custom protocol (e.g. 'file://')
     function ContentToOutput(aStatus: integer; aOutStream: TStream): integer;
+    /// set ContentInputName from a TOnHttpServerBodyDownload spool stream
+    // - and rfContentFileNameNeedDelete, unless the stream deletes it by itself
+    procedure SetContentInputName(aStream: TFileStreamEx);
+    /// move a received TOnHttpServerBodyDownload body into ContentInputStream
+    // - to be called once the body has been fully received, because the
+    // response process will reuse the ContentStream field for its own output
+    procedure ContentInputDone;
     /// should be done when the HTTP Server state machine is done
     // - will check and process hfContentStreamNeedFree flag
     procedure ProcessDone;
@@ -804,16 +823,25 @@ type
   // rejected as HTTP_PAYLOADTOOLARGE = 413 while it is received
   // - only a body with a Content-Length: header or chunked Transfer-Encoding
   // is streamed: the deprecated HTTP/1.0 close-delimited body is not
-  // - the stream is owned by the server, and will be freed once the body has
-  // been fully received; if the stream is a TFileStreamEx, the request is
-  // then supplied to the OnRequest callback with InContentType set to
-  // STATICFILE_CONTENT_TYPE and InContent set to the local file name (mirroring
-  // the response process), and the file is deleted once the request has been
-  // processed - a handler can rename/move the file to take data ownership
-  // - any other TStream class is freed once the body has been received, i.e.
-  // before OnRequest is called: such a stream should therefore write into
-  // some independently owned storage (e.g. a database or a memory mapped
-  // file), and the instance itself should not be accessed after the download
+  // - the stream is owned by the server, and stays available to the OnRequest
+  // callback as THttpServerRequestAbstract.InContentStream - rewinded to its
+  // beginning if seekable - then is freed once the request has been processed:
+  // a handler should not free it, nor keep any reference past the request
+  // - if the stream is a TFileStreamEx, the request is also supplied with
+  // InContentType set to STATICFILE_CONTENT_TYPE and InContent set to the local
+  // file name (mirroring the response process), and the file is deleted once
+  // the request has been processed - a handler can rename/move the file to take
+  // data ownership; note that the stream is still open at that time, so on
+  // Windows the file needs a sharing mode to be read back by its name, e.g.
+  // TFileStreamEx.Create(fn, fmCreate or fmShareRead)
+  // - use TFileStreamEventuallyDelete for the file to be deleted by the stream
+  // itself: this is the simplest way of binding the spool file lifetime to the
+  // request, and the server won't track that file name by itself
+  // - any other TStream class (e.g. a TPipeStream to a consumer thread, or a
+  // compression stream) has no InContent file name, but is still supplied as
+  // InContentStream - beware that a TPipeStream Write() blocks until its
+  // consumer drains the pipe, which on THttpAsyncServer holds one of the few
+  // event loop threads for the whole upload duration
   // - aInHeaders is the raw headers text, which also includes the 'RemoteIP:'
   // header on THttpServer, but not (yet) on THttpAsyncServer: use aRemoteIP
   // - the original Content-Type header is still available from InHeaders
@@ -857,6 +885,7 @@ type
     fOutContentType: RawUtf8;
     fOutCustomHeaders: RawUtf8;
     fInContent: RawByteString;
+    fInContentStream: TStream;
     fOutContent: RawByteString;
     fConnectionID: THttpServerConnectionID;                  // 64-bit
     fConnectionFlags: THttpServerRequestFlags;               // 8-bit
@@ -898,6 +927,19 @@ type
     // - e.g. some GET/POST/PUT JSON data can be specified here
     property InContent: RawByteString
       read fInContent write fInContent;
+    /// the body stream supplied by the TOnHttpServerBodyDownload event
+    // - nil unless this server has an OnBodyDownload event which returned a
+    // TStream for this request: then the body was written into this stream
+    // instead of the InContent memory buffer, and is available here without
+    // any RAM copy - rewinded to its beginning if the stream is seekable
+    // - is owned by the server, and released once the request is processed:
+    // don't free it, and don't keep any reference past this request
+    // - if the stream was a TFileStreamEx, InContent does also contain its
+    // file name and InContentType is STATICFILE_CONTENT_TYPE - note that on
+    // Windows, reading that file by its name requires the stream to have been
+    // created with a sharing mode, e.g. fmCreate or fmShareRead
+    property InContentStream: TStream
+      read fInContentStream;
     /// output parameter to be set to the response message body
     property OutContent: RawByteString
       read fOutContent write fOutContent;
@@ -3421,6 +3463,29 @@ end;
 
 { THttpRequestContext }
 
+procedure THttpRequestContext.SetContentInputName(aStream: TFileStreamEx);
+begin
+  ContentInputName := aStream.FileName;
+  if not aStream.InheritsFrom(TFileStreamEventuallyDelete) or
+     not TFileStreamEventuallyDelete(aStream).DeleteFileOnDestroy then
+    // this stream won't remove its own file: the server is responsible for it
+    include(ResponseFlags, rfContentFileNameNeedDelete);
+end;
+
+procedure THttpRequestContext.ContentInputDone;
+begin
+  if not (rfContentStreamNeedFree in ResponseFlags) then
+    exit; // not a server-owned TOnHttpServerBodyDownload input stream
+  ContentInputStream := ContentStream; // released by ProcessDone
+  exclude(ResponseFlags, rfContentStreamNeedFree);
+  ContentStream := nil; // input only: don't interfere with the response
+  if (ContentInputStream <> nil) and
+     not ContentInputStream.InheritsFrom(TStreamWithNoSeek) then
+    // rewind for InContentStream reading - but not e.g. on a TPipeStream,
+    // which is the TStreamWithNoSeek class marking a non-seekable stream
+    ContentInputStream.Position := 0;
+end;
+
 procedure THttpRequestContext.ProcessDone;
 begin
   if rfContentStreamNeedFree in ResponseFlags then
@@ -3428,9 +3493,16 @@ begin
     FreeAndNilSafe(ContentStream);
     exclude(ResponseFlags, rfContentStreamNeedFree);
   end;
+  if ContentInputStream <> nil then
+    // a TFileStreamEventuallyDelete does remove its spool file in Destroy
+    FreeAndNilSafe(ContentInputStream);
   if ContentInputName <> '' then
   begin
-    DeleteFile(ContentInputName); // remove any pending spooled body file
+    if rfContentFileNameNeedDelete in ResponseFlags then
+    begin
+      DeleteFile(ContentInputName); // remove any pending spooled body file
+      exclude(ResponseFlags, rfContentFileNameNeedDelete);
+    end;
     ContentInputName := '';
   end;
 end;
@@ -4754,6 +4826,7 @@ begin
     FastAssign(fAuthBearer, aHttp.BearerToken);
   fUserAgent := aHttp.UserAgent;
   fInContent := aHttp.Content;
+  fInContentStream := aHttp.ContentInputStream; // nil if no OnBodyDownload
   if aHttp.ContentInputName <> '' then
   begin
     // the body was spooled into a local file by TOnHttpServerBodyDownload:
@@ -4784,6 +4857,7 @@ begin
   fInHeaders := aInHeaders;
   fInContentType := aInContentType;
   fInContent := aInContent;
+  fInContentStream := nil; // no OnBodyDownload on this non-HTTP code path
 end;
 
 procedure THttpServerRequestAbstract.AddInHeader(AppendedHeader: RawUtf8);

--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -830,18 +830,27 @@ type
   // - if the stream is a TFileStreamEx, the request is also supplied with
   // InContentType set to STATICFILE_CONTENT_TYPE and InContent set to the local
   // file name (mirroring the response process), and the file is deleted once
-  // the request has been processed - a handler can rename/move the file to take
-  // data ownership; note that the stream is still open at that time, so on
-  // Windows the file needs a sharing mode to be read back by its name, e.g.
-  // TFileStreamEx.Create(fn, fmCreate or fmShareRead)
-  // - use TFileStreamEventuallyDelete for the file to be deleted by the stream
-  // itself: this is the simplest way of binding the spool file lifetime to the
-  // request, and the server won't track that file name by itself
-  // - any other TStream class (e.g. a TPipeStream to a consumer thread, or a
-  // compression stream) has no InContent file name, but is still supplied as
-  // InContentStream - beware that a TPipeStream Write() blocks until its
-  // consumer drains the pipe, which on THttpAsyncServer holds one of the few
-  // event loop threads for the whole upload duration
+  // the request has been processed - note that the stream is still open while
+  // the handler runs, so on Windows the file needs a sharing mode to be read
+  // back by its name, e.g. TFileStreamEx.Create(fn, fmCreate or fmShareRead),
+  // and can not be renamed/moved from the handler itself, since our FileShare()
+  // never includes FILE_SHARE_DELETE
+  // - to keep the spool file, i.e. as nginx "client_body_in_file_only on" does,
+  // return a TFileStreamEventuallyDelete: this class owns its own file, so the
+  // server won't delete it, and the handler can set its DeleteFileOnDestroy to
+  // false (from InContentStream) to take data ownership and process the file
+  // once the request is done - with a plain TFileStreamEx, the same is achieved
+  // by excluding rfContentFileNameNeedDelete from ConnectionHttp^.ResponseFlags
+  // - any other TStream class (e.g. a TPipeStream to a consumer thread) has no
+  // InContent file name, but is still supplied as InContentStream - beware that
+  // a TPipeStream Write() blocks until its consumer drains the pipe, which on
+  // THttpAsyncServer holds one of the few event loop threads for the whole
+  // upload duration
+  // - a transformation stream which only finalizes its output when released -
+  // e.g. TSynZipCompressor, which flushes and writes its .gz trailer in its
+  // destructor - will complete its own destination only AFTER the request has
+  // been processed, since the stream is released at that point: such a
+  // callback should not expect its destination to be readable from OnRequest
   // - aInHeaders is the raw headers text, which also includes the 'RemoteIP:'
   // header on THttpServer, but not (yet) on THttpAsyncServer: use aRemoteIP
   // - the original Content-Type header is still available from InHeaders
@@ -3466,9 +3475,11 @@ end;
 procedure THttpRequestContext.SetContentInputName(aStream: TFileStreamEx);
 begin
   ContentInputName := aStream.FileName;
-  if not aStream.InheritsFrom(TFileStreamEventuallyDelete) or
-     not TFileStreamEventuallyDelete(aStream).DeleteFileOnDestroy then
-    // this stream won't remove its own file: the server is responsible for it
+  if not aStream.InheritsFrom(TFileStreamEventuallyDelete) then
+    // this stream has no deletion policy of its own: the server owns the file
+    // - note: a TFileStreamEventuallyDelete is left alone even if its
+    // DeleteFileOnDestroy is false, which is how a callback can ask for the
+    // spool file to be kept, as nginx "client_body_in_file_only on" does
     include(ResponseFlags, rfContentFileNameNeedDelete);
 end;
 
@@ -3483,7 +3494,12 @@ begin
      not ContentInputStream.InheritsFrom(TStreamWithNoSeek) then
     // rewind for InContentStream reading - but not e.g. on a TPipeStream,
     // which is the TStreamWithNoSeek class marking a non-seekable stream
-    ContentInputStream.Position := 0;
+    try
+      ContentInputStream.Position := 0;
+    except
+      // paranoid: a custom non-seekable TStream is supplied as it is, and
+      // should not abort the request from this TStream-focused method
+    end;
 end;
 
 procedure THttpRequestContext.ProcessDone;

--- a/src/net/mormot.net.server.pas
+++ b/src/net/mormot.net.server.pas
@@ -3328,6 +3328,7 @@ begin
   FastAssignNew(fAuthBearer);
   FastAssignNew(fUserAgent);
   fRespStatus := 0;
+  fInContentStream := nil; // paranoid: Prepare() would set it anyway
   fOutContent := '';
   FastAssignNew(fOutContentType);
   FastAssignNew(fOutCustomHeaders);

--- a/src/net/mormot.net.server.pas
+++ b/src/net/mormot.net.server.pas
@@ -5540,34 +5540,25 @@ begin // called from GetRequest() to process OnBodyDownload event
     Http.ContentStream := strm; // freed by Reset on broken connection
     include(Http.ResponseFlags, rfContentStreamNeedFree);
     if strm.InheritsFrom(TFileStreamEx) then
-      Http.ContentInputName := TFileStreamEx(strm).FileName;
+      Http.SetContentInputName(TFileStreamEx(strm));
     // needed to track and limit the cumulated chunked body size
     Http.ContentMaxSize := fServer.MaximumAllowedContentLength;
   end;
 end;
 
 procedure THttpServerSocket.GetBodyStream;
-var
-  strm: TStream;
-  strmfree: boolean;
 begin
   // download into the stream supplied by the OnBodyDownload event
-  strm := Http.ContentStream;
-  strmfree := rfContentStreamNeedFree in Http.ResponseFlags; // likely = true
-  Http.ContentStream := nil; // input only: don't interfere with the response
-  exclude(Http.ResponseFlags, rfContentStreamNeedFree);
   try
-    try
-      GetBody(strm);
-    finally
-      if strmfree then
-        strm.Free; // any spooled file remains during the request processing
-    end;
+    GetBody(Http.ContentStream);
+    // the stream (and any spool file) remains during the request processing,
+    // as InContentStream - and is released by ProcessDone afterwards
+    Http.ContentInputDone;
   except
     on EHttpSocketOverflow do
     begin
       // e.g. a chunked body over ContentMaxSize: report 413 before closing
-      Http.ProcessDone; // delete any partially spooled file
+      Http.ProcessDone; // release the stream + delete any partial spool file
       fServer.ComputeRejectBody(Http.Content, 0, HTTP_PAYLOADTOOLARGE);
       SockSendFlush(Http.Content);
       raise; // the caller will close the connection
@@ -5575,14 +5566,14 @@ begin
     on EStreamError do
     begin
       // e.g. ENOSPC when spooling the body: report it before closing
-      Http.ProcessDone; // delete any partially spooled file
+      Http.ProcessDone; // release the stream + delete any partial spool file
       fServer.ComputeRejectBody(Http.Content, 0, HTTP_INSUFFICIENTSTORAGE);
       SockSendFlush(Http.Content);
       raise; // the caller will close the connection
     end;
     on Exception do
     begin
-      Http.ProcessDone; // delete any partially spooled file
+      Http.ProcessDone; // release the stream + delete any partial spool file
       raise;
     end;
   end;

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -77,6 +77,7 @@ type
     bodytype: RawUtf8;
     bodystreamed, bodyhash: cardinal;
     bodyeventlen: Int64;
+    bodyconsumer: TThread; // is a TPipeConsumerThread (declared below)
     // for _TTunnelLocal
     tunnelappsec: RawUtf8;
     tunneloptions: TTunnelOptions;
@@ -4314,6 +4315,19 @@ type
     function Seek(const Offset: Int64; Origin: TSeekOrigin): Int64; override;
   end;
 
+  // consume a TPipeStream body while the server is still receiving it
+  TPipeConsumerThread = class(TThread)
+  protected
+    fPipe: TPipeStream;
+    fExpected: Int64;
+    fReceived: RawByteString;
+    procedure Execute; override;
+  public
+    constructor Create(aPipe: TPipeStream; aExpected: Int64); reintroduce;
+    property Received: RawByteString
+      read fReceived;
+  end;
+
 function TFailingStream.Read(var Buffer; Count: Longint): Longint;
 begin
   result := 0; // never read from, but avoid an abstract method
@@ -4332,6 +4346,36 @@ begin
   result := 0;
 end;
 
+constructor TPipeConsumerThread.Create(aPipe: TPipeStream; aExpected: Int64);
+begin
+  fPipe := aPipe;
+  fExpected := aExpected;
+  inherited Create({suspended=}false);
+end;
+
+procedure TPipeConsumerThread.Execute;
+var
+  ms: TRawByteStringStream;
+  tmp: TBuffer64K;
+  n: integer;
+begin
+  // the server Write() blocks on a full pipe, so this thread is what makes
+  // the whole upload advance - it stops once the announced size is reached
+  ms := TRawByteStringStream.Create;
+  try
+    while ms.Size < fExpected do
+    begin
+      n := fPipe.Read(tmp, SizeOf(tmp));
+      if n <= 0 then
+        break; // timeout, or Abort from TPipeStream.Destroy
+      ms.WriteBuffer(tmp, n);
+    end;
+    fReceived := ms.DataString;
+  finally
+    ms.Free;
+  end;
+end;
+
 function TNetworkProtocols.DoBodyDownload(const aUrl, aMethod, aInHeaders,
   aInContentType, aRemoteIP: RawUtf8; aContentLength: Int64): TStream;
 begin
@@ -4341,6 +4385,16 @@ begin
     exit; // in-memory Content fallback
   if aUrl = '/ram' then
     result := TRawByteStringStream.Create // not a file: no InContent name
+  else if aUrl = '/pipe' then
+  begin
+    // pipe the body to a background consumer, with no buffering at all
+    result := TPipeStream.Create; // 64KB buffer, i.e. much less than the body
+    // both timeouts default to INFINITE: bound them, so that a regression of
+    // the #543 race would fail this test instead of hanging the whole suite
+    TPipeStream(result).WriteTimeout := 30000;
+    TPipeStream(result).ReadTimeout := 30000;
+    bodyconsumer := TPipeConsumerThread.Create(TPipeStream(result), aContentLength);
+  end
   else if aUrl = '/fail' then
     result := TFailingStream.Create
   else
@@ -4383,6 +4437,18 @@ begin
     Check(Ctxt.InContentStream = nil, 'mem no stream');
     h := crc32cHash(Ctxt.InContent);
     CheckEqual(h, bodyhash, 'mem hash');
+  end
+  else if Ctxt.Url = '/pipe' then
+  begin
+    // the body was piped to bodyconsumer while the server was receiving it
+    CheckEqual(Ctxt.InContent, '', 'pipe no content');
+    Check(Ctxt.InContentStream <> nil, 'pipe stream');
+    // the consumer has read the whole body by now: join it before the server
+    // releases the TPipeStream, which would Abort any pending Read
+    bodyconsumer.WaitFor;
+    h := crc32cHash(TPipeConsumerThread(bodyconsumer).Received);
+    CheckEqual(h, bodyhash, 'pipe hash');
+    FreeAndNil(bodyconsumer);
   end
   else if Ctxt.Url = '/ram' then
   begin
@@ -4533,6 +4599,15 @@ begin
           CheckEqual(status, HTTP_SUCCESS, 'ram status');
           CheckEqual(clt.Content, ok, 'ram resp');
           CheckEqual(bodystreamed, prev + 1, 'ram streamed');
+          // a TPipeStream body: 8MB through a 64KB pipe, i.e. the server does
+          // block on Write() until the consumer thread drains it (this needs
+          // the TSynEvent.WaitFor fix of #543 to be reliable)
+          prev := bodystreamed;
+          status := clt.Post('/pipe', body8mb, bodytype);
+          CheckEqual(status, HTTP_SUCCESS, 'pipe status');
+          CheckEqual(clt.Content, ok, 'pipe resp');
+          CheckEqual(bodystreamed, prev + 1, 'pipe streamed');
+          Check(bodyconsumer = nil, 'pipe consumer joined');
           // a spooled JSON body should keep its Content-Type: in InHeaders
           // (this is the single content type not stored as header text)
           bodytype := JSON_CONTENT_TYPE;

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -4352,6 +4352,14 @@ begin
       // this stream removes its own file: no rfContentFileNameNeedDelete
       result := TFileStreamEventuallyDelete.Create(bodyfile,
         fmCreate or fmShareRead)
+    else if aUrl = '/keep' then
+    begin
+      // this callback takes ownership of the spool file: neither the stream
+      // nor the server should delete it
+      result := TFileStreamEventuallyDelete.Create(bodyfile,
+        fmCreate or fmShareRead);
+      TFileStreamEventuallyDelete(result).DeleteFileOnDestroy := false;
+    end
     else
       result := TFileStreamEx.Create(bodyfile, fmCreate or fmShareRead);
   end;
@@ -4458,6 +4466,7 @@ var
   fam, status, prev, n, endsec: cardinal;
   body8mb: RawByteString;
   mp, ok, hosthead, mpct, mptext, mptrunc, cmd: RawUtf8;
+  keepfile: TFileName;
   mpa: TMultiPartDynArray;
 begin
   TSynLog.Family.ExceptionIgnore.AddSeveral([
@@ -4508,7 +4517,15 @@ begin
           CheckEqual(status, HTTP_SUCCESS, 'del status');
           CheckEqual(clt.Content, ok, 'del resp');
           CheckEqual(bodystreamed, prev + 1, 'del streamed');
-          WaitDeleted('del');
+          WaitDeleted(bodyfile, 'del');
+          // with DeleteFileOnDestroy=false, the spool file should survive the
+          // request - neither the stream nor the server should remove it
+          prev := bodystreamed;
+          status := clt.Post('/keep', body8mb, bodytype);
+          CheckEqual(status, HTTP_SUCCESS, 'keep status');
+          CheckEqual(clt.Content, ok, 'keep resp');
+          CheckEqual(bodystreamed, prev + 1, 'keep streamed');
+          keepfile := bodyfile; // checked after srv.Free below
           // a stream which is not a file has no InContent name at all: it is
           // only reachable from the request as InContentStream
           prev := bodystreamed;
@@ -4770,6 +4787,9 @@ begin
       // the server shutdown should have deleted the truncated spool file
       // (maybe with a delay on THttpAsyncServer due to its connections GC)
       WaitDeleted(bodyfile, 'abort');
+      // by now, the /keep spool file should still be there, untouched
+      Check(FileExists(keepfile), 'keep kept');
+      Check(DeleteFile(keepfile), 'keep deleted');
     end;
   finally
     TSynLog.Family.ExceptionIgnore.RemoveSeveral([

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -4339,12 +4339,21 @@ begin
   bodyeventlen := aContentLength;
   if aUrl = '/mem' then
     exit; // in-memory Content fallback
-  if aUrl = '/fail' then
+  if aUrl = '/ram' then
+    result := TRawByteStringStream.Create // not a file: no InContent name
+  else if aUrl = '/fail' then
     result := TFailingStream.Create
   else
   begin
     bodyfile := TemporaryFileName;
-    result := TFileStreamEx.Create(bodyfile, fmCreate);
+    // fmShareRead is needed because the stream is still open (as
+    // InContentStream) when the request reads the spool file by its name
+    if aUrl = '/del' then
+      // this stream removes its own file: no rfContentFileNameNeedDelete
+      result := TFileStreamEventuallyDelete.Create(bodyfile,
+        fmCreate or fmShareRead)
+    else
+      result := TFileStreamEx.Create(bodyfile, fmCreate or fmShareRead);
   end;
   inc(bodystreamed); // increment last: the tests poll on this counter
 end;
@@ -4363,8 +4372,28 @@ begin
   begin
     // default in-memory process, since DoBodyDownload returned nil
     CheckEqual(Ctxt.InContentType, bodytype, 'mem typ');
+    Check(Ctxt.InContentStream = nil, 'mem no stream');
     h := crc32cHash(Ctxt.InContent);
     CheckEqual(h, bodyhash, 'mem hash');
+  end
+  else if Ctxt.Url = '/ram' then
+  begin
+    // the event returned a stream which is not a file: no InContent name, but
+    // the stream itself is available to this request as InContentStream
+    CheckEqual(Ctxt.InContentType, bodytype, 'ram typ');
+    CheckEqual(Ctxt.InContent, '', 'ram no content');
+    Check(Ctxt.InContentStream <> nil, 'ram stream');
+    Check(Ctxt.InContentStream.InheritsFrom(TRawByteStringStream), 'ram class');
+    // a seekable stream is rewinded, so can be read back from here
+    CheckEqual(Ctxt.InContentStream.Position, 0, 'ram rewind');
+    ms := TRawByteStringStream.Create;
+    try
+      StreamCopyUntilEnd(Ctxt.InContentStream, ms);
+      h := crc32cHash(ms.DataString);
+    finally
+      ms.Free;
+    end;
+    CheckEqual(h, bodyhash, 'ram hash');
   end
   else
   begin
@@ -4404,6 +4433,17 @@ begin
     begin
       h := crc32cHash(StringFromFile(fn));
       CheckEqual(h, bodyhash, 'spool hash');
+      // the spool stream is still open, rewinded, and readable from here
+      Check(Ctxt.InContentStream <> nil, 'spool stream');
+      Check(Ctxt.InContentStream.InheritsFrom(TFileStreamEx), 'spool class');
+      CheckEqual(Ctxt.InContentStream.Position, 0, 'spool rewind');
+      ms := TRawByteStringStream.Create;
+      try
+        StreamCopyUntilEnd(Ctxt.InContentStream, ms);
+        CheckEqual(crc32cHash(ms.DataString), bodyhash, 'spool stream hash');
+      finally
+        ms.Free;
+      end;
     end;
   end;
   Ctxt.OutContent := Make(['ok ', CardinalToHexShort(h)]);
@@ -4461,6 +4501,21 @@ begin
           CheckEqual(status, HTTP_SUCCESS, 'mem status');
           CheckEqual(clt.Content, ok, 'mem resp');
           CheckEqual(bodystreamed, prev + 1, 'mem not streamed');
+          // a TFileStreamEventuallyDelete spool removes its own file, so the
+          // server does not set rfContentFileNameNeedDelete for it
+          prev := bodystreamed;
+          status := clt.Post('/del', body8mb, bodytype);
+          CheckEqual(status, HTTP_SUCCESS, 'del status');
+          CheckEqual(clt.Content, ok, 'del resp');
+          CheckEqual(bodystreamed, prev + 1, 'del streamed');
+          WaitDeleted('del');
+          // a stream which is not a file has no InContent name at all: it is
+          // only reachable from the request as InContentStream
+          prev := bodystreamed;
+          status := clt.Post('/ram', body8mb, bodytype);
+          CheckEqual(status, HTTP_SUCCESS, 'ram status');
+          CheckEqual(clt.Content, ok, 'ram resp');
+          CheckEqual(bodystreamed, prev + 1, 'ram streamed');
           // a spooled JSON body should keep its Content-Type: in InHeaders
           // (this is the single content type not stored as header text)
           bodytype := JSON_CONTENT_TYPE;


### PR DESCRIPTION
Follow-up to #541, addressing the stream lifetime question you raised in its review.

You wrote: *"TFileStreamEventuallyDelete could be the most simple solution. But a new rfContentFileNameNeedDelete item in ResponseFlags could make sense too, because it could work with any kind of stream. We could have both anyway."* — so this has both.

## What is in here

**`TFileStreamEventuallyDelete`** (mormot.core.os) — a `TFileStreamEx` deleting its own file in `Destroy`, with `DeleteFileOnDestroy` to switch it off. The spool file lifetime is then bound to the stream instance, with nothing to track.

**`rfContentFileNameNeedDelete`** (ResponseFlags) — the other half: the server owns the `ContentInputName` file. It is set for any `TFileStreamEx` which is not a `TFileStreamEventuallyDelete`, so the deletion no longer depends on which class the callback returned. Note this fills the flags byte exactly — 8 items now, and both comments in the code promise a single byte.

The two combine into the nginx pair: `client_body_in_file_only clean` is the default, and `on` is a `TFileStreamEventuallyDelete` with `DeleteFileOnDestroy := false`, which the server then leaves alone.

**`THttpServerRequestAbstract.InContentStream`** — the part that makes the rest useful. The body stream now survives until the request has been processed instead of being freed before `Prepare`, and is handed to the handler, rewinded if seekable. `THttpRequestContext.ContentInputDone` moves it out of `ContentStream` (which the response reuses) into the new `ContentInputStream`, and `ProcessDone` releases it at the end of the request. This replaces the early free in both server families.

That last point is what lets a non-file stream be used at all: before, any `TStream` other than a `TFileStreamEx` was written to and then destroyed before `OnRequest`, so the handler never saw it. Now a `TRawByteStringStream`, a pipe or any custom stream can feed the request directly.

## Things worth knowing

- **The spool file can no longer be renamed from the handler on Windows.** The stream stays open while the handler runs, and our `FileShare()` never includes `FILE_SHARE_DELETE`, so `MoveFileW` fails with a sharing violation. It worked before because the stream was closed at that point. Ownership transfer now goes through `DeleteFileOnDestroy := false` (or by excluding the flag) and processing the file after the request. Documented at the event.
- **A stream which finalizes in its destructor completes late.** `TSynZipCompressor` writes its `Flush` and `.gz` trailer in `Destroy`, so its destination is only complete after the request, not during it. That is the direct cost of keeping the stream alive, and the two cannot both be true. If you want an opt-out, the flags byte is now full.
- Spool files need a sharing mode to be read back by their `InContent` name while the stream is open: the tests use `fmCreate or fmShareRead`.

## TPipeStream

You asked to validate that `TPipeStream` works here. It does now — but getting there turned up #543: `TSynEvent.WaitFor` could report a timeout on an event which had been set, which made `TPipeStream.Read` return 0 as if the data had ended. About one request in eight then failed as a 507 after a 30 s stall. With your fix in, the case is covered by a test: an 8 MB body through a 64 KB pipe into a consumer thread, on both server families, 10 consecutive runs green.

Worth keeping in mind regardless: a blocking pipe write happens on the read poll thread in `THttpAsyncServer`, so it stalls that thread's other connections for the upload duration. Noted at the event.
## Tests

`TNetworkProtocols` `HttpBodyDownload` grew three cases, run against both server families: a self-deleting spool, a spool kept by `DeleteFileOnDestroy := false` (checked after server shutdown, and verified to go red without the fix), and a non-file stream read back from `InContentStream`. The existing spool path additionally asserts that `InContentStream` is present and rewinded, and a fourth case pipes the body to a consumer thread. The local `WaitDeleted` helper is gone, using your new `TSynTestCase.WaitDeleted`.

## Gate

Rebased on current master. FPC 3.2.2 aarch64 Linux: `TNetworkProtocols` 0/174246, `TTestCoreBase` 0/118823681, `TTestCoreProcess` 0/14841287. Delphi 13 Win32 and Win64: 0/448 each. The `HttpBodyDownload` block alone was run repeatedly to check for flakiness.

The two review rounds behind this: a self-deleting stream whose `DeleteFileOnDestroy` was false at setup time was still deleted by the server, contradicting the class contract; the `InContentStream` rewind raised on a non-seekable stream not descending from `TStreamWithNoSeek`, aborting the connection with no response; and `THttpServerRequest.Recycle` kept a pointer to the released stream.
