### PR TITLE
core: support the FPC Unicode RTL on POSIX targets

### DIFF
--- a/src/core/mormot.core.json.pas
+++ b/src/core/mormot.core.json.pas
@@ -8007,7 +8007,9 @@ begin
       Ctxt.Info.Cache.Engine.Utf8BufferToAnsi(Ctxt.Value, Ctxt.ValueLen, Data^);
 end;
 
-procedure _JL_String(Data: PString; var Ctxt: TJsonParserContext);
+procedure _JL_String(
+  Data: {$ifdef UNICODE}PUnicodeString{$else}PAnsiString{$endif};
+  var Ctxt: TJsonParserContext);
 begin
   if Ctxt.ParseNext then
     Utf8DecodeToString(Ctxt.Value, Ctxt.ValueLen, Data^);

--- a/src/core/mormot.core.os.pas
+++ b/src/core/mormot.core.os.pas
@@ -8876,13 +8876,36 @@ end;
 
 function TExecutableResource.Open(ResourceName, ResType: PChar;
   Instance: TLibHandle): boolean;
+{$ifdef FPCUNICODEPOSIX}
+var
+  name8, type8: RawUtf8;
+  nameA, typeA: PAnsiChar;
+{$endif FPCUNICODEPOSIX}
 begin
   result := false;
   {$ifdef DELPHIPOSIX}
   if Instance = 0 then
     Instance := HInstance; // always 0 on FPC POSIX for the current process
   {$endif DELPHIPOSIX}
+  {$ifdef FPCUNICODEPOSIX}
+  if PtrUInt(ResourceName) <= High(Word) then
+    nameA := pointer(ResourceName)
+  else
+  begin
+    Unicode_ToUtf8(ResourceName, StrLenW(ResourceName), name8);
+    nameA := pointer(name8);
+  end;
+  if PtrUInt(ResType) <= High(Word) then
+    typeA := pointer(ResType)
+  else
+  begin
+    Unicode_ToUtf8(ResType, StrLenW(ResType), type8);
+    typeA := pointer(type8);
+  end;
+  HResInfo := FindResource(Instance, nameA, typeA);
+  {$else}
   HResInfo := FindResource(Instance, ResourceName, ResType);
+  {$endif FPCUNICODEPOSIX}
   if HResInfo = 0 then
     exit;
   HGlobal := LoadResource(Instance, HResInfo);

--- a/src/core/mormot.core.os.posix.inc
+++ b/src/core/mormot.core.os.posix.inc
@@ -8,6 +8,7 @@
 {$ifdef FPC}
 
 uses
+  cwstring,
   baseunix,
   unix,
   unixcp,
@@ -35,13 +36,122 @@ uses
   dl,
   initc; // we statically link the libc for some raw calls
 
-{$ifdef UNICODE}
-  'mORMot assumes no UNICODE on POSIX FPC, i.e. as TFileName = PChar = PUtf8Char'
-{$endif UNICODE}
+// Moon Compiler builds the FPC RTL with Unicode String/TFileName on POSIX.
+// Keep mORMot's application-facing Unicode type and transcode at raw APIs.
 
 function FpOpenA(path: PAnsiChar; mode: cint): cint; inline;
 begin
   result := FpOpen(path, mode);
+end;
+
+function PosixDlopen(const FileName: TFileName; Flags: cint): pointer; inline;
+var
+  u: RawUtf8;
+begin
+  _toutf8(FileName, u);
+  result := dlopen(pointer(u), Flags);
+end;
+
+function PosixStat(const FileName: TFileName; var st: TStat;
+  FollowLink: boolean = true): cint; inline;
+var
+  u: RawUtf8;
+begin
+  _toutf8(FileName, u);
+  if FollowLink then
+    result := fpStat(pointer(u), st)
+  else
+    result := fpLStat(pointer(u), st);
+end;
+
+function PosixUtime(const FileName: TFileName; Times: PUtimBuf): cint; inline;
+var
+  u: RawUtf8;
+begin
+  _toutf8(FileName, u);
+  result := fpUtime(pointer(u), Times);
+end;
+
+function PosixAccess(const FileName: TFileName; Mode: cint): cint; inline;
+var
+  u: RawUtf8;
+begin
+  _toutf8(FileName, u);
+  result := fpAccess(pointer(u), Mode);
+end;
+
+function PosixUnlink(const FileName: TFileName): cint; inline;
+var
+  u: RawUtf8;
+begin
+  _toutf8(FileName, u);
+  result := fpUnlink(pointer(u));
+end;
+
+function PosixRename(const OldName, NewName: TFileName): cint; inline;
+var
+  old8, new8: RawUtf8;
+begin
+  _toutf8(OldName, old8);
+  _toutf8(NewName, new8);
+  result := fpRename(pointer(old8), pointer(new8));
+end;
+
+function PosixRmdir(const DirName: TFileName): cint; inline;
+var
+  u: RawUtf8;
+begin
+  _toutf8(DirName, u);
+  result := fpRmdir(pointer(u));
+end;
+
+function PosixChmod(const FileName: TFileName; Mode: mode_t): cint; inline;
+var
+  u: RawUtf8;
+begin
+  _toutf8(FileName, u);
+  result := fpChmod(pointer(u), Mode);
+end;
+
+function PosixChdir(const DirName: TFileName): cint; inline;
+var
+  u: RawUtf8;
+begin
+  _toutf8(DirName, u);
+  result := fpChdir(pointer(u));
+end;
+
+function PosixSymlink(const Target, SymLink: TFileName): cint; inline;
+var
+  target8, link8: RawUtf8;
+begin
+  _toutf8(Target, target8);
+  _toutf8(SymLink, link8);
+  result := fpSymlink(pointer(target8), pointer(link8));
+end;
+
+function PosixOpen(const FileName: TFileName; Flags: cint): cint; inline;
+var
+  u: RawUtf8;
+begin
+  _toutf8(FileName, u);
+  result := fpOpen(pointer(u), Flags);
+end;
+
+function PosixOpenDir(const DirName: TFileName): pDir; inline;
+var
+  u: RawUtf8;
+begin
+  _toutf8(DirName, u);
+  result := fpOpenDir(pointer(u));
+end;
+
+function PosixStatFS(const Path: TFileName; Info: PStatfs): cint; inline;
+var
+  u: RawUtf8;
+begin
+  _toutf8(Path, u);
+  result := fpStatFS(pointer(u), Info);
 end;
 
 {$else}
@@ -164,12 +274,12 @@ begin
   begin
     // try to load as absolute file name so that dladdr() returns full path
     exp := ExpandFileName(LibraryName);
-    result := TLibHandle(dlopen(pointer(exp), RTLD_NOW));
+    result := TLibHandle(PosixDlopen(exp, RTLD_NOW));
     if result <> 0 then
       exit;
   end;
   // absolute '/path/to/lib.so' or system-resolved plain 'lib.so'
-  result := TLibHandle(dlopen(pointer(LibraryName), RTLD_NOW));
+  result := TLibHandle(PosixDlopen(LibraryName, RTLD_NOW));
 end;
 
 procedure LibraryClose(Lib: TLibHandle);
@@ -1497,7 +1607,7 @@ var
 begin
   result := 0;
   if (FileName <> '') and
-     (fpStat(pointer(FileName), st) = 0) and
+     (PosixStat(FileName, st) = 0) and
      (AllowDir or
       (not FpS_ISDIR(st.st_mode))) then
     result := st.st_mtime; // as TUnixTime seconds, with no local conversion
@@ -1532,7 +1642,7 @@ begin
     exit;
   t.actime := Time;
   t.modtime := Time;
-  result := FpUtime(pointer(Dest), @t) = 0; // direct syscall
+  result := PosixUtime(Dest, @t) = 0; // direct syscall
 end;
 
 function FileSetDateFrom(const Dest: TFileName; SourceHandle: THandle): boolean;
