### PR TITLE
Proposal: let a handler supply its own response body stream - see #509

### DIFF
--- a/src/net/mormot.net.async.pas
+++ b/src/net/mormot.net.async.pas
@@ -5354,6 +5354,8 @@ begin
     end;
     // finalize and send the response back to the client
     c.fRequest.RespStatus := Status;
+    c.fRequest.OutContentStreamDiscard; // this delayed Content does replace
+                                        // any pending SetOutStream() body
     c.fRequest.OutContent := Content;
     c.fRequest.OutContentType := ContentType;
     if hfConnectionClose in c.fHttp.HeaderFlags then

--- a/src/net/mormot.net.http.pas
+++ b/src/net/mormot.net.http.pas
@@ -350,6 +350,20 @@ type
     rfAsynchronous,
     rfProgressiveStatic);
 
+  /// define THttpRequestContext.ContentFromStream() behavior, as supplied by
+  // THttpServerRequestAbstract.SetOutStream()
+  // - hosOwned will release the stream once the response has been sent, or the
+  // request aborted - otherwise the caller does own it, and should keep it
+  // valid until the response has been sent, i.e. after the handler returned
+  // - hosNoRange won't serve any 'Range: ' request from this stream, but
+  // return an 'Accept-Ranges: none' header instead - note that a
+  // TStreamWithNoSeek, or a stream raising on Position/Size, is detected as
+  // such by itself, so this option is only needed for other classes
+  THttpOutStreamOption = (
+    hosOwned,
+    hosNoRange);
+  THttpOutStreamOptions = set of THttpOutStreamOption;
+
   /// define THttpRequestContext.ProcessBody response
   // - hrpSend should try to send the Dest buffer content
   // - hrpWait is returned in rfProgressiveStatic mode to wait for more data
@@ -540,6 +554,17 @@ type
     // - if CompressGz is set, would also try for a cached local FileName+'.gz'
     // - returns HTTP_SUCCESS, HTTP_NOTFOUND or HTTP_RANGENOTSATISFIABLE
     function ContentFromFile(const FileName: TFileName; CompressGz: integer): integer;
+    /// initialize ContentStream/ContentLength from a given TStream
+    // - as supplied by THttpServerRequestAbstract.SetOutStream() to a handler
+    // - aStart is the stream position of the first content byte, and the
+    // origin of any 'Range: ' request; aLength is the content size in bytes
+    // - hosOwned does set rfContentStreamNeedFree, i.e. the stream is released
+    // by ProcessDone once the response has been sent
+    // - hosNoRange serves no range: an 'Accept-Ranges: none' header is
+    // returned instead, and any Range: request is ignored
+    // - returns HTTP_SUCCESS or HTTP_RANGENOTSATISFIABLE
+    function ContentFromStream(aStream: TStream; aStart, aLength: Int64;
+      aOptions: THttpOutStreamOptions): integer;
     /// uncompress Content according to CompressContentEncoding header
     procedure UncompressData;
     /// check RangeOffset/RangeLength against ContentLength
@@ -896,6 +921,10 @@ type
     fInContent: RawByteString;
     fInContentStream: TStream;
     fOutContent: RawByteString;
+    fOutContentStream: TStream; // from SetOutStream()
+    fOutContentStreamLength: Int64;
+    fOutContentStreamPos: Int64; // stream position when SetOutStream() was set
+    fOutContentStreamOpt: THttpOutStreamOptions;             // 8-bit
     fConnectionID: THttpServerConnectionID;                  // 64-bit
     fConnectionFlags: THttpServerRequestFlags;               // 8-bit
     fAuthenticationStatus: THttpServerRequestAuthentication; // 8-bit
@@ -913,6 +942,9 @@ type
     function GetRouteValue(const Name: RawUtf8): RawUtf8;
       {$ifdef HASINLINE} inline; {$endif}
   public
+    /// finalize this instance
+    // - will release any pending SetOutStream() owned stream
+    destructor Destroy; override;
     /// prepare an incoming request from a parsed THttpRequestContext
     // - will set input parameters URL/Method/InHeaders/InContent/InContentType
     // - won't reset other parameters: should come after a plain Create or
@@ -1037,9 +1069,67 @@ type
     // status HTTP_NOTMODIFIED (304) if it did not change
     function SetOutContent(const Content: RawByteString; Handle304NotModified: boolean;
       const ContentType: RawUtf8 = ''; CacheControlMaxAgeSec: integer = 0): cardinal;
+    /// set the response body to be read from a TStream, with no buffering
+    // - the socket-based servers do send this stream by chunks from their own
+    // sending loop, with a constant memory usage, as they already do for a
+    // static file - so a handler can serve content which is not a local file,
+    // e.g. rebuilt from database blobs, without a whole RawByteString body
+    // - aContentLength = -1 computes aStream.Size - aStream.Position, as a file
+    // would use its size: the stream is sent from its current position, which
+    // is also the origin of any Range: - so don't move it after this call
+    // - supply an explicit aContentLength if Position/Size do raise on this
+    // stream: it is then sent sequentially, and is the only length we know
+    // - a body of unknown length is NOT supported, since the send loop always
+    // emits a Content-Length: and has no chunked response encoding
+    // - if aOwned is true, the stream is released by the server once the
+    // response has been sent, or the request aborted: a handler should not
+    // free it, nor keep any reference - if aOwned is false, it shall stay
+    // valid until the response has been sent, i.e. after the handler returned
+    // - 'Range: ' is served as for a file, i.e. 206 with a Content-Range: or
+    // 416 if unsatisfiable; a stream which can not seek - a TStreamWithNoSeek
+    // like TPipeStream, or one raising on Position/Size - is detected as such
+    // and gets an 'Accept-Ranges: none' header, ignoring any Range:
+    // - a stream which does answer Position/Size but raises on the actual
+    // seek can not be detected in advance, so it returns 416 for that range:
+    // supply hosNoRange for such a stream, to serve it sequentially instead
+    // - THttpApiServer (http.sys) and REST-over-WebSockets can not stream an
+    // in-process TStream: they read it into OutContent, so that a handler is
+    // portable, with no Range: support and no memory gain on those servers -
+    // but only up to HttpContentFromFileSizeInMemory (1MB on 32-bit, 2MB on
+    // 64-bit): a bigger body does answer 500 there, so raise that global
+    // variable if your handler may run on those servers
+    // - the body is not compressed, just like a static file is not
+    // - a stream supplying less bytes than announced aborts the response and
+    // closes the connection, once the headers have been sent
+    // - a stream raising in Read() is not catched by the sending loop: as for
+    // any ContentStream, it will abort the whole THttpAsyncServer write
+    // thread, so a handler stream should return 0 rather than raise
+    // - the length is mandatory: a stream with no Size and no aContentLength
+    // is rejected with HTTP_SERVERERROR, since the send loop always emits a
+    // Content-Length: and has no chunked response encoding
+    // - calling it twice does release any previously owned stream
+    function SetOutStream(aStream: TStream;
+      aOptions: THttpOutStreamOptions = []; const aContentType: RawUtf8 = '';
+      aContentLength: Int64 = -1): cardinal;
     /// append a new line of HTTP headers to the request output
     // - just a wrapper around AppendLine(fOutCustomHeaders, Args)
     procedure SetOutCustomHeader(const Args: array of const);
