### PR TITLE
tests: tolerate a SQLITE_OMIT_LOCALTIME sqlite3 library

### DIFF
--- a/test/test.orm.sqlite3.pas
+++ b/test/test.orm.sqlite3.pas
@@ -537,7 +537,12 @@ begin
   s := Demo.ExecuteNoExceptionUtf8('SELECT datetime(current_timestamp);');
   check(s <> '', 'datetime');
   s := Demo.ExecuteNoExceptionUtf8('SELECT datetime(current_timestamp,''localtime'');');
-  check(s <> '', 'localtime');
+  // 'localtime' returns NULL with a SQLITE_OMIT_LOCALTIME library, e.g. any
+  // .dll built with FOR_WIN10=1 as the official win-arm64 binaries are
+  check((s <> '') or
+        (Demo.ExecuteNoExceptionUtf8(
+          'SELECT sqlite_compileoption_used(''OMIT_LOCALTIME'');') = '1'),
+        'localtime');
 end;
 
 procedure TTestSQLite3Engine.VirtualTableDirectAccess;


### PR DESCRIPTION
Follow-up to your suggestion in #411.

`datetime(...,'localtime')` returns NULL when the sqlite3 library was built
with `SQLITE_OMIT_LOCALTIME`, which is what `FOR_WIN10=1` in SQLite's
`Makefile.msc` does - the official win-arm64 binaries are built that way, so
`TTestSQLite3Engine` failed in all four Sqlite suites on Windows on ARM.

Rather than skipping the check, this asks the library: the void result is
accepted only when `sqlite_compileoption_used('OMIT_LOCALTIME')` confirms the
feature was left out, so a real failure is still reported.

With this, aarch64-win64 is green: `0 / 195,372,996` assertions in 1m15,
using FPC 3.3.1 trunk plus the four compiler fixes tracked in #411.
Unchanged on x86_64-win64, where the check takes the first branch as before.