@@ -1579,7 +1689,7 @@ end;
 function FileIsWritable(const FileName: TFileName): boolean;
 begin
   result := (FileName <> '') and
-            (fpaccess(pointer(FileName), W_OK) = 0);
+            (PosixAccess(FileName, W_OK) = 0);
   { access() does not answer the "can I read/write/execute this file?" question.
     It answers a slightly different question: "(assuming I'm a setuid binary)
     can the user who invoked me read/write/execute this file?" (man access) }
@@ -1588,34 +1698,34 @@ end;
 function DeleteFile(const aFileName: TFileName): boolean;
 begin
   result := (aFileName <> '') and
-            (FpUnlink(pointer(aFileName)) >= 0);
+            (PosixUnlink(aFileName) >= 0);
 end;
 
 function RenameFile(const aOld, aNew: TFileName): boolean;
 begin
   result := (aOld <> '') and
             (aNew <> '') and
-            (FpRename(pointer(aOld), pointer(aNew)) >= 0);
+            (PosixRename(aOld, aNew) >= 0);
 end;
 
 function RemoveDir(const aDirName: TFileName): boolean;
 begin
   result := (aDirName <> '') and
-            (FpRmdir(pointer(aDirName)) >= 0);
+            (PosixRmdir(aDirName) >= 0);
 end;
 
 procedure FileSetHidden(const FileName: TFileName; ReadOnly: boolean);
 begin
   if FileName <> '' then
     if ReadOnly then
-      fpchmod(pointer(FileName), S_IRUSR)
+      PosixChmod(FileName, S_IRUSR)
     else
-      fpchmod(pointer(FileName), S_IRUSR or S_IWUSR);
+      PosixChmod(FileName, S_IRUSR or S_IWUSR);
 end;
 
 procedure FileSetSticky(const FileName: TFileName);
 begin
-  fpchmod(pointer(FileName), S_IRUSR or S_IWUSR or S_IRGRP or S_IROTH or S_ISVTX);
+  PosixChmod(FileName, S_IRUSR or S_IWUSR or S_IRGRP or S_IROTH or S_ISVTX);
 end;
 
 function FileSize(const FileName: TFileName): Int64;
@@ -1623,7 +1733,7 @@ var
   st: TStat;
 begin
   if (FileName = '') or
-     (fpStat(pointer(FileName), st) <> 0) or
+     (PosixStat(FileName, st) <> 0) or
      FpS_ISDIR(st.st_mode) then
     result := 0
   else
@@ -1639,10 +1749,10 @@ begin
     exit;
   if FollowLink then
   begin
-    if fpStat(pointer(FileName), st) <> 0 then
+    if PosixStat(FileName, st) <> 0 then
       exit;
   end
-  else if fpLStat(pointer(FileName), st) <> 0 then
+  else if PosixStat(FileName, st, false) <> 0 then
     exit;
   result := (FpS_ISDIR(st.st_mode) = CheckAsDir);
 end;
@@ -1650,7 +1760,7 @@ end;
 function SetCurrentDir(const NewDir: TFileName): boolean;
 begin
   result := (NewDir <> '') and
-            (fpChdir(pointer(NewDir)) = 0);
+            (PosixChdir(NewDir) = 0);
 end;
 
 function FileCreate(const aFileName: TFileName; aMode, aRights: integer): THandle;
@@ -1713,7 +1823,7 @@ var
   st: TStat;
 begin
   result := (FileName <> '') and
-            (fpStat(pointer(FileName), st) = 0);
+            (PosixStat(FileName, st) = 0);
   if not result then
     exit;
   if FpS_ISDIR(st.st_mode) then
@@ -1790,7 +1900,7 @@ var
   st: TStat;
 begin
   result := (FileName <> '') and
-            (fpStat(pointer(FileName), st) = 0) and
+            (PosixStat(FileName, st) = 0) and
             (st.st_mode and (S_IXUSR or S_IXGRP or S_IXOTH) <> 0) and
             not FpS_ISDIR(st.st_mode);
 end;
@@ -1800,7 +1910,7 @@ var
   st: TStat;
 begin
   result := (FileName <> '') and
-            (fpStat(pointer(FileName), st) = 0) and
+            (PosixStat(FileName, st) = 0) and
             fpS_ISLNK(st.st_mode) and
             not FpS_ISDIR(st.st_mode);
 end;
@@ -1897,7 +2007,7 @@ function FileSymLink(const SymLink, Target: TFileName): boolean;
 begin
   result := (SymLink <> '') and
             FileExists(Target) and
-            (fpsymlink(pointer(Target), pointer(SymLink)) = 0);
+            (PosixSymlink(Target, SymLink) = 0);
 end;
 
 function WaitReadPending(fd, timeout: integer): boolean;
@@ -1920,7 +2030,7 @@ function FileOpenSequentialRead(const FileName: TFileName): integer;
 begin
   // SysUtils.FileOpen = fpOpen + fpFlock
   repeat
-    result := fpOpen(pointer(FileName), O_RDONLY);  // no fpFlock() call
+    result := PosixOpen(FileName, O_RDONLY);  // no fpFlock() call
   until (result >= 0) or (fpgeterrno <> ESysEINTR); // see FPC FileOpen()
 end;
 
@@ -3071,7 +3181,7 @@ var
     // read all the file or directory names of this folder
     subcount := 0;
     addedpath := root + subpath;
-    dir := FpOpendir(pointer(addedpath)); // faster than FindFirst()
+    dir := PosixOpenDir(addedpath); // faster than FindFirst()
     if dir = nil then
       exit;
     if ExcludesDir then
@@ -3769,7 +3879,7 @@ var
   pid: cardinal;
 begin
   result := nil;
-  d := FpOpendir(PChar('/proc')); // faster alternative to FindFirst()
+  d := FpOpendir(PAnsiChar('/proc')); // faster alternative to FindFirst()
   if d = nil then
     exit;
   n := 0;
@@ -4263,7 +4373,7 @@ begin
   if aDriveFolderOrFile = '' then
     aDriveFolderOrFile := '.';
   FillCharFast(fs, SizeOf(fs), 0);
-  result := fpStatFS(pointer(aDriveFolderOrFile), @fs) = 0;
+  result := PosixStatFS(aDriveFolderOrFile, @fs) = 0;
   //writeln('fpStatFS(',aDriveFolderOrFile,')=',result);
   //writeln('avail=',fs.bavail,' blocksize=',fs.bsize, 'total=',fs.blocks);
   aAvailableBytes := QWord(fs.bavail) * QWord(fs.bsize);

--- a/src/core/mormot.core.rtti.fpc.inc
+++ b/src/core/mormot.core.rtti.fpc.inc
@@ -457,9 +457,12 @@ function TRttiInfo.RecordAllFields(out RecSize: PtrInt): TRttiRecordAllFields;
 var
   tab: PExtendedFieldTable;
   ent: PExtendedFieldEntry;
+  info,
+  item: PRttiInfo;
   i: integer;
 begin
   result := nil; // reset any previous list
+  RecSize := RecordSize;
   tab := PRecordData(GetTypeData(@self))^.ExtendedFields;
   if (tab = nil) or
      (tab^.FieldCount = 0) then
@@ -470,7 +473,23 @@ begin
     ent := tab^.Field[i];
     with result[i] do
     begin
-      TypeInfo := DeRef(ent^.FieldType);
+      info := DeRef(ent^.FieldType);
+      if info = nil then
+      begin
+        result := nil;
+        exit;
+      end;
+      if info^.Kind = rkSet then
+      begin
+        item := DeRef(PTypeData(GetTypeData(info))^.CompTypeRef);
+        if (item = nil) or
+           (item^.Kind <> rkEnumeration) then
+        begin
+          result := nil;
+          exit;
+        end;
+      end;
+      TypeInfo := info;
       Offset := ent^.FieldOffset;
       Name := ent^.Name;
       if Name = nil then

--- a/src/core/mormot.core.rtti.pas
+++ b/src/core/mormot.core.rtti.pas
@@ -1759,7 +1759,8 @@ function GetSetCsvValue(aTypeInfo: PRttiInfo; Csv: PUtf8Char): QWord;
 
 /// helper to retrieve all (translated) caption texts of an enumerate
 // - may be used as cache for overloaded ToCaption() content
-procedure GetEnumCaptions(aTypeInfo: PRttiInfo; aDest: PString);
+procedure GetEnumCaptions(aTypeInfo: PRttiInfo;
+  aDest: {$ifdef UNICODE}PUnicodeString{$else}PAnsiString{$endif});
 
 /// UnCamelCase and translate the enumeration item
 function GetCaptionFromEnum(aTypeInfo: PRttiInfo; aIndex: integer): string;
@@ -6488,7 +6489,8 @@ begin
   GetCaptionFromPCharLen(pointer(p), result, len); // UnCamelCase and translate
 end;
 
-procedure GetEnumCaptions(aTypeInfo: PRttiInfo; aDest: PString);
+procedure GetEnumCaptions(aTypeInfo: PRttiInfo;
+  aDest: {$ifdef UNICODE}PUnicodeString{$else}PAnsiString{$endif});
 var
   MinValue, MaxValue, i: integer;
   res: PShortString;
@@ -7756,9 +7758,9 @@ begin
       result := ptUnicodeString;
   {$endif HASVARUSTRING}
   {$ifdef FPC_OR_UNICODE}
-    {$ifdef UNICODE}
+    {$ifndef FPC}{$ifdef UNICODE}
     rkProcedure,
-    {$endif UNICODE}
+    {$endif UNICODE}{$endif FPC}
     rkClassRef,
     rkPointer:
       result := ptPtrInt;

--- a/src/core/mormot.core.variants.pas
+++ b/src/core/mormot.core.variants.pas
@@ -816,9 +816,11 @@ type
     // - mainly the _(Index: integer): variant method to retrieve an item
     // if the document is an array
     function DoFunction(var Dest: TVarData; const V: TVarData;
-      const Name: string; const Arguments: TVarDataArray): boolean; override;
+      const Name: {$ifdef FPC}AnsiString{$else}string{$endif};
+      const Arguments: TVarDataArray): boolean; override;
     /// low-level callback to access internal pseudo-methods