+    /// read any pending SetOutStream() body into the OutContent memory buffer
+    // - to be called by the servers which can not stream a response body, e.g.
+    // THttpApiServer (http.sys) or a REST-over-WebSockets answer
+    // - returns true on success, or if there was no pending stream at all
+    // - returns false if reading the stream failed, leaving a void OutContent:
+    // those servers track their status aside, so the caller sets its own error
+    function OutContentStreamToBuffer: boolean;
+    /// release any pending SetOutStream() body without reading it
+    // - if we do own it, e.g. once the response has been sent otherwise
+    procedure OutContentStreamDiscard;
+      {$ifdef HASINLINE} inline; {$endif}
+    /// the TStream supplied to SetOutStream() as response body, or nil
+    // - published as read-only, e.g. for the servers to detect that a body
+    // has been set even if OutContent is void
+    property OutContentStream: TStream
+      read fOutContentStream;
   published
     /// input parameter containing the caller URI
     property Url: RawUtf8
@@ -4495,6 +4585,55 @@ begin
   result := hrpSend;
 end;
 
+function THttpRequestContext.ContentFromStream(aStream: TStream;
+  aStart, aLength: Int64; aOptions: THttpOutStreamOptions): integer;
+var
+  offs: Int64;
+begin
+  result := HTTP_SUCCESS;
+  // a previous ContentFromFile() may have set its own owned ContentStream:
+  // do not leak it, nor free the caller stream we may not own
+  if rfContentStreamNeedFree in ResponseFlags then
+    FreeAndNilSafe(ContentStream);
+  exclude(ResponseFlags, rfContentStreamNeedFree);
+  ContentLength := aLength;
+  if hosNoRange in aOptions then
+  begin
+    // this stream can only be read forward: no Range: support at all
+    AppendLine(ResponseHeaders, ['Accept-Ranges: none']);
+    // ignoring the range means a whole 200 response, and not a 206 without
+    // any Content-Range:, which rfWantRange would otherwise produce
+    exclude(ResponseFlags, rfWantRange);
+  end
+  else if rfWantRange in ResponseFlags then
+    if ValidateRange then
+    begin
+      if PCardinal(CommandMethod)^ <> HEAD_32 then // HEAD sends no body at all
+      try
+        offs := aStart + RangeOffset;
+        if aStream.Seek(offs, soBeginning) <> offs then
+          result := HTTP_RANGENOTSATISFIABLE;
+      except // a stream which can not actually seek
+        result := HTTP_RANGENOTSATISFIABLE;
+      end;
+    end
+    else
+      result := HTTP_RANGENOTSATISFIABLE;
+  if result <> HTTP_SUCCESS then
+  begin
+    ContentLength := 0;
+    // clear both flags, otherwise CompressContentAndFinalizeHead would
+    // validate the range once again, against the generated error page
+    ResponseFlags := ResponseFlags - [rfRange, rfWantRange];
+    exit;
+  end;
+  if not (hosNoRange in aOptions) then
+    include(ResponseFlags, rfAcceptRange);
+  ContentStream := aStream;
+  if hosOwned in aOptions then
+    include(ResponseFlags, rfContentStreamNeedFree);
+end;
+
 function THttpRequestContext.ContentFromFile(const FileName: TFileName;
   CompressGz: integer): integer;
 var
@@ -4841,6 +4980,13 @@ end;
 
 { THttpServerRequestAbstract }
 
+destructor THttpServerRequestAbstract.Destroy;
+begin
+  if hosOwned in fOutContentStreamOpt then // e.g. connection aborted before
+    FreeAndNilSafe(fOutContentStream);     // SetupResponse did hand it over
+  inherited Destroy;
+end;
+
 procedure THttpServerRequestAbstract.Prepare(var aHttp: THttpRequestContext;
   const aRemoteIP: RawUtf8; aAuthorize: THttpServerRequestAuthentication);
 begin
@@ -5150,6 +5296,86 @@ begin
     GetMimeContentTypeFromBuffer(Content, fOutContentType);
   fOutContent := Content;
   result := HTTP_SUCCESS;
+end;
+
+function THttpServerRequestAbstract.SetOutStream(aStream: TStream;
+  aOptions: THttpOutStreamOptions; const aContentType: RawUtf8;
+  aContentLength: Int64): cardinal;
+begin
+  result := HTTP_SUCCESS;
+  OutContentStreamDiscard; // release any previous SetOutStream() owned stream
+  fOutContentStream := aStream;
+  if aStream = nil then
+    exit;
+  fOutContentStreamOpt := aOptions;
+  if aStream.InheritsFrom(TStreamWithNoSeek) then
+    include(fOutContentStreamOpt, hosNoRange); // detected: no Range: support
+  // capture the initial position now: it is the origin of any later Range:,
+  // and both Position and Size may raise on a stream which has none - note
+  // that a TStreamWithNoSeek does allow to read its position, just not to
+  // change it, so a partially consumed one still reports the correct length
+  fOutContentStreamPos := 0;
+  try
+    fOutContentStreamPos := aStream.Position;
+    if aContentLength < 0 then
+      // as ContentFromFile() does with the file size: send up to the end
+      aContentLength := aStream.Size - fOutContentStreamPos;
+  except
+    // a stream with no Position/Size at all: send it sequentially, and let
+    // the caller-supplied aContentLength be the only length we know
+    include(fOutContentStreamOpt, hosNoRange);
+    fOutContentStreamPos := 0;
+  end;
+  if aContentLength < 0 then
+  begin
+    // a stream with no Size and no supplied length: the send loop always
+    // emits a Content-Length:, so fail here instead of a silent empty body
+    OutContentStreamDiscard; // release it if we do own it
+    result := HTTP_SERVERERROR;
+    exit;
+  end;
+  fOutContentStreamLength := aContentLength;
+  if aContentType <> '' then
+    fOutContentType := aContentType;
+  FastAssignNew(fOutContent); // the body does come from the stream
+end;
+
+procedure THttpServerRequestAbstract.OutContentStreamDiscard;
+begin
+  if hosOwned in fOutContentStreamOpt then
+    FreeAndNilSafe(fOutContentStream)
+  else
+    fOutContentStream := nil;
+  fOutContentStreamOpt := [];
+  fOutContentStreamLength := 0;
+  fOutContentStreamPos := 0;
+end;
+
+function THttpServerRequestAbstract.OutContentStreamToBuffer: boolean;
+begin
+  result := true; // nothing to do is a success
+  if fOutContentStream = nil then
+    exit;
+  // this server can not stream a response body: read it as a regular content,
+  // but only up to the size we would keep in memory for a static file
+  if fOutContentStreamLength > HttpContentFromFileSizeInMemory then
+    result := false // too big to be buffered by this kind of server
+  else if fOutContentStreamLength <> 0 then
+    try
+      result := StreamReadAll(fOutContentStream,
+        FastNewRawByteString(fOutContent, fOutContentStreamLength),
+        fOutContentStreamLength);
+    except
+      // a handler stream may raise on Read(): those servers have already
+      // started their response, so let them send their own error status
+      result := false;
+    end;
+  if not result then
+  begin
+    FastAssignNew(fOutContent); // no body to send
+    fRespStatus := HTTP_SERVERERROR;
+  end;
+  OutContentStreamDiscard;
 end;
 
 procedure THttpServerRequestAbstract.SetOutCustomHeader(const Args: array of const);

