### PR TITLE
core: fix Utf8ToWideChar() MaxDestChars overload truncating output by half

### DIFF
--- a/src/core/mormot.core.unicode.pas
+++ b/src/core/mormot.core.unicode.pas
@@ -3322,6 +3322,9 @@ begin // slightly slower overload with explicit destlen
     {$endif ASMX86}
   end;
   inc(sourceBytes, PtrUInt(source)); // PUtf8Char(sourceBytes)  = endSource
+  // MaxDestChars is a WideChar count, but the loop below compares it against
+  // the dest pointer, which advances by SizeOf(WideChar) per character
+  inc(MaxDestChars, MaxDestChars);   // WideChar count -> byte count
   inc(MaxDestChars, PtrUInt(dest));  // PUtf8Char(MaxDestChars) = endDest
   {$ifndef CPUX86NOTPIC}
   utf8 := @UTF8_TABLE;

--- a/test/test.core.base.pas
+++ b/test/test.core.base.pas
@@ -6026,6 +6026,7 @@ var
   WS: WideString;
   SU, SU2: SynUnicode;
   WU: array[0..3] of WideChar;
+  WU2: array[0..15] of WideChar;
   str: string;
   ss: ShortString;
   fn: TFileName;
@@ -7081,8 +7082,17 @@ begin
   Check(Utf8ToUnicodeLength(Pointer(U)) = 2);
   Check(Utf8FirstLineToUtf16Length(Pointer(U)) = 2);
   PCardinal(@WU)^ := 0;
-  if CheckEqual(Utf8ToWideChar(WU, pointer(U), SizeOf(WU), length(U), false), 4) then
+  if CheckEqual(Utf8ToWideChar(WU, pointer(U), length(WU), length(U), false), 4) then
     Check(PCardinal(@WU)^ = $DCD2D863);
+  // ensure MaxDestChars is a WideChar count - not a byte count
+  U := 'abcdefgh';
+  FillCharFast(WU2, SizeOf(WU2), 0);
+  CheckEqual(Utf8ToWideChar(@WU2, pointer(U), length(WU2), length(U), false), 16);
+  CheckEqual(StrLenW(@WU2), 8);
+  FillCharFast(WU2, SizeOf(WU2), 0);
+  CheckEqual(Utf8ToWideChar(@WU2, pointer(U), 5, length(U), false), 10);
+  CheckEqual(StrLenW(@WU2), 5);
+  Check(CompareMemSmall(@WU2, PWideChar('abcde'), 10), 'truncate at MaxDestChars');
   U := SynUnicodeToUtf8(SU);
   if Check(length(U) = 4) then
     Check(PCardinal(U)^ = $92b3a8f0);


### PR DESCRIPTION
The explicit-destlen overload of `Utf8ToWideChar()` treats `MaxDestChars` as a byte offset when building the end-of-buffer guard:

```pascal
inc(MaxDestChars, PtrUInt(dest)); // PUtf8Char(MaxDestChars) = endDest
```

The loop advances `dest` by `SizeOf(WideChar)` per character, so only `ceil(MaxDestChars / 2)` characters are ever written.

Visible through the TDataSet layer: `mormot.db.rad.ui.pas` passes `Field.DataSize shr 1` (a character count), so every `ftWideString` column of a `TVirtualDataSet` descendant is truncated — reading a varchar `abcdefgh` from PostgreSQL via `ToDataSet()` returns `abcde`. `TOrmTableAbstract.GetWP()` is affected the same way. Delphi 7 is not, since `mormot.db.rad.ui.pas` uses `Utf8ToWideString()` when `HASDBFTWIDE` is undefined.

Fix converts the character count to bytes before folding it into the guard.

The existing test passed `SizeOf(WU)` where a character count is expected, so the two errors cancelled out — corrected to `length(WU)` and extended with a regression test. Without the one-line fix it fails with 3 assertions; with it, `TTestCoreBase` is green (0 / 31,357,914) on Delphi 13 Win32.