### PR TITLE
ex: new http-server-upload sample streaming multipart uploads to disk

### DIFF
--- a/ex/README.md
+++ b/ex/README.md
@@ -53,6 +53,14 @@ It is a good example of what could be done to achieve the best performance with 
 
 ## Integrated and Advanced Samples
 
+### http-server-upload
+
+[This sample](./http-server-upload) is a stand-alone HTTP server receiving `multipart/form-data` file uploads without ever buffering the request body in memory.
+
+It combines `THttpServerGeneric.OnBodyDownload`, which spools the incoming body into a temporary file, with `THttpMultiPartDecoder`, which walks that spool file section by section - see [issue #292](https://github.com/synopse/mORMot2/issues/292).
+
+A 400 MB upload peaks at 89 MB of resident memory, against 406 MB via the default in-memory path.
+
 ### mvc-blog
 
 [MVC sample web application](./mvc-blog), publishing a simple BLOG.

--- a/ex/http-server-upload/README.md
+++ b/ex/http-server-upload/README.md
@@ -1,0 +1,117 @@
+# Streamed File Upload Server
+
+A stand-alone HTTP server which receives `multipart/form-data` uploads without
+ever holding the request body in memory - the answer to
+[issue #292](https://github.com/synopse/mORMot2/issues/292).
+
+## Running it
+
+Build `httpServerUpload.dpr` (or open `httpServerUpload.lpi` in Lazarus), then:
+
+    ./httpServerUpload --port 8888 --folder ./uploads --maxsize 64
+
+Open `http://localhost:8888/` in a browser for a small upload form, or use any
+HTTP client:
+
+    curl -F 'file=@somefile.bin' -F 'comment=hello' http://localhost:8888/upload
+
+Options: `--port`, `--folder` (where uploads are stored), `--spool` (where the
+temporary body files go, defaults to the system temporary folder), `--maxsize`
+(the maximum accepted body size in MB), `--silent`, `--help`.
+
+## How it works
+
+Two halves, each doing one job:
+
+1. **`THttpServerGeneric.OnBodyDownload`** is asked, once the headers are parsed
+   and a body is known to follow, where that body should go. Returning a
+   `TFileStreamEventuallyDelete` makes the server write the incoming bytes
+   straight into a temporary file instead of the in-memory `Content` buffer. The
+   stream is handed to the request as `InContentStream`, then released - and the
+   spool file deleted with it - once the request has been processed.
+
+   The event returns `nil` for every other URI, so the rest of the server keeps
+   the default in-memory path, which is the right one for small JSON bodies.
+
+2. **`THttpMultiPartDecoder`** walks that stream section by section. Each file
+   section exposes its content as an incremental `TStream`, so a section is
+   copied to its destination without being assembled in memory first.
+
+Each file section is written to a uniquely named staging file inside a
+`.staging` sub-folder of the destination, and renamed to its final name only
+once `Close()` confirmed the final `--boundary--` delimiter was received. A
+connection cut in the middle of an upload otherwise leaves truncated files that
+look exactly like complete ones - and a staging file that outlives a crash stays
+out of the folder being served.
+
+## What it costs
+
+Measured on Linux/FPC with a single 400 MB upload, reading `VmHWM` (peak
+resident memory) of the server process:
+
+| body path | peak memory |
+| --- | --- |
+| `POST /upload` - `OnBodyDownload` returns a spool stream | 89 MB |
+| `POST /other` - `OnBodyDownload` returns `nil`, i.e. the default | 406 MB |
+
+The in-memory path grows with the body: the payload *is* the footprint. With a
+spool stream it does not.
+
+`MaximumAllowedContentLength` is still what bounds a single request: above it,
+the server answers `413` while the body is being received. It applies to a
+`Content-Length` body and - because this sample supplies a stream - to a chunked
+one as well, on its cumulated size.
+
+## Things worth knowing
+
+- **This sample has no authentication, and listens on every interface.** It
+  writes whatever it is sent into a folder. Do not run it on a reachable
+  network without putting something in front of it.
+- **The file name of a section is raw client input.** This sample normalizes
+  the delimiters, strips any path, then rejects what is left if it is empty,
+  `.`, `..`, ends with `.` or a space (Win32 drops those silently, so the stored
+  name would differ from the validated one), or resolves to a DOS device name
+  such as `CON` or `NUL.txt`. The device check looks at the part before the
+  *first* dot, which is how Win32 resolves a device: checking the name without
+  its last extension would let `con.txt.txt` through. The rejections apply on
+  every platform, so the sample behaves the same everywhere.
+- **Staging files live in `<destination>/.staging`.** They must share the file
+  system with the destination, otherwise the final rename fails outright (POSIX
+  `EXDEV`; `MoveFileW` without `MOVEFILE_COPY_ALLOWED`), which rules out putting
+  them next to the spool files. The folder is swept at startup, since a process
+  killed mid-upload leaves its staging file behind.
+- **Replacing an existing file is last-wins, and not atomic on Windows.** The
+  rename is tried first - on POSIX that already replaces the target atomically.
+  Only if it fails is the target deleted and the rename retried, which is what
+  Windows needs, since `RenameFile()` is `MoveFileW()` without
+  `MOVEFILE_REPLACE_EXISTING`. Doing the delete upfront would be simpler but
+  would destroy the previous file even when the new one cannot be put in place.
+- **A failing rename gives `500`, but the result can still be partial**: files
+  published by earlier iterations of the loop stay. There is no atomic way to
+  publish a whole set; a real service would rather version names than replace.
+- The spool file is still open while the handler runs. On Windows it therefore
+  needs a sharing mode to be read back by name (`fmCreate or fmShareRead`, as
+  used here), and it cannot be renamed or moved from the handler, since
+  `FileShare()` never includes `FILE_SHARE_DELETE`. Its default location is the
+  system temporary folder, which on POSIX is world-readable: point `--spool`
+  somewhere private if the uploads are sensitive.
+- `THttpMultiPartDecoder.CreateFromContentType()` only looks for a `boundary`
+  parameter, so the media type is checked separately - otherwise `text/plain;
+  boundary=x` would be decoded as multipart and stored.
+- The number of sections is capped (`MAX_PARTS`): each file section costs one
+  staging file, so a body made of many tiny parts would otherwise be a cheap way
+  to burn inodes and CPU.
+- `MaximumAllowedContentLength` of `0` or less means *no limit* to mORMot, which
+  is why `--maxsize` is read with a bounded overload: a typo would otherwise
+  remove the very protection the option advertises.
+- A body with a `Content-Encoding` matching a registered compression algorithm
+  cannot be streamed, and is rejected as `415`. The deprecated HTTP/1.0
+  close-delimited body is not streamed either.
+- **The handler still occupies one server thread for the whole decode.**
+  Spooling the body keeps it out of memory, not out of the thread pool:
+  `StreamCopyUntilEnd` copies each section synchronously on one of the (four,
+  here) `THttpAsyncServer` threads. For multi-gigabyte uploads, hand the work to
+  dedicated workers, or use a server model made for blocking handlers. A
+  `TPipeStream` to a consumer thread would avoid the intermediate file
+  altogether, but its `Write()` blocks until the consumer drains it, holding an
+  event loop thread for the whole upload rather than just the decode.

--- a/ex/http-server-upload/httpServerUpload.dpr
+++ b/ex/http-server-upload/httpServerUpload.dpr
@@ -1,0 +1,35 @@
+program httpServerUpload;
+
+{
+  HTTP Server receiving multipart/form-data file uploads without buffering
+  the request body in memory - see https://github.com/synopse/mORMot2/issues/292
+}
+
+{$I mormot.defines.inc}
+
+{$ifdef OSWINDOWS}
+  {$apptype console}
+  {$R ..\..\src\mormot.win.default.manifest.res}
+{$endif OSWINDOWS}
+
+uses
+  {$I mormot.uses.inc} // may include mormot.core.fpcx64mm.pas
+  sysutils,
+  mormot.core.os,
+  mormot.core.text,
+  uploadServerMain in 'uploadServerMain.pas';
+
+begin
+  try
+    //ReportMemoryLeaksOnShutdown := true;
+    Main;
+    {$ifdef FPC_X64MM}
+    if (ExitCode = 0) and
+       not silent then
+      WriteHeapStatus(' ', 16, 8, {compileflags=}true);
+    {$endif FPC_X64MM}
+  except
+    on E: Exception do
+      ConsoleShowFatalException(E);
+  end;
+end.

--- a/ex/http-server-upload/httpServerUpload.lpi
+++ b/ex/http-server-upload/httpServerUpload.lpi
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="\"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+        <CompatibilityMode Value="True"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="httpServerUpload"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes Count="1">
+      <Item1 Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+    </RunParams>
+    <RequiredPackages Count="1">
+      <Item1>
+        <PackageName Value="mormot2"/>
+      </Item1>
+    </RequiredPackages>
+    <Units Count="2">
+      <Unit0>
+        <Filename Value="httpServerUpload.dpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit0>
+      <Unit1>
+        <Filename Value="uploadServerMain.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit1>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target>
+      <Filename Value="exe\httpServerUpload"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+    <CodeGeneration>
+      <Optimizations>
+        <OptimizationLevel Value="3"/>
+      </Optimizations>
+    </CodeGeneration>
+    <Linking>
+      <Debugging>
+        <DebugInfoType Value="dsDwarf3"/>
+        <UseExternalDbgSyms Value="True"/>
+      </Debugging>
+    </Linking>
+    <Other>
+      <CustomOptions Value="-dFPC_X64MM
+-dFPCMM_SERVER
+-dFPCMM_REPORTMEMORYLEAKS
+-dFPCMM_DEBUG"/>
+    </Other>
+  </CompilerOptions>
+  <Debugging>
+    <Exceptions Count="3">
+      <Item1>
+        <Name Value="EAbort"/>
+      </Item1>
+      <Item2>
+        <Name Value="ECodetoolError"/>
+      </Item2>
+      <Item3>
+        <Name Value="EFOpenError"/>
+      </Item3>
+    </Exceptions>
+  </Debugging>
+</CONFIG>

--- a/ex/http-server-upload/uploadServerMain.pas
+++ b/ex/http-server-upload/uploadServerMain.pas
@@ -1,0 +1,391 @@
+unit uploadServerMain;
+
+{$I mormot.defines.inc}
+
+interface
+
+uses
+  sysutils,
+  classes,
+  mormot.core.base,
+  mormot.core.os,
+  mormot.core.text,
+  mormot.core.unicode,
+  mormot.net.http,
+  mormot.net.server,
+  mormot.net.async,
+  mormot.net.client; // for THttpMultiPartDecoder
+
+type
+  /// a HTTP server receiving file uploads with a constant memory usage
+  // - the incoming request body never reaches the RAM: OnBodyDownload spools
+  // it into a temporary file, then THttpMultiPartDecoder walks that file
+  // section by section - see https://github.com/synopse/mORMot2/issues/292
+  TUploadServer = class
+  protected
+    fHttp: THttpAsyncServer;
+    fDestFolder, fSpoolFolder, fStagingFolder: TFileName;
+    // the two halves of the process
+    function DoBodyDownload(const aUrl, aMethod, aInHeaders, aInContentType,
+      aRemoteIP: RawUtf8; aContentLength: Int64): TStream;
+    function DoRequest(Ctxt: THttpServerRequestAbstract): cardinal;
+    // POST /upload: decode the spooled body, and store its file sections
+    function DoUpload(Ctxt: THttpServerRequestAbstract): cardinal;
+    // turn the client supplied file name into a name within fDestFolder
+    function SafeDestFile(const aClientName: RawUtf8; out aDest: TFileName): boolean;
+    // publish one staging file, working around the platform rename semantics
+    function Publish(const aStaging, aDest: TFileName): boolean;
+  public
+    /// start the HTTP server on the supplied port
+    constructor Create(const aPort: RawUtf8; const aDestFolder, aSpoolFolder: TFileName;
+      aMaxBodyMB: integer);
+    /// release the HTTP server
+    destructor Destroy; override;
+  end;
+
+var
+  silent: boolean;
+
+procedure Main;
+
+implementation
+
+const
+  UPLOAD_URI = '/upload';
+
+  /// sub-folder of the destination, holding the files being written
+  // - must be on the SAME file system as the destination, otherwise the final
+  // rename would fail (POSIX EXDEV, and MoveFileW without MOVEFILE_COPY_ALLOWED)
+  STAGING_SUBFOLDER = '.staging';
+
+  /// refuse a body made of an unreasonable number of sections
+  // - each file section costs one staging file, so an otherwise legitimate
+  // 64 MB body made of tiny parts could exhaust inodes and CPU
+  MAX_PARTS = 64;
+
+  // Win32 reserved device names: creating one of these opens the DEVICE, not a
+  // file - THttpMultiPartDecoder documentation asks callers to reject them
+  DOS_DEVICES: array[0 .. 21] of RawUtf8 = (
+    'CON', 'PRN', 'AUX', 'NUL',
+    'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+    'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9');
+
+  // the browser form served at the root URI, to try the sample by hand
+  UPLOAD_FORM: RawUtf8 =
+    '<!doctype html><html><head><meta charset="utf-8">' +
+    '<title>mORMot upload sample</title></head><body>' +
+    '<h1>mORMot streamed upload</h1>' +
+    '<form method="post" action="/upload" enctype="multipart/form-data">' +
+    '<p><input type="file" name="file" multiple></p>' +
+    '<p><input type="text" name="comment" placeholder="a plain form field"></p>' +
+    '<p><button type="submit">Upload</button></p>' +
+    '</form></body></html>';
+
+
+{ TUploadServer }
+
+constructor TUploadServer.Create(const aPort: RawUtf8;
+  const aDestFolder, aSpoolFolder: TFileName; aMaxBodyMB: integer);
+begin
+  fDestFolder := EnsureDirectoryExists(aDestFolder, EOSException);
+  fStagingFolder := EnsureDirectoryExists(
+    fDestFolder + STAGING_SUBFOLDER, EOSException);
+  fSpoolFolder := EnsureDirectoryExists(aSpoolFolder, EOSException);
+  // a process killed mid-upload leaves its staging and spool files behind, so
+  // sweep them at startup - they are useless once their request is gone
+  DirectoryDelete(fStagingFolder, FILES_ALL, {filesonly=}true);
+  fHttp := THttpAsyncServer.Create(aPort, nil, nil, 'upload', {threads=}4);
+  // a body larger than this is refused with a 413 while it is received, so
+  // neither the RAM nor the spool disk can be filled by a single client - this
+  // applies to a Content-Length body AND to a chunked one, the latter only
+  // because DoBodyDownload below returns a stream
+  // - note: mORMot reads a value <= 0 as "no limit at all", so the caller is
+  // responsible for never passing one (see Main below)
+  fHttp.MaximumAllowedContentLength := Int64(aMaxBodyMB) shl 20;
+  fHttp.OnBodyDownload := DoBodyDownload;
+  fHttp.OnRequest := DoRequest;
+  fHttp.WaitStarted;
+end;
+
+destructor TUploadServer.Destroy;
+begin
+  fHttp.Free;
+  inherited Destroy;
+end;
+
+function TUploadServer.DoBodyDownload(const aUrl, aMethod, aInHeaders,
+  aInContentType, aRemoteIP: RawUtf8; aContentLength: Int64): TStream;
+begin
+  // this event is called once the headers have been parsed and a body is
+  // actually following - returning nil falls back to the default in-memory
+  // buffering, which is what every other URI of this server wants
+  result := nil;
+  if not IdemPropNameU(aMethod, 'POST') or
+     not IdemPropNameU(aUrl, UPLOAD_URI) then
+    exit;
+  // one spool file per request - TemporaryFileName() is thread-safe, which
+  // matters because this event runs on the server event loop threads, and it
+  // returns a name which does not exist yet
+  // - TFileStreamEventuallyDelete removes that file when the server releases
+  // the stream, i.e. once the request has been processed: nothing to track,
+  // and nothing to clean up on error
+  // - fmShareRead is what allows the file to be read back by its name while
+  // this stream is still open - mandatory on Windows, harmless elsewhere
+  result := TFileStreamEventuallyDelete.Create(
+    TemporaryFileName(fSpoolFolder, 'upload'), fmCreate or fmShareRead);
+end;
+
+function TUploadServer.DoRequest(Ctxt: THttpServerRequestAbstract): cardinal;
+begin
+  if IdemPropNameU(Ctxt.Method, 'POST') and
+     IdemPropNameU(Ctxt.Url, UPLOAD_URI) then
+    result := DoUpload(Ctxt)
+  else if IdemPropNameU(Ctxt.Method, 'GET') and
+          (IdemPropNameU(Ctxt.Url, '/') or
+           (Ctxt.Url = '')) then
+  begin
+    Ctxt.OutContent := UPLOAD_FORM;
+    Ctxt.OutContentType := HTML_CONTENT_TYPE;
+    result := HTTP_SUCCESS;
+  end
+  else
+    result := HTTP_NOTFOUND;
+end;
+
+function TUploadServer.SafeDestFile(const aClientName: RawUtf8;
+  out aDest: TFileName): boolean;
+var
+  fn, base: TFileName;
+  last: char;
+  dot: PtrInt;
+begin
+  result := false;
+  // the "filename" parameter is raw client input: it may hold a path, a '..'
+  // sequence, or the delimiter of the OTHER operating system - so any path is
+  // stripped here and only the last name kept, i.e. 'a/../../b.txt' is stored
+  // as 'b.txt' rather than being rejected, which keeps browsers sending a full
+  // local path usable
+  fn := NormalizeFileName(Utf8ToString(aClientName)); // unify \ and /
+  fn := ExtractFileName(fn);                          // drop any path
+  // what is left can still be unusable, e.g. '..' has no path to strip
+  if (fn = '') or
+     (fn = '.') or
+     (fn = '..') or
+     not SafeFileName(fn) then
+    exit;
+  // Win32 silently drops a trailing '.' or ' ', so the stored file would not
+  // have the name we validated - rejected on every platform, for one behaviour
+  last := fn[length(fn)];
+  if (last = '.') or
+     (last = ' ') then
+    exit;
+  // same reasoning for the DOS device names: 'CON' or 'NUL.txt' would write to
+  // a device on Windows, so they are refused everywhere rather than turning
+  // this sample into a platform-dependent one
+  // - the name to check is what comes before the FIRST dot, with any trailing
+  // space removed, which is how Win32 resolves a device - not the file name
+  // without its last extension, otherwise 'con.txt.txt' would slip through
+  dot := Pos('.', fn);
+  if dot = 0 then
+    base := fn
+  else
+    base := copy(fn, 1, dot - 1);
+  while (base <> '') and
+        (base[length(base)] = ' ') do
+    SetLength(base, length(base) - 1); // Win32 ignores trailing spaces, too
+  if FindPropName(DOS_DEVICES, StringToUtf8(base)) >= 0 then
+    exit;
+  aDest := fDestFolder + fn;
+  result := true;
+end;
+
+function TUploadServer.Publish(const aStaging, aDest: TFileName): boolean;
+begin
+  // try the plain rename first: on POSIX it atomically replaces any existing
+  // target, so nothing is ever missing in between
+  result := RenameFile(aStaging, aDest);
+  if result then
+    exit;
+  // it failed - most likely because the target exists and this is Windows,
+  // where RenameFile() is MoveFileW() without MOVEFILE_REPLACE_EXISTING
+  // - deleting the target first is what makes both platforms behave alike, but
+  // it is deliberately the SECOND attempt: doing it upfront would destroy the
+  // previous file even when the new one cannot be put in place
+  // - a real service would rather not replace at all, e.g. by versioning the
+  // name; this sample settles on last-wins and keeps the window as small as
+  // the platform allows
+  if not DeleteFile(aDest) then
+    exit;
+  result := RenameFile(aStaging, aDest);
+end;
+
+function TUploadServer.DoUpload(Ctxt: THttpServerRequestAbstract): cardinal;
+var
+  mp: THttpMultiPartDecoder;
+  ct, fields: RawUtf8;
+  dest: TFileName;
+  // each section is written to a staging file of its own, and renamed to its
+  // final name only once the whole body proved valid
+  staging, final: array of TFileName;
+  part: TFileStreamEx;
+  files, parts, i: integer;
+begin
+  result := HTTP_BADREQUEST;
+  Ctxt.OutContentType := TEXT_CONTENT_TYPE;
+  files := 0;
+  parts := 0;
+  fields := '';
+  final := nil;   // silence the compiler: managed types are nil anyway
+  staging := nil;
+  // the spooled body is supplied as InContentStream, rewinded and still open
+  // - with a TFileStreamEx (as here), Ctxt.InContent also holds its local file
+  // name and InContentType is STATICFILE_CONTENT_TYPE, mirroring the response
+  // process - but reading the stream directly needs no file name at all
+  if (Ctxt.InContentStream = nil) or
+     not FindNameValue(Ctxt.InHeaders, 'CONTENT-TYPE:', ct) or
+     // CreateFromContentType() only looks for a "boundary" parameter, so the
+     // media type itself has to be checked here - otherwise 'text/plain;
+     // boundary=x' would be decoded as multipart and stored
+     not IdemPChar(pointer(ct), 'MULTIPART/FORM-DATA') then
+  begin
+    Ctxt.OutContent := 'expected a multipart/form-data body';
+    exit;
+  end;
+  try
+    try
+      mp := THttpMultiPartDecoder.CreateFromContentType(Ctxt.InContentStream, ct);
+      try
+        while mp.NextPart do
+        begin
+          inc(parts);
+          if parts > MAX_PARTS then
+          begin
+            Ctxt.OutContent := 'too many sections in this body';
+            exit; // the outer finally removes what was written so far
+          end;
+          if mp.FileName = '' then
+            // a plain form field - this sample only reports the field names, so
+            // its value is left for NextPart to drain from the spool file
+            fields := FormatUtf8('% %', [fields, mp.Name])
+          else
+          begin
+            // a file section: stream it out, never buffering the whole content
+            if not SafeDestFile(mp.FileName, dest) then
+            begin
+              Ctxt.OutContent := 'unusable file name';
+              exit;
+            end;
+            if files = length(final) then
+            begin
+              SetLength(final, NextGrow(files));
+              SetLength(staging, length(final));
+            end;
+            final[files] := dest;
+            // the staging name is unique, and lives in a sub-folder of the
+            // destination: same file system, so the rename below stays cheap,
+            // but out of the folder being served - a process killed mid-upload
+            // would otherwise leave a partial file among the published ones
+            // - a shared '<name>.part' would not do either: two sections of one
+            // request, or two concurrent requests, carrying the same file name
+            // would write over each other and publish a corrupted file that
+            // still looks complete
+            staging[files] := TemporaryFileName(fStagingFolder, 'part');
+            inc(files);
+            part := TFileStreamEx.Create(staging[files - 1], fmCreate);
+            try
+              // Content is incremental and its size is unknown in advance, so
+              // TStream.CopyFrom(src, 0) would silently copy nothing here
+              StreamCopyUntilEnd(mp.Content, part);
+            finally
+              part.Free;
+            end;
+          end;
+        end;
+        // only a final --boundary-- delimiter proves the body was complete: a
+        // connection cut in the middle would otherwise leave truncated files
+        // looking exactly like good ones
+        if not mp.Close then
+        begin
+          Ctxt.OutContent := 'truncated or malformed multipart body';
+          exit;
+        end;
+      finally
+        mp.Free;
+      end;
+      // the upload is valid: publish each file under its final name
+      for i := 0 to files - 1 do
+        if not Publish(staging[i], final[i]) then
+        begin
+          // report no success for a file which was not stored - note that the
+          // files published by the previous iterations do stay: there is no
+          // atomic way of publishing a whole set, so this is a partial result
+          // - only the client supplied name is echoed back, never our path
+          Ctxt.OutContent := FormatUtf8('could not store %',
+            [ExtractFileName(final[i])]);
+          result := HTTP_SERVERERROR;
+          exit;
+        end;
+      Ctxt.OutContent := FormatUtf8('% file(s) stored, fields:%', [files, fields]);
+      result := HTTP_SUCCESS;
+    except
+      on EHttpMultiPart do
+        // malformed input is a client error, not a server failure: Read() does
+        // raise on truncated data, rather than returning it as a short section
+        // - the exception text names our internal classes, so it is not echoed
+        Ctxt.OutContent := 'invalid multipart body';
+    end;
+  finally
+    // whatever went wrong, no staging file survives the request - a staging
+    // file already renamed above simply is not there any more
+    for i := 0 to files - 1 do
+      DeleteFile(staging[i]);
+  end;
+end;
+
+
+procedure Main;
+var
+  cmd: TExecutableCommandLine;
+  port: RawUtf8;
+  dest, spool: TFileName;
+  maxmb: integer;
+  server: TUploadServer;
+begin
+  cmd := Executable.Command;
+  port  := cmd.Param('&port', 'the HTTP #port to listen on', '8888');
+  dest  := cmd.ParamS('&folder', 'the #foldername where uploads are stored',
+    Executable.ProgramFilePath + 'uploads');
+  spool := cmd.ParamS('&spool', 'the #foldername for temporary body files',
+    GetSystemPath(spTemp));
+  // a bounded value on purpose: MaximumAllowedContentLength <= 0 means "no
+  // limit" to mORMot, so '--maxsize 0' would silently remove the cap
+  if not cmd.Get('&maxsize', 1, 65536, maxmb, 'the maximum body #size in MB',
+       {default=}64) then
+    maxmb := 64;
+  silent := cmd.Option('silent', 'no output to the console');
+  if cmd.ConsoleHelpFailed(
+    'mORMot 2.' + SYNOPSE_FRAMEWORK_BRANCH + ' Streamed Upload Server') then
+  begin
+    ExitCode := 1;
+    exit;
+  end;
+  server := TUploadServer.Create(port, dest, spool, maxmb);
+  try
+    if not silent then
+    begin
+      // this sample has no authentication whatsoever, and the server listens on
+      // every network interface, not just the loopback one
+      ConsoleWrite('Listening on port % (ALL interfaces, no authentication)',
+        [port], ccLightRed);
+      ConsoleWrite('Try http://localhost:%/ - uploads go to %',
+        [port, dest], ccLightGreen);
+      ConsoleWrite('Press [Enter] to quit', ccLightGray);
+    end;
+    // wait even when silent: this is what keeps the server running
+    ConsoleWaitForEnterKey;
+  finally
+    server.Free;
+  end;
+end;
+
+end.


### PR DESCRIPTION
Closes #292

`OnBodyDownload` (#541, #544) and `THttpMultiPartDecoder` (#505) are both in, but
no sample shows them together - so #292 currently leads to two classes and no
entry point.

`POST /upload` returns a `TFileStreamEventuallyDelete` from `OnBodyDownload`: the
body is spooled to a temp file that vanishes with the request, and the decoder
copies each section straight to its destination. Any other URI returns `nil` and
keeps the in-memory path. `GET /` serves a form to try it from a browser.

Peak RSS (`VmHWM`) for one 400 MB upload, Linux/FPC: **89 MB** through the spool
stream, **406 MB** with `OnBodyDownload` returning `nil`.

Sample code gets copied, so the tricky parts are handled and commented:

- `TemporaryFileName()` for spool and staging names - `OnBodyDownload` runs on the
  event loop threads
- staging in a `.staging` sub-folder of the destination: same file system, but out
  of the served folder if the process is killed (swept at startup). A shared
  `<name>.part` breaks when two sections carry the same file name
- publish = rename first (atomic replace on POSIX), delete + retry only on failure
  (`RenameFile()` is `MoveFileW()` without `MOVEFILE_REPLACE_EXISTING`). Deleting
  upfront would lose the old file when the new one can't be put in place
- file name: path stripped, then `''`, `.`, `..`, trailing `.`/space and DOS device
  names refused - device check on the part before the *first* dot, otherwise
  `con.txt.txt` slips through
- media type checked separately: `CreateFromContentType()` only looks for a
  `boundary`, so `text/plain; boundary=x` would decode
- section count capped; `--maxsize` bounded (`MaximumAllowedContentLength <= 0` =
  no limit); errors echo no server paths or exception text
- `EHttpMultiPart` -> 400, not 500

README lists what the sample does *not* do: no auth, listens on all interfaces,
spool defaults to the world-readable temp folder, no atomic publish of a whole
set, and the decode still holds one server thread.

Verified: warning-free with FPC 3.2.2 (aarch64-linux) and dcc64 37.0. Runtime on
Linux: byte-identical round-trip to 400 MB, name matrix incl. the bypass attempts,
`text/plain; boundary=x`, 70 sections, failing rename (500, no leftover, target
intact), staging swept after SIGKILL, 413 / 400 / 404 paths.

Windows build is compiled only, not run - this machine is ARM64, so a failure
under Prism emulation could just as well be the emulator.