--- a/src/net/mormot.net.server.pas
+++ b/src/net/mormot.net.server.pas
@@ -397,6 +397,7 @@ type
     procedure DoPurgeHeaders;
     procedure ProcessErrorMessage;
     procedure ProcessStaticFile(var Context: THttpRequestContext; CompressGz: integer);
+    procedure ProcessOutStream(var Context: THttpRequestContext);
   public
     /// initialize the context, associated to a HTTP server instance
     constructor Create(aServer: THttpServerGeneric;
@@ -3330,6 +3331,7 @@ begin
   fRespStatus := 0;
   fInContentStream := nil; // paranoid: Prepare() would set it anyway
   fOutContent := '';
+  OutContentStreamDiscard; // paranoid: SetupResponse() did hand it over
   FastAssignNew(fOutContentType);
   FastAssignNew(fOutCustomHeaders);
   fAuthenticationStatus := hraNone;
@@ -3345,7 +3347,7 @@ end;
 destructor THttpServerRequest.Destroy;
 begin
   fTempWriter.Free;
-  // inherited Destroy; is void
+  inherited Destroy; // release any pending SetOutStream() owned stream
 end;
 
 procedure THttpServerRequest.DoPurgeHeaders;
@@ -3374,6 +3376,33 @@ begin
     [fServer.ServerName, fRespStatus, fRespStatus, txt^, fOutContentType,
      XPOWEREDVALUE, OS_TEXT], RawUtf8(fOutContent));
   fOutContentType := HTML_CONTENT_TYPE; // body = human friendly HTML message
+end;
+
+procedure THttpServerRequest.ProcessOutStream(var Context: THttpRequestContext);
+begin
+  // hand a SetOutStream() body to the context, as ProcessStaticFile() does
+  if not StatusCodeIsSuccess(fRespStatus) then
+  begin
+    // a handler answering e.g. 404 or its own 416 from a stream should not
+    // have that body range-processed, nor replaced by our own error page
+    exclude(Context.ResponseFlags, rfWantRange);
+    // and should not advertise a Range: support we just disabled
+    include(fOutContentStreamOpt, hosNoRange);
+  end;
+  if Context.ContentFromStream(fOutContentStream, fOutContentStreamPos,
+       fOutContentStreamLength, fOutContentStreamOpt) = HTTP_SUCCESS then
+  begin
+    fOutContentStream := nil; // handed over: no double free by Recycle/Destroy
+    fOutContentStreamOpt := [];
+    fOutContentStreamLength := 0;
+    fOutContentStreamPos := 0;
+  end
+  else
+  begin
+    OutContentStreamDiscard; // release it: there is no body to send
+    fRespStatus := HTTP_RANGENOTSATISFIABLE;
+    fErrorMessage := 'Out of range'; // detected by ProcessErrorMessage
+  end;
 end;
 
 procedure THttpServerRequest.ProcessStaticFile(var Context: THttpRequestContext;
@@ -3447,6 +3476,13 @@ begin
     else if (fOutContent <> '') and
             (fOutContentType = STATICFILE_CONTENT_TYPE) then
       ProcessStaticFile(Context, CompressGz);
+  if fOutContentStream <> nil then
+    if fErrorMessage = '' then
+      ProcessOutStream(Context) // SetOutStream() response body
+    else
+      // the handler did raise after SetOutStream(): never send that body as
+      // the error response, which ContentStream <> nil would silently do
+      OutContentStreamDiscard;
   if fErrorMessage <> '' then
     ProcessErrorMessage;
   // append Command
@@ -4273,6 +4309,7 @@ begin
       if cod <> 0 then
       begin
         if (Ctxt.OutContent = '') and
+           (Ctxt.OutContentStream = nil) and // SetOutStream() is a body too
            (cod <> HTTP_ASYNCRESPONSE) and
            not StatusCodeIsSuccess(cod) then
         begin
@@ -4290,7 +4327,8 @@ begin
     if cod <> 0 then
     begin
       Ctxt.RespStatus := cod;
-      if Ctxt.OutContent = '' then
+      if (Ctxt.OutContent = '') and
+         (Ctxt.OutContentStream = nil) then // SetOutStream() is a body too
         Ctxt.fErrorMessage := 'Rejected request';
       IncStat(grRejected);
     end
@@ -8401,6 +8439,11 @@ var // lots of local variable so that this method is thread-safe
     if not result then
       exit;
     respsent := true;
+    // http.sys does send from the kernel: it can not stream a TStream, so any
+    // SetOutStream() body is read into OutContent - done here and not at the
+    // call sites, since OnBeforeRequest may respond before the main process
+    if not ctxt.OutContentStreamToBuffer then
+      outstatcode := HTTP_SERVERERROR; // failed to read that stream
     resp^.SetStatus(outstatcode, outstat);
     if Terminated then
       exit;
@@ -8683,10 +8726,13 @@ begin
                 if afterstatcode > 0 then
                   outstatcode := afterstatcode;
               end;
-              // send response
-              if not respsent then
-                if not SendResponse then
-                  continue;
+              // send response - SendResponse does buffer any SetOutStream()
+              if respsent then
+                // e.g. DoBeforeRequest did already send a 202: there is no
+                // response left to put a new body into
+                ctxt.OutContentStreamDiscard
+              else if not SendResponse then
+                continue;
               QueryPerformanceMicroSeconds(elapsed);
               dec(elapsed, started);
               ctxt.Host := host; // may have been reset during Request()
@@ -8694,11 +8740,16 @@ begin
                 ctxt, referer, outstatcode, elapsed, incontlen, bytessent);
             except
               on E: Exception do
+              begin
+                // a handler which did raise after SetOutStream() would
+                // otherwise keep its stream until this thread is reused
+                ctxt.OutContentStreamDiscard;
                 // handle any exception raised during process: show must go on!
                 if not respsent then
                   if not E.InheritsFrom(EHttpApiServer) or // ensure still connected
                      (EHttpApiServer(E).LastApiError <> HTTPAPI_ERROR_NONEXISTENTCONNECTION) then
                     SendError(HTTP_SERVERERROR, StringToUtf8(E.Message), E);
+              end;
             end;
           finally
             LockedDec32(@fCurrentProcess);

--- a/src/net/mormot.net.ws.core.pas
+++ b/src/net/mormot.net.ws.core.pas
@@ -2041,6 +2041,9 @@ var
   OutContentType: pointer; // weak RawUtf8
 begin
   OutContentType := nil;
+  // a WebSockets frame is sent at once: read any SetOutStream() body in memory
+  if not Ctxt.OutContentStreamToBuffer then
+    Status := HTTP_SERVERERROR; // failed to read that stream: no body to send
   if (Ctxt.OutContent <> '') and
      not IsContentTypeJsonU(Ctxt.OutContentType) then
     OutContentType := pointer(Ctxt.OutContentType);

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -75,6 +75,9 @@ type
     reqfour: Int64;
     // for FileRange
     rangefile: TFileName;
+    // for OutStream
+    outdata: RawByteString;
+    outkept: TRawByteStringStream; // supplied with aOwned=false
     // for BodyDownload
     bodyfile: TFileName;
     bodytype: RawUtf8;
@@ -101,6 +104,8 @@ type
     function OnPeerCacheRequest(Ctxt: THttpServerRequestAbstract): cardinal;
     // event used by FileRange
     function DoRangeRequest(Ctxt: THttpServerRequestAbstract): cardinal;
+    // event used by OutStream
+    function DoOutStreamRequest(Ctxt: THttpServerRequestAbstract): cardinal;
     // both events used by BodyDownload
     function DoBodyDownload(const aUrl, aMethod, aInHeaders, aInContentType,
       aRemoteIP: RawUtf8; aContentLength: Int64): TStream;
@@ -128,6 +133,8 @@ type
     procedure DoHttpBodyDownload(Sender: TObject);
     /// validate 'Range:' file responses, especially against invalid offsets
     procedure DoHttpFileRange(Sender: TObject);
+    /// validate THttpServerRequestAbstract.SetOutStream streamed body download
+    procedure DoHttpOutStream(Sender: TObject);
   published
     /// Engine.IO and Socket.IO regression tests
     procedure _SocketIO;
@@ -259,6 +266,7 @@ begin
   // start some slow tests in background if /multithread is enabled
   Run(DoHttpBodyDownload, self, 'HttpBodyDownload', true, false);
   Run(DoHttpFileRange, self, 'HttpFileRange', true, false);
+  Run(DoHttpOutStream, self, 'HttpOutStream', true, false);
   Run(DoTFTPServer, self, 'TFTPServer', true, false);
   {$ifdef OSPOSIX}
   Run(DoUnixDomainSocket, self, 'UnixDomainSocket', true, false);
@@ -4106,6 +4114,7 @@ var
   ctx: THttpRequestContext;
   dest: TRawByteStringBuffer;
   ms: TRawByteStringStream;
+  req: THttpServerRequest;
 
   procedure Check4;
   begin
@@ -4458,6 +4467,25 @@ begin
   Check(ctx.ValidateRange, 'huge end offset'); // RangeOffset + RangeLength would
   CheckEqual(ctx.ContentLength, 900, 'huge end tosend'); // overflow to negative
   CheckEqual(ctx.RangeLength, 1000, 'huge end total');
+  // validate OutContentStreamToBuffer() for the non-streaming servers
+  req := THttpServerRequest.Create(nil, 0, nil, 0, [], nil);
+  try
+    req.SetOutStream(TRawByteStringStream.Create('1234567890'), [hosOwned]);
+    Check(req.OutContentStreamToBuffer, 'buffer ok');
+    CheckEqual(req.OutContent, '1234567890', 'buffer content');
+    Check(req.OutContentStreamToBuffer, 'buffer twice');
+    // a body bigger than what we would keep in memory for a file is refused -
+    // note that this stream is fully readable, so only the size limit rejects
+    // it: a short stream would fail in StreamReadAll() for another reason
+    ms := TRawByteStringStream.Create;
+    ms.Size := HttpContentFromFileSizeInMemory + 1;
+    req.SetOutStream(ms, [hosOwned]);
+    Check(not req.OutContentStreamToBuffer, 'buffer too big');
+    CheckEqual(req.OutContent, '', 'buffer too big void');
+    CheckEqual(req.RespStatus, HTTP_SERVERERROR, 'buffer too big status');
+  finally
+    req.Free;
+  end;
   // validate ProcessBody() abort on a stream shorter than ContentLength
   ctx.Reset;
   ctx.CommandMethod := 'GET';
@@ -4477,7 +4505,55 @@ begin
   end;
 end;
 
+var
+  // how many TCountedStringStream have been released, to validate that
+  // SetOutStream(aOwned=true) does free the stream - and aOwned=false does not
+  outstreamfreed: integer;
+
 type
+  // a stream which does count its own destruction, from the server threads
+  TCountedStringStream = class(TRawByteStringStream)
+  public
+    destructor Destroy; override;
+  end;
+
+  // a readable stream which raises on Position/Seek, and does NOT descend
+  // from TStreamWithNoSeek: SetOutStream() should detect it the hard way -
+  // note that GetPosition is overriden for FPC only, because Delphi has no
+  // such virtual method and does call Seek(0, soCurrent) instead
+  TRaiseSeekStream = class(TRawByteStringStream)
+  protected
+    {$ifdef FPC}
+    function GetPosition: Int64; override;
+    {$endif FPC}
+  public
+    function Write(const Buffer; Count: Longint): Longint; override;
+    function Seek(const Offset: Int64; Origin: TSeekOrigin): Int64; override;
+  end;
+
+  // a readable stream which does answer its position, but can not jump to
+  // any other one: only ContentFromStream() will notice, on the actual Seek()
+  TNoJumpStream = class(TRawByteStringStream)
+  public
+    function Seek(const Offset: Int64; Origin: TSeekOrigin): Int64; override;
+  end;
+
+  // a stream which does raise in Read(), e.g. a broken database connection
+  TRaiseReadStream = class(TRawByteStringStream)
+  public
+    function Read(var Buffer; Count: Longint): Longint; override;
+  end;
+
+  // a readable stream which does not support any Seek(), e.g. like a pipe:
+  // used to validate the SetOutStream() 'Accept-Ranges: none' fallback
+  TNoSeekReadStream = class(TStreamWithNoSeek)
+  protected
+    fData: RawByteString;
+  public
+    constructor Create(const aData: RawByteString); reintroduce;
+    function Read(var Buffer; Count: Longint): Longint; override;
+  end;
+
   // simulate e.g. a full disk: raise EWriteError after 64KB
   TFailingStream = class(TStream)
   protected
@@ -4500,6 +4576,71 @@ type
     property Received: RawByteString
       read fReceived;
   end;
+
+destructor TCountedStringStream.Destroy;
+begin
+  LockedInc32(@outstreamfreed); // released from the server thread
+  inherited Destroy;
+end;
+
+function TRaiseSeekStream.Write(const Buffer; Count: Longint): Longint;
+begin
+  result := 0;
+  raise EStreamError.Create('TRaiseSeekStream is read only');
+end;
+
+function TRaiseSeekStream.Seek(const Offset: Int64; Origin: TSeekOrigin): Int64;
+begin // also called by the Position property on Delphi
+  result := 0;
+  raise EStreamError.Create('TRaiseSeekStream can not seek');
+end;
+
+{$ifdef FPC}
+function TRaiseSeekStream.GetPosition: Int64;
+begin // on FPC, the Position property does not call Seek()
+  result := 0;
+  raise EStreamError.Create('TRaiseSeekStream has no position');
+end;
+{$endif FPC}
+
+function TRaiseReadStream.Read(var Buffer; Count: Longint): Longint;
+begin
+  result := 0;
+  raise EStreamError.Create('TRaiseReadStream can not read');
+end;
+
+function TNoJumpStream.Seek(const Offset: Int64; Origin: TSeekOrigin): Int64;
+begin
+  if (Offset = 0) and
+     (Origin = soCurrent) then
+    result := inherited Seek(Offset, Origin) // just reading the position
+  else
+  begin
+    result := 0;
+    raise EStreamError.Create('TNoJumpStream can not jump');
+  end;
+end;
+
+constructor TNoSeekReadStream.Create(const aData: RawByteString);
+begin
+  inherited Create;
+  fData := aData;
+  fSize := length(aData);
+end;
+
+function TNoSeekReadStream.Read(var Buffer; Count: Longint): Longint;
+begin
+  result := fSize - fPosition;
+  if result > Count then
+    result := Count;
+  if result <= 0 then
+  begin
+    result := 0;
+    exit;
+  end;
+  MoveFast(PByteArray(fData)[fPosition], Buffer, result);
+  inc(fPosition, result);
+end;
 
 function TFailingStream.Read(var Buffer; Count: Longint): Longint;
 begin
@@ -4805,6 +4946,360 @@ begin
     end;
   finally
     Check(DeleteFile(rangefile), 'range file deleted');
+  end;
+end;
+
+function TNetworkProtocols.DoOutStreamRequest(
+  Ctxt: THttpServerRequestAbstract): cardinal;
+var
+  ms: TNoSeekReadStream;
+  tmp: RawByteString;
+begin
+  result := HTTP_SUCCESS;
+  if Ctxt.Url = '/ram' then
+    // the regular case: a stream owned by the server, released once sent
+    Ctxt.SetOutStream(TCountedStringStream.Create(outdata), [hosOwned],
+      BINARY_CONTENT_TYPE)
+  else if Ctxt.Url = '/keep' then
+  begin
+    // this stream belongs to the test, and should survive the response
+    outkept.Position := 0;
+    Ctxt.SetOutStream(outkept, [], BINARY_CONTENT_TYPE);
+  end
+  else if Ctxt.Url = '/noseek' then
+    // a stream which can not Seek(): no Range: support, but still served
+    Ctxt.SetOutStream(TNoSeekReadStream.Create(outdata), [hosOwned],
+      BINARY_CONTENT_TYPE)
+  else if Ctxt.Url = '/half' then
+    // an explicit length, shorter than what the stream could supply
+    Ctxt.SetOutStream(TCountedStringStream.Create(outdata), [hosOwned],
+      BINARY_CONTENT_TYPE, length(outdata) shr 1)
+  else if Ctxt.Url = '/replaced' then
+  begin
+    // a second SetOutStream() call should release the first stream at once
+    Ctxt.SetOutStream(TCountedStringStream.Create('discarded'), [hosOwned]);
+    Ctxt.SetOutStream(TCountedStringStream.Create(outdata), [hosOwned],
+      BINARY_CONTENT_TYPE);
+  end
+  else if Ctxt.Url = '/raise' then
+  begin
+    // a handler which fails after SetOutStream(): the error response should
+    // never send that body, and the stream should not leak
+    Ctxt.SetOutStream(TCountedStringStream.Create(outdata), [hosOwned],
+      BINARY_CONTENT_TYPE);
+    raise EHttpServer.Create('SetOutStream regression test');
+  end
+  else if (Ctxt.Url = '/notfound') or
+          (Ctxt.Url = '/routed') then
+  begin
+    // a handler answering a non-200 status from its own stream body: the
+    // range must be ignored, and the body left untouched - /routed reaches
+    // this very code through the TUriRouter, which has its own void body check
+    Ctxt.SetOutStream(TCountedStringStream.Create(outdata), [hosOwned],
+      BINARY_CONTENT_TYPE);
+    result := HTTP_NOTFOUND;
+  end
+  else if Ctxt.Url = '/noseekpos' then
+  begin
+    // a TStreamWithNoSeek partially consumed before SetOutStream(): it does
+    // allow reading its position, so only the remainder is the body
+    ms := TNoSeekReadStream.Create(outdata);
+    SetLength(tmp, 1000);
+    ms.Read(pointer(tmp)^, 1000); // consume the first 1000 bytes
+    Ctxt.SetOutStream(ms, [hosOwned], BINARY_CONTENT_TYPE);
+  end
+  else if Ctxt.Url = '/norange' then
+    // the same stream, but explicitly flagged as not serving any range
+    Ctxt.SetOutStream(TRaiseSeekStream.Create(outdata), [hosOwned, hosNoRange],
+      BINARY_CONTENT_TYPE, length(outdata))
+  else if Ctxt.Url = '/failseek' then
+    // a stream whose Position/Seek both raise, and which is not a
+    // TStreamWithNoSeek: it needs an explicit length, and no Range: support
+    Ctxt.SetOutStream(TRaiseSeekStream.Create(outdata), [hosOwned],
+      BINARY_CONTENT_TYPE, length(outdata))
+  else if Ctxt.Url = '/failrange' then
+    // a stream which does answer Position/Size, so its length and its
+    // Range: support are detected, but whose actual Seek() does raise
+    Ctxt.SetOutStream(TNoJumpStream.Create(outdata), [hosOwned],
+      BINARY_CONTENT_TYPE)
+  else if Ctxt.Url = '/offset' then
+  begin
+    // a stream supplied already positioned: only the remainder is the body
+    outkept.Position := 1000;
+    Ctxt.SetOutStream(outkept, [], BINARY_CONTENT_TYPE);
+  end
+  else
+    result := HTTP_NOTFOUND;
+end;
+
+procedure TNetworkProtocols.DoHttpOutStream(Sender: TObject);
+var
+  srv: THttpServerSocketGeneric;
+  clt: THttpClientSocket;
+  fam: integer;
+  hosthead, ctr: RawUtf8;
+
+  function RawGet(const url, range: RawUtf8; out headers: RawUtf8;
+    body: PRawByteString = nil): RawUtf8;
+  var
+    raw: TCrtSocket;
+    cmd, len: RawUtf8;
+  begin
+    // a raw socket with a timeout, so that a regression of the send loop shows
+    // up as a failed assertion here instead of hanging the whole test suite
+    raw := TCrtSocket.Open('127.0.0.1', srv.SockPort, nlTcp, 5000);
+    try
+      raw.CreateSockIn; // needed for proper SockRecvLn() below
+      raw.SockSend(['GET ', url, ' HTTP/1.1']);
+      raw.SockSend(hosthead);
+      if range <> '' then
+        raw.SockSend(['Range: bytes=', range]);
+      raw.SockSend('Connection: close');
+      raw.SockSendCRLF; // void line: end of headers
+      raw.SockSendFlush;
+      result := '';
+      raw.SockRecvLn(result); // the status line
+      headers := '';
+      repeat
+        cmd := '';
+        raw.SockRecvLn(cmd);
+        if cmd <> '' then
+          AppendLine(headers, [cmd]);
+      until cmd = ''; // end of response headers
+      if body = nil then
+        exit;
+      // actually read the body, so that a truncated one is detected here -
+      // SockInRead() and not SockRecv(), since the headers above were read
+      // through SockIn, whose buffer does already hold some body bytes
+      len := '';
+      FindNameValue(headers, 'CONTENT-LENGTH:', len);
+      body^ := raw.SockInRead(GetInteger(pointer(len)));
+    finally
+      raw.Free;
+    end;
+  end;
+
+  function HeaderValue(const headers, name: RawUtf8): RawUtf8;
+  begin
+    result := ''; // needed before being supplied as a var parameter below
+    FindNameValue(headers, pointer(name), result); // '' if not found
+  end;
+
+  procedure WaitFreed(expected: integer; const context: RawUtf8);
+  var
+    endsec: cardinal;
+  begin
+    // the stream is released by the server thread, just after the last byte
+    // has been sent: the client may notice the end of the body slightly before
+    endsec := GetTickSec + 5;
+    while (outstreamfreed < expected) and
+          (GetTickSec < endsec) do
+      SleepHiRes(1);
+    CheckEqual(outstreamfreed, expected, context);
+  end;
+
+var
+  status, headers: RawUtf8;
+  body: RawByteString;
+  req: THttpServerRequest;
+  ctx: THttpRequestContext;
+  kept: TRawByteStringStream;
+begin
+  TSynLog.Family.ExceptionIgnore.Add(EHttpServer); // the '/raise' test below
+  outdata := RandomWinAnsi(3 shl 20); // 3MB, way above any socket buffer
+  CheckEqual(length(outdata), 3 shl 20, 'outdata');
+  // two SetOutStream() guards which need no server at all
+  req := THttpServerRequest.Create(nil, 0, nil, 0, [], nil);
+  try
+    // a stream raising in Read() should be reported, not let escape: the
+    // non-streaming servers have already started their response by then
+    req.RespStatus := HTTP_SUCCESS;
+    req.SetOutStream(TRaiseReadStream.Create('1234567890'), [hosOwned]);
+    Check(not req.OutContentStreamToBuffer, 'buffer raise');
+    CheckEqual(req.OutContent, '', 'buffer raise void');
+    CheckEqual(req.RespStatus, HTTP_SERVERERROR, 'buffer raise status');
+    Check(req.OutContentStream = nil, 'buffer raise freed');
+    // a stream with no measurable size and no supplied length is refused,
+    // since the send loop always emits a Content-Length: header
+    CheckEqual(req.SetOutStream(TRaiseSeekStream.Create('123'), [hosOwned]),
+      HTTP_SERVERERROR, 'no length refused');
+    Check(req.OutContentStream = nil, 'no length freed');
+  finally
+    req.Free;
+  end;
+  // a body already set as a ContentStream - e.g. by ContentFromFile() after
+  // SetOutFile() - must not be leaked, nor make us free a stream we do not own
+  FillCharFast(ctx, SizeOf(ctx), 0);
+  ctx.Reset;
+  ctx.CommandMethod := 'GET';
+  outstreamfreed := 0;
+  ctx.ContentStream := TCountedStringStream.Create('12345');
+  include(ctx.ResponseFlags, rfContentStreamNeedFree); // as ContentFromFile()
+  kept := TRawByteStringStream.Create('67890');
+  try
+    CheckEqual(ctx.ContentFromStream(kept, 0, 5, []), HTTP_SUCCESS, 'from stream');
+    CheckEqual(outstreamfreed, 1, 'previous owned stream released');
+    Check(not (rfContentStreamNeedFree in ctx.ResponseFlags), 'not ours to free');
+    Check(ctx.ContentStream = kept, 'stream did replace the file one');
+  finally
+    ctx.ContentStream := nil;
+    kept.Free;
+  end;
+  outkept := TRawByteStringStream.Create(outdata);
+  try
+    for fam := 0 to 1 do
+    begin
+      // validate both socket server families with the very same steps
+      if fam = 0 then
+        srv := THttpServer.Create('8895', nil, nil, 'outstream', 2)
+      else
+        srv := THttpAsyncServer.Create('8896', nil, nil, 'outstream', 2);
+      try
+        Join(['Host: 127.0.0.1:', srv.SockPort], hosthead);
+        srv.OnRequest := DoOutStreamRequest;
+        srv.Route.Get('/routed', DoOutStreamRequest); // cover the router path too
+        srv.WaitStarted(10);
+        clt := THttpClientSocket.Open('127.0.0.1', srv.SockPort);
+        try
+          // a whole body sent from a server-owned stream
+          outstreamfreed := 0;
+          CheckEqual(clt.Get('/ram'), HTTP_SUCCESS, 'ram status');
+          CheckEqual(length(clt.Content), length(outdata), 'ram length');
+          CheckEqual(crc32cHash(clt.Content), crc32cHash(outdata), 'ram content');
+          CheckEqual(clt.ContentType, BINARY_CONTENT_TYPE, 'ram type');
+          WaitFreed(1, 'ram freed'); // aOwned=true: released once sent
+          // a Range: request should be served like a static file does
+          clt.RangeStart := 100;
+          clt.RangeEnd := 199;
+          CheckEqual(clt.Get('/ram'), HTTP_PARTIALCONTENT, 'range status');
+          CheckEqual(length(clt.Content), 100, 'range length');
+          CheckEqual(clt.Content, copy(outdata, 101, 100), 'range content');
+          // an unsatisfiable Range: should be rejected as 416
+          clt.RangeStart := 4 shl 20; // above the 3MB content
+          clt.RangeEnd := (4 shl 20) + 10;
+          CheckEqual(clt.Get('/ram'), HTTP_RANGENOTSATISFIABLE, 'range 416');
+          clt.RangeStart := 0; // Range: is only auto-reset on a 2xx status
+          clt.RangeEnd := 0;
+          WaitFreed(3, 'range 416 freed'); // 3 requests, 3 owned streams so far
+          // an explicit length shorter than the stream content
+          CheckEqual(clt.Get('/half'), HTTP_SUCCESS, 'half status');
+          CheckEqual(length(clt.Content), length(outdata) shr 1, 'half length');
+          CheckEqual(clt.Content, copy(outdata, 1, length(outdata) shr 1),
+            'half content');
+          WaitFreed(4, 'half freed'); // the 416 stream was freed by then too
+          // a second SetOutStream() call replaces (and frees) the first stream
+          CheckEqual(clt.Get('/replaced'), HTTP_SUCCESS, 'replaced status');
+          CheckEqual(crc32cHash(clt.Content), crc32cHash(outdata),
+            'replaced content');
+          WaitFreed(6, 'replaced freed'); // both the discarded and the sent one
+          // a stream we do own ourselves should survive the response
+          CheckEqual(clt.Get('/keep'), HTTP_SUCCESS, 'keep status');
+          CheckEqual(crc32cHash(clt.Content), crc32cHash(outdata),
+            'keep content');
+          CheckEqual(outkept.Size, length(outdata), 'keep alive'); // not freed
+          CheckEqual(outstreamfreed, 6, 'keep not freed'); // aOwned=false
+          // a handler raising after SetOutStream() must not send that body:
+          // the stream is in place when the 500 error response is generated
+          CheckEqual(clt.Get('/raise'), HTTP_SERVERERROR, 'raise status');
+          CheckNotEqual(length(clt.Content), length(outdata), 'raise no body');
+          Check(PosEx('SetOutStream regression test', clt.Content) > 0,
+            'raise message');
+          WaitFreed(7, 'raise freed'); // and the stream is still released
+          // a stream supplied already positioned: only the remainder is sent
+          CheckEqual(clt.Get('/offset'), HTTP_SUCCESS, 'offset status');
+          CheckEqual(length(clt.Content), length(outdata) - 1000, 'offset length');
+          CheckEqual(clt.Content, copy(outdata, 1001, maxInt), 'offset content');
+          CheckEqual(outstreamfreed, 7, 'offset not freed'); // aOwned=false
+        finally
+          clt.Free;
+        end;
+        // a non-seekable stream: served sequentially, but no Range: support
+        status := RawGet('/noseek', '', headers, @body);
+        CheckUtf8(PosEx(' 200 ', status) > 0, 'noseek status %', [status]);
+        CheckEqual(HeaderValue(headers, 'ACCEPT-RANGES:'), 'none', 'noseek none');
+        ctr := HeaderValue(headers, 'CONTENT-LENGTH:');
+        CheckEqual(GetInt64(pointer(ctr)), length(outdata), 'noseek length');
+        CheckEqual(crc32cHash(body), crc32cHash(outdata), 'noseek body');
+        // a Range: on that stream is ignored, and the whole body is sent
+        status := RawGet('/noseek', '100-199', headers, @body);
+        CheckUtf8(PosEx(' 200 ', status) > 0, 'noseek range status %', [status]);
+        ctr := HeaderValue(headers, 'CONTENT-LENGTH:');
+        CheckEqual(GetInt64(pointer(ctr)), length(outdata), 'noseek range length');
+        CheckEqual(crc32cHash(body), crc32cHash(outdata), 'noseek range body');
+        // a seekable stream does advertise its Range: support, and a ranged
+        // response does include the expected Content-Range: header
+        status := RawGet('/ram', '', headers, @body);
+        CheckUtf8(PosEx(' 200 ', status) > 0, 'ram raw status %', [status]);
+        CheckEqual(HeaderValue(headers, 'ACCEPT-RANGES:'), 'bytes', 'ram bytes');
+        CheckEqual(crc32cHash(body), crc32cHash(outdata), 'ram raw body');
+        status := RawGet('/ram', '100-199', headers, @body);
+        CheckUtf8(PosEx(' 206 ', status) > 0, 'ram 206 %', [status]);
+        CheckEqual(HeaderValue(headers, 'CONTENT-RANGE:'),
+          Make(['bytes 100-199/', length(outdata)]), 'ram content-range');
+        CheckEqual(body, copy(outdata, 101, 100), 'ram 206 body');
+        // a non-200 response from a stream: the range is ignored, so the
+        // handler's own body is sent whole, with its own status
+        status := RawGet('/notfound', '100-199', headers, @body);
+        CheckUtf8(PosEx(' 404 ', status) > 0, 'notfound status %', [status]);
+        CheckEqual(HeaderValue(headers, 'CONTENT-RANGE:'), '', 'notfound no range');
+        // and should not advertise a Range: support which was just disabled
+        CheckEqual(HeaderValue(headers, 'ACCEPT-RANGES:'), 'none', 'notfound none');
+        CheckEqual(crc32cHash(body), crc32cHash(outdata), 'notfound body');
+        // the very same answer, but routed by TUriRouter: its own 'no body'
+        // check must see the pending stream, or it replaces it by an error page
+        status := RawGet('/routed', '', headers, @body);
+        CheckUtf8(PosEx(' 404 ', status) > 0, 'routed status %', [status]);
+        CheckEqual(crc32cHash(body), crc32cHash(outdata), 'routed body');
+        // a TStreamWithNoSeek already partially read: its position is readable,
+        // so only the remaining bytes are announced and sent
+        status := RawGet('/noseekpos', '', headers, @body);
+        CheckUtf8(PosEx(' 200 ', status) > 0, 'noseekpos status %', [status]);
+        ctr := HeaderValue(headers, 'CONTENT-LENGTH:');
+        CheckEqual(GetInt64(pointer(ctr)), length(outdata) - 1000, 'noseekpos len');
+        CheckEqual(body, copy(outdata, 1001, maxInt), 'noseekpos body');
+        // a stream whose very Position raises: SetOutStream() detects it as
+        // not seekable at all, so it is served whole with no Range: support,
+        // the point being that the exception never escapes SetupResponse
+        status := RawGet('/failseek', '', headers, @body);
+        CheckUtf8(PosEx(' 200 ', status) > 0, 'failseek status %', [status]);
+        CheckEqual(HeaderValue(headers, 'ACCEPT-RANGES:'), 'none', 'failseek none');
+        CheckEqual(crc32cHash(body), crc32cHash(outdata), 'failseek body');
+        status := RawGet('/failseek', '100-199', headers, @body);
+        CheckUtf8(PosEx(' 200 ', status) > 0, 'failseek range %', [status]);
+        CheckEqual(crc32cHash(body), crc32cHash(outdata), 'failseek range body');
+        // a stream which does answer Position/Size, so its Range: support is
+        // advertised, but whose actual Seek() raises: 416, and no exception
+        status := RawGet('/failrange', '', headers, @body);
+        CheckUtf8(PosEx(' 200 ', status) > 0, 'failrange status %', [status]);
+        CheckEqual(HeaderValue(headers, 'ACCEPT-RANGES:'), 'bytes', 'failrange bytes');
+        CheckEqual(crc32cHash(body), crc32cHash(outdata), 'failrange body');
+        status := RawGet('/failrange', '100-199', headers, @body);
+        CheckUtf8(PosEx(' 416 ', status) > 0, 'failrange range %', [status]);
+        // the same stream with the hosNoRange option: no range is even tried,
+        // so it is served sequentially with an 'Accept-Ranges: none' header
+        status := RawGet('/norange', '', headers, @body);
+        CheckUtf8(PosEx(' 200 ', status) > 0, 'norange status %', [status]);
+        CheckEqual(HeaderValue(headers, 'ACCEPT-RANGES:'), 'none', 'norange none');
+        CheckEqual(crc32cHash(body), crc32cHash(outdata), 'norange body');
+        status := RawGet('/norange', '100-199', headers, @body);
+        CheckUtf8(PosEx(' 200 ', status) > 0, 'norange range %', [status]);
+        CheckEqual(crc32cHash(body), crc32cHash(outdata), 'norange range body');
+        // a Range: on a stream supplied already positioned is relative to that
+        // initial position, not to the start of the stream
+        status := RawGet('/offset', '0-99', headers, @body);
+        CheckUtf8(PosEx(' 206 ', status) > 0, 'offset 206 %', [status]);
+        CheckEqual(HeaderValue(headers, 'CONTENT-RANGE:'),
+          Make(['bytes 0-99/', length(outdata) - 1000]), 'offset content-range');
+        CheckEqual(body, copy(outdata, 1001, 100), 'offset 206 body');
+        WaitFreed(11, 'raw freed'); // 2 x /ram + /notfound + /routed owned one
+      finally
+        srv.Free;
+      end;
+    end;
+  finally
+    FreeAndNil(outkept);
+    outdata := '';
+    TSynLog.Family.ExceptionIgnore.Remove(EHttpServer);
   end;
 end;
 


### PR DESCRIPTION

This is a **proposal**, not a finished feature waiting to be merged. #509 has had no
answer yet, and the API shape is your call - I wrote this so there is something
concrete to react to, and I am happy to throw any part of it away.

The send loop is already stream based (`ContentStream`, `ProcessBody`,
`ValidateRange`, `rfContentStreamNeedFree`), so this adds an entry point rather
than new plumbing.

Note that this builds on the `Range:` overflow fix you merged as b61d9db4d: the
feature relies on its `ProcessBody()` abort, since a handler-supplied stream can
end short far more easily than a file can.

## API

```pascal
// THttpServerRequestAbstract
function SetOutStream(aStream: TStream; aOptions: THttpOutStreamOptions = [];
  const aContentType: RawUtf8 = ''; aContentLength: Int64 = -1): cardinal;
```

Returns `HTTP_SUCCESS`, like the other `SetOut*` methods, so a handler can write
`result := Ctxt.SetOutStream(...)`.

- `aContentLength = -1` computes `aStream.Size - aStream.Position`, like a file
  would use its size; that position is also the origin of any `Range:`
- `hosOwned` hands the stream to the server, which frees it once the response is
  sent or the request aborted
- `hosNoRange` declares up front that this stream serves no `Range:`, for a source
  which can only be read forward; it is also set automatically when the stream
  turns out not to be seekable
- a body of *unknown* length stays out of scope, as I wrote in the issue: the
  send loop always emits `Content-Length:` and has no chunked response encoding

## How it is wired

The actual work is a new `THttpRequestContext.ContentFromStream()`, sitting right
next to `ContentFromFile()` and doing the same things: set `ContentLength`,
validate the range, seek, assign `ContentStream`, set `rfContentStreamNeedFree`,
return `HTTP_SUCCESS` or `HTTP_RANGENOTSATISFIABLE`. `THttpServerRequest.
ProcessOutStream` is then a ~20 line wrapper called from `SetupResponse`, mirroring
`ProcessStaticFile`. Both socket server families share that path, so both stream it.

- ranges behave like a file: 206 with `Content-Range:`, 416 when unsatisfiable
- a stream which can not seek - a `TStreamWithNoSeek` such as `TPipeStream`, or
  one whose `Position`/`Size` raise - is served sequentially with
  `Accept-Ranges: none`, and a `Range:` request on it is ignored, so it answers
  200 with the whole body rather than a 206 without a `Content-Range:`
- servers which can not stream an in-process `TStream` - `THttpApiServer`, where
  http.sys sends from the kernel, and REST-over-WebSockets answers - call
  `OutContentStreamToBuffer`, which reads it into `OutContent`. A handler stays
  portable and only loses the memory benefit there, mirroring how `OnBodyDownload`
  falls back when it returns nil. Rejecting outright would have been the other
  option; I picked the one that does not break a handler moved between server
  classes. For http.sys this happens inside `SendResponse`, so that an
  `OnBeforeRequest` answering early cannot bypass it.

## Ownership and error paths

The stream is owned by the request until `SetupResponse` hands it to the context,
and by the context afterwards. It is released on every path I could find:
`ProcessDone` after sending, `Recycle` on a reused `THttpAsyncServer` connection,
the new `THttpServerRequestAbstract.Destroy` if the connection dies first, a
second `SetOutStream` call, and the 416 rejection.
`THttpAsyncServer.AsyncResponse` discards a pending stream before assigning its
delayed content, otherwise the stale stream would win in `SetupResponse`.

Two cases are worth calling out, because I got both wrong at first:

- a handler which raises *after* `SetOutStream` had its body sent as the 500
  response, since `CompressContentAndFinalizeHead` uses `ContentStream` and never
  looks at the error page in `OutContent`. An error response now always discards a
  pending stream.
- a handler returning a non-200 status with its own stream body had that body
  range-processed - a `Range:` request could truncate a 404 body, or replace it
  with the generated 416 page. Range handling is now gated on `StatusCodeIsSuccess`.

Note: `THttpServerRequest.Destroy` previously did not call `inherited` (it was
void); it does now. An external descendant overriding `Destroy` without calling
`inherited` would leak - none exists in this repository.

## Tests

`TNetworkProtocols.DoHttpOutStream` runs the same steps against **both**
`THttpServer` and `THttpAsyncServer`: a 3MB body from an owned stream, a range
request with its `Content-Range:` header, an unsatisfiable range, an explicit
shorter length, a replaced stream, a caller-owned stream which must survive, a
handler which raises after `SetOutStream`, a non-200 response with a range, a
stream supplied already positioned (with and without a range), a partially
consumed `TStreamWithNoSeek`, a stream whose `Position` raises without it being a
`TStreamWithNoSeek`, and one which does answer `Position`/`Size` but raises on the
actual `Seek()`.

Those last two are deliberately separate, because they exercise different guards:
the first is caught in `SetOutStream` and downgrades the stream to
`Accept-Ranges: none`, the second is caught in `ContentFromStream` and answers 416.
Keeping them apart also keeps the test compiler independent - `GetPosition` is
virtual under FPC only, so a helper stream which raises on `Seek(0, soCurrent)`
alone would take one path under FPC and the other under Delphi.

Ownership is counted, not assumed: the test streams increment a counter in their
destructor, so a leak or a double free fails an assertion. Every claim was
verified by reverting the corresponding code and confirming the matching
assertions fail - on both server families separately.

## What was measured, and what was not

I develop on ARM64, where x64 only runs under emulation, so everything needing a
native x64 result was run on separate hardware (Windows 11, i9-14900K, FPC 3.2.2
x86_64-win64, Delphi 13 `dcc64` and `dcc32`).

- FPC 3.2.2, aarch64-linux and x86_64-win64: `TNetworkProtocols` green and stable
  over repeated runs.
- Delphi 13, Win64 **and** Win32, actually executed: `HTTP` and `_SocketIO` green
  over 30 runs each. Win32 matters here because the whole path is `Int64` sized.
- `THttpApiServer` (http.sys), exercised directly rather than through the suite:
  a 1MB stream arrives byte identical, and a 3MB one - above
  `HttpContentFromFileSizeInMemory` - answers 500 with an empty body instead of a
  truncated one.
- REST-over-WebSockets, the same two cases through `TWebSocketServerRest`, same
  result. That is the path `OutputToFrame` gained, and it had never been executed
  before.
- Still not covered by a test: HTTP pipelining, `Recycle` cleanup of a pending
  stream, and a connection dying between the handler and `SetupResponse`. I traced
  them by reading the code and believe they are sound, but no assertion proves it.

That x64 round also caught a real defect, fixed in the current commit: a test
helper stream raised on every `Seek()`, including the harmless `Seek(0, soCurrent)`
that Delphi's `TStream.Position` uses, so `/failseek` took a different branch per
compiler - 30 out of 30 Delphi runs red, green under FPC throughout. The shipped
code was correct on both; the test expectation was not.

## Open questions, where I would follow your preference

1. ~~**Non-seekable detection.**~~ Settled by your review: automatic detection
   stays, and `hosNoRange` is there for a handler which already knows.
2. ~~**The other backends.**~~ Settled: they buffer into `OutContent`.
3. **206 status selection.** `SetupResponse` picks 206 from `rfWantRange` alone,
   before knowing whether a partial response actually happens. That never shows
   with files, since a file always validates the range or fails with 416; it
   surfaced here for the non-seekable and non-200 cases, which I handled by
   clearing `rfWantRange`. If you would rather have the status follow `rfRange`,
   that is a one line change in `SetupResponse` and both workarounds can go.
4. **416 without `Content-Range: bytes */size`.** Unchanged from `ContentFromFile`,
   so this proposal does not alter it - mentioning it only because RFC 9110
   recommends the header.

My use case, for context: file contents stored as 4MB chunks across sharded
SQLite databases, so there is no file to point `SetOutFile` at, and a temporary
file per download would be pointless I/O.