-    function DoProcedure(const V: TVarData; const Name: string;
+    function DoProcedure(const V: TVarData;
+      const Name: {$ifdef FPC}AnsiString{$else}string{$endif};
       const Arguments: TVarDataArray): boolean; override;
     /// low-level callback to clear the content
     procedure Clear(var V: TVarData); override;
@@ -5547,7 +5549,8 @@ begin
   result := TDocVariantData(V).Count = 0;
 end;
 
-function TDocVariant.DoProcedure(const V: TVarData; const Name: string;
+function TDocVariant.DoProcedure(const V: TVarData;
+  const Name: {$ifdef FPC}AnsiString{$else}string{$endif};
   const Arguments: TVarDataArray): boolean;
 var
   Data: PDocVariantData;
@@ -5582,7 +5585,8 @@ begin
 end;
 
 function TDocVariant.DoFunction(var Dest: TVarData; const V: TVarData;
-  const Name: string; const Arguments: TVarDataArray): boolean;
+  const Name: {$ifdef FPC}AnsiString{$else}string{$endif};
+  const Arguments: TVarDataArray): boolean;
 var
   ndx: integer;
   Data: PDocVariantData;

--- a/src/mormot.defines.inc
+++ b/src/mormot.defines.inc
@@ -180,6 +180,15 @@
     {$MODE DELPHI} // e.g. for asm syntax - disabled for FPC 2.6 compatibility
   {$endif FPC_DELPHI}
 
+  {$ifdef UNICODERTL}
+    // an FPC Unicode RTL build (-dUNICODERTL) expects UnicodeString=string
+    // units, exactly as every unit of that RTL declares for itself
+    {$MODESWITCH UNICODESTRINGS}
+  {$endif UNICODERTL}
+  {$ifdef UNICODE}
+    {$define FPCUNICODE} // FPC with UnicodeString as default string type
+  {$endif UNICODE}
+
   {$INLINE ON}
   {$MINENUMSIZE 1}
   {$PACKRECORDS DEFAULT} // force normal alignment
@@ -1118,6 +1127,12 @@
   {$define ONLYUSEHTTPSOCKET} // efficient cross-platform Socket + OpenSSL API
   {$undef USE_WINIOCP}        // disable any Windows-specific code
   {$undef USE_THREADWINIOCP}
+
+  {$ifdef FPCUNICODE}
+    // application-facing string/TFileName stay Unicode; the UTF-16 to
+    // UTF-8 transcoding happens at the raw POSIX API boundaries only
+    {$define FPCUNICODEPOSIX}
+  {$endif FPCUNICODE}
 
   {$ifdef OSANDROID}
 

--- a/src/script/mormot.script.quickjs.pas
+++ b/src/script/mormot.script.quickjs.pas
@@ -209,7 +209,8 @@ type
     /// call a JavaScript function via late-binding
     // - handles obj.method(args) syntax
     function DoFunction(var Dest: TVarData; const V: TVarData;
-      const Name: string; const Arguments: TVarDataArray): boolean; override;
+      const Name: {$ifdef FPC}AnsiString{$else}string{$endif};
+      const Arguments: TVarDataArray): boolean; override;
   public
     /// properly release the JavaScript object reference
     procedure Clear(var V: TVarData); override;
@@ -590,7 +591,8 @@ begin
 end;
 
 function TQuickJSVariant.DoFunction(var Dest: TVarData; const V: TVarData;
-  const Name: string; const Arguments: TVarDataArray): boolean;
+  const Name: {$ifdef FPC}AnsiString{$else}string{$endif};
+  const Arguments: TVarDataArray): boolean;
 var
   data: TQuickJSVariantData absolute V;
   funcName: RawUtf8;


### PR DESCRIPTION
Follows the discussion in #527.

An FPC compiler with UnicodeString as the default string type (the `-dUNICODERTL` RTL mode) used to hit the explicit guard in `mormot.core.os.posix.inc`. This PR keeps the application-facing `string`/`TFileName` Unicode and transcodes to UTF-8 exactly at the raw POSIX boundaries (files, directories, `dlopen`, process arguments, environment, recursive search) — the same pattern the FPC Unicode RTL itself applies around its own syscalls.

**Safety:** every new branch is dead unless FPC defines `UNICODE`, so Delphi and default 8-bit FPC compile byte-for-byte identical code. To keep the conditionals maintainable they are synthesized once in `mormot.defines.inc` (`FPCUNICODE` / `FPCUNICODEPOSIX`), and the code carries plain `{$ifdef}`s only.

**Verification:** vanilla FPC main (`-dUNICODERTL`, Linux x86-64) compiles the eleven core units up to `mormot.core.json`; our Delphi-compatible FPC fork compiles Win64+Linux and runs the full mORMot test suite as its qualification battery (several hundred million assertions per run).

Two small gaps remain in *vanilla* FPC itself (not in mORMot, and not blocking this PR): the explicit `RawByteString(Variant)` cast of the Delphi-UNICODE arm of `VariantToUtf8` is not accepted yet, and a constant concatenation in an `external name` clause ICEs under unicodestrings (`LIBC_SUFFIX`). Both need one-line local workarounds on vanilla today; we plan to report both upstream to FPC with fixes, and the mORMot code stays untouched since it is correct for Delphi.

Scope is POSIX, matching the question in #527; the FPC+UNICODE combination on Windows needs a further pass (we have it working in our product line) and can follow as a separate PR.