### PR TITLE
Use an ABI-specific block register in _FreeMem

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -2491,7 +2491,7 @@ const
 
 function _FreeMem(P: pointer): PtrUInt;
   {$ifdef NOSFRAME} nostackframe; {$endif} assembler;
-asm     // P = rcx on Windows, P = rdi on SystemV; use rsi = TSmallBlockType
+asm     // P = rcx on Windows, P = rdi on SystemV; keep P in rcx on both ABIs
         {$ifndef MSWINDOWS}
         mov     rcx, P
         {$endif MSWINDOWS}
@@ -2510,22 +2510,22 @@ asm     // P = rcx on Windows, P = rdi on SystemV; use rsi = TSmallBlockType
         // Is it a small block in use?
         test    dl, IsFreeBlockFlag + IsMediumBlockFlag + IsLargeBlockFlag
         jnz     @NotSmallBlockInUse
-        // Get the small block type in rsi and try to grab it
+        // Get the small block type in rdi and try to grab it
         {$ifdef MSWINDOWS}
-        push    rsi
+        push    rdi
         {$endif MSWINDOWS}
-        mov     rsi, [rdx].TSmallBlockPoolHeader.BlockType
+        mov     rdi, [rdx].TSmallBlockPoolHeader.BlockType
         {$ifndef FPCMM_ASSUMEMULTITHREAD}
         cmp     byte ptr [rax], false
         je      @FreeAndUnLock
         {$endif FPCMM_ASSUMEMULTITHREAD}
         mov     eax, $100
-  lock  cmpxchg byte ptr [rsi].TSmallBlockType.Locked, ah
+  lock  cmpxchg byte ptr [rdi].TSmallBlockType.Locked, ah
         jne     @TinySmallLocked
 @FreeAndUnlock:
-        // rsi=TSmallBlockType rcx=P rdx=TSmallBlockPoolHeader
+        // rdi=TSmallBlockType rcx=P rdx=TSmallBlockPoolHeader
         // Adjust number of blocks in use, set rax = old first free block
-        add     [rsi].TSmallBlockType.FreememCount, 1
+        add     [rdi].TSmallBlockType.FreememCount, 1
         mov     rax, [rdx].TSmallBlockPoolHeader.FirstFreeBlock
         sub     [rdx].TSmallBlockPoolHeader.BlocksInUse, 1
         jz      @PoolIsNowEmpty
@@ -2538,21 +2538,21 @@ asm     // P = rcx on Windows, P = rdi on SystemV; use rsi = TSmallBlockType
         test    rax, rax
         jnz     @SmallPoolWasNotFull
         // Insert the pool back into the linked list if it was full
-        mov     rcx, [rsi].TSmallBlockType.NextPartiallyFreePool
-        mov     [rdx].TSmallBlockPoolHeader.PreviousPartiallyFreePool, rsi
+        mov     rcx, [rdi].TSmallBlockType.NextPartiallyFreePool
+        mov     [rdx].TSmallBlockPoolHeader.PreviousPartiallyFreePool, rdi
         mov     [rdx].TSmallBlockPoolHeader.NextPartiallyFreePool, rcx
         mov     [rcx].TSmallBlockPoolHeader.PreviousPartiallyFreePool, rdx
-        mov     [rsi].TSmallBlockType.NextPartiallyFreePool, rdx
+        mov     [rdi].TSmallBlockType.NextPartiallyFreePool, rdx
 @SmallPoolWasNotFull:
         // Try to release all pending bin from this block while we have the lock
-        cmp     dword ptr [rsi].TSmallBlockType.LastFreeCount, 0
+        cmp     dword ptr [rdi].TSmallBlockType.LastFreeCount, 0
         jne     @ProcessPendingBin
         // Release the lock and return the block size as FPC RTL MM
-@NoBin: mov     byte ptr [rsi].TSmallBlockType.Locked, false
-        movzx   eax, word ptr [rsi].TSmallBlockType.BlockSize
+@NoBin: mov     byte ptr [rdi].TSmallBlockType.Locked, false
+        movzx   eax, word ptr [rdi].TSmallBlockType.BlockSize
         {$ifdef NOSFRAME}
         {$ifdef MSWINDOWS}
-        pop     rsi
+        pop     rdi
         {$endif MSWINDOWS}
         ret
 @Void:  xor     eax, eax
@@ -2573,17 +2573,17 @@ asm     // P = rcx on Windows, P = rdi on SystemV; use rsi = TSmallBlockType
         mov     [rcx].TSmallBlockPoolHeader.PreviousPartiallyFreePool, rax
         // Is this the sequential feed pool? If so, stop sequential feeding
         xor     eax, eax
-        cmp     [rsi].TSmallBlockType.CurrentSequentialFeedPool, rdx
+        cmp     [rdi].TSmallBlockType.CurrentSequentialFeedPool, rdx
         jne     @NotSequentialFeedPool
 @IsSequentialFeedPool:
-        mov     [rsi].TSmallBlockType.MaxSequentialFeedBlockAddress, rax
+        mov     [rdi].TSmallBlockType.MaxSequentialFeedBlockAddress, rax
 @NotSequentialFeedPool:
         // Unlock blocktype and release this pool
-        mov     byte ptr [rsi].TSmallBlockType.Locked, false
+        mov     byte ptr [rdi].TSmallBlockType.Locked, false
         mov     rcx, rdx
         mov     rdx, [rdx - BlockHeaderSize]
         {$ifdef FPCMM_MULTIPLESMALLNOTWITHMEDIUM}
-        mov     rax, rsi
+        mov     rax, rdi
         lea     r10, [rip + SmallBlockInfo]
         sub     rax, r10
         shr     eax, SmallBlockTypePO2 - 3 // 1 shl 3 = SizeOf(pointer)
@@ -2591,13 +2591,13 @@ asm     // P = rcx on Windows, P = rdi on SystemV; use rsi = TSmallBlockType
         {$else}
         lea     r10, [rip + SmallMediumBlockInfo]
         {$endif FPCMM_MULTIPLESMALLNOTWITHMEDIUM}
-        movzx   eax, word ptr [rsi].TSmallBlockType.BlockSize
+        movzx   eax, word ptr [rdi].TSmallBlockType.BlockSize
         push    rax
         call    FreeMediumBlock // no call nor BinLocked to avoid race condition
         pop     rax
         {$ifdef NOSFRAME}
         {$ifdef MSWINDOWS}
-        pop     rsi
+        pop     rdi
         {$endif MSWINDOWS}
         ret
         {$else}
@@ -2605,13 +2605,16 @@ asm     // P = rcx on Windows, P = rdi on SystemV; use rsi = TSmallBlockType
         {$endif NOSFRAME}
 @ProcessPendingBin:
         // Release the next SmallLastFree list block while we own the lock
-        cmp     byte ptr [rsi].TSmallBlockType.LastFreeLocked, false
+        cmp     byte ptr [rdi].TSmallBlockType.LastFreeLocked, false
         jne     @NoBin
+        mov     r9, rsi
+        mov     rsi, rdi
         call    GetSmallLastFreeBlock
+        mov     rsi, r9 // mov does not alter the zero flag from the helper
         jz      @NoBin
         mov     rcx, rax
         mov     rdx, [rax - BlockHeaderSize]
-        // rsi=TSmallBlockType rcx=P rdx=TSmallBlockPoolHeader
+        // rdi=TSmallBlockType rcx=P rdx=TSmallBlockPoolHeader
         jmp     @FreeAndUnlock // will loop until LastFreeCount=0
 @NotSmallBlockInUse:
         {$ifdef FPCMM_MEDIUMPERTHREAD}
@@ -2649,26 +2652,26 @@ asm     // P = rcx on Windows, P = rdi on SystemV; use rsi = TSmallBlockType
         {$endif FPCMM_MEDIUMPERTHREAD}
 @TinySmallLocked:
         // This small block is locked: add rcx=P to the LastFree list block
-        mov     rax, rsi
+        mov     rax, rdi
         lea     r10, [rip + SmallBlockInfo]
         sub     rax, r10
         shr     eax, SmallBlockTypePO2 - 3 // 1 shl 3 = SizeOf(pointer)
         lea     r10, [r10 + rax].TSmallBlockInfo.SmallLastFree
-        // r10 = @SmallLastFree[] of this rsi
+        // r10 = @SmallLastFree[] of this rdi
 @Atom2: mov     eax, $100
-  lock  cmpxchg byte ptr [rsi].TSmallBlockType.LastFreeLocked, ah
+  lock  cmpxchg byte ptr [rdi].TSmallBlockType.LastFreeLocked, ah
         je      @Atom3
         pause
         jmp     @Atom2
 @Atom3: mov     rax, [r10]
         mov     [rcx], rax  // very simple linked list
         mov     [r10], rcx
-        inc     dword ptr [rsi].TSmallBlockType.LastFreeCount
-        mov     byte ptr [rsi].TSmallBlockType.LastFreeLocked, false
-        movzx   eax, word ptr [rsi].TSmallBlockType.BlockSize
-@Done:  // restore rsi and the stack frame before ret
+        inc     dword ptr [rdi].TSmallBlockType.LastFreeCount
+        mov     byte ptr [rdi].TSmallBlockType.LastFreeLocked, false
+        movzx   eax, word ptr [rdi].TSmallBlockType.BlockSize
+@Done:  // restore rdi and the stack frame before ret
         {$ifdef MSWINDOWS}
-        pop     rsi
+        pop     rdi
         {$endif MSWINDOWS}
 @Quit:
 end;


### PR DESCRIPTION
Using `RSI` for `TSmallBlockType` is beneficial on System V because `RSI` is
caller-saved, so `_FreeMem` no longer needs to preserve it.

On Win64, however, `RSI` is nonvolatile just like `RBX`, so it still needs to
be saved and restored. In a compiled same-class allocation/free ring, the
caller also keeps its loop counter in `ESI`. Restoring `RSI` immediately before
return creates a dependency for the next iteration and caused a reproducible
Win64 regression.

This change selects the register at compile time, with no runtime branch:

- Win64 keeps `TSmallBlockType` in `RBX`;
- System V keeps it in `RSI`;
- the rare Win64 pending-bin path adapts `RBX` to the existing RSI helper
  through `R9`, without duplicating the helper.

Exact A/B on current upstream `master`, FPC 3.3.1, O3,
`FPC_X64MM + FPCMM_SERVER`, 12 paired interleaved medium runs of a
same-class 96-byte ring:

- upstream median: 19.131941 TSC ticks/operation;
- candidate median: 17.817627 TSC ticks/operation;
- candidate/upstream: 0.931303, or 6.87% faster.

Validation:

- Win64, stock FPC 3.2.2, full `TTestCoreBase`: 119,302,178 assertions,
  no failures;
- Win64 multithreaded `TTestCoreBase`: 114,936,181 assertions, no failures;
- all memory-manager performance cases completed with the expected digests;
- Linux probe binaries built from upstream and this branch are byte-identical
  (`SHA-256 4d8b827d2bc86c4beeab38e825e79d8a595d3fa3aa9fe5c79400d219550b71d2`).
