### PR TITLE
Fix Linux x86-64 large allocations

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -2340,7 +2340,7 @@ asm     // size = rcx on Windows, = rdi on SystemV; use rsi = TSmallBlockType
         // ---------- LARGE block allocation ----------
 @IsALargeBlockRequest:
         xor     rax, rax
-        test    rcx, rcx
+        test    size, size
         js      @Done
         // Note: size is still in the rcx/rdi first param register
         call    AllocateLargeBlock

--- a/test/test.core.base.pas
+++ b/test/test.core.base.pas
@@ -359,6 +359,22 @@ end;
 
 {$ifdef FPC_X64MM}
 
+{$ifdef LINUX}
+
+type
+  TFpcX64GetMem = function(Size: PtrUInt): pointer;
+
+function FpcX64GetMemWithNegativeRcx(GetMemProc: TFpcX64GetMem;
+  Size: PtrUInt): pointer; nostackframe; assembler;
+asm
+        mov     rax, rdi
+        mov     rdi, rsi
+        mov     rcx, -1
+        jmp     rax
+end;
+
+{$endif LINUX}
+
 procedure TTestCoreBase._fpcx64mm;
 const
   Sizes: array[0 .. 13] of PtrUInt = (
@@ -370,7 +386,17 @@ const
 var
   i: PtrInt;
   p: pointer;
+  {$ifdef LINUX}
+  manager: TMemoryManager;
+  {$endif LINUX}
 begin
+  {$ifdef LINUX}
+  GetMemoryManager(manager);
+  p := FpcX64GetMemWithNegativeRcx(manager.GetMem, 1024 * 1024);
+  Check(p <> nil, 'GetMem Linux large');
+  if p <> nil then
+    FreeMem(p);
+  {$endif LINUX}
   for i := 0 to high(Sizes) do
   begin
     p := GetMem(Sizes[i]);


### PR DESCRIPTION
After `_GetMem` was moved to `RSI`, its large-allocation path still tested
`RCX`:

```asm
test rcx, rcx
```

This happens to be the `size` argument on Win64, but under the System V ABI the
argument is passed in `RDI`. `RCX` is caller-saved and no longer has a defined
value at this point. A valid large allocation could therefore return `nil` when
the high bit of the unrelated `RCX` value was set.

The fix uses the symbolic argument instead:

```asm
test size, size
```

FPC resolves it to `RCX` on Win64 and `RDI` on System V, so the Win64 machine
code is unchanged.

The regression test calls the installed memory manager through a small Linux
x86-64 assembler wrapper, sets `RCX = -1`, and requests 1 MiB. It fails
deterministically on current `master` and passes with this fix.

Validation on the exact PR base:

- Linux x86-64, stock FPC 3.2.2, `FPC_X64MM + FPCMM_SERVER`;
- before the fix: `_fpcx64mm` fails 1 of 15 checks;
- after the fix: 15 of 15 checks pass;
- multithreaded `TTestCoreBase`: 107,911,064 assertions, no failures;
- the Win64 unit and focused allocation probe compile and pass.
