### PR TITLE
net: own and join TFTP connection threads before server teardown

### DIFF
--- a/src/net/mormot.net.tftp.server.pas
+++ b/src/net/mormot.net.tftp.server.pas
@@ -93,6 +93,7 @@ type
     fLastSent: pointer;
     fLastSentLen: integer;
     procedure DoExecute; override;
+    function HasFinished: boolean;
   public
     /// initialize this connection
     constructor Create(const Source: TTftpContext; Owner: TTftpServerThread); reintroduce;
@@ -167,6 +168,7 @@ type
     procedure OnFrameReceived(len: integer; var remote: TNetAddr); override;
     procedure OnIdle(tix64: Int64); override; // called every second
     procedure OnShutdown; override; // from Destroy
+    procedure CleanupFinishedConnections;
     procedure NotifyShutdown;
   public
     /// initialize and bind the server instance, in non-suspended state
@@ -271,22 +273,25 @@ begin
   GetMem(fLastSent, fFrameMaxSize);
   MoveFast(Source.Frame^, fLastSent^, Source.FrameLen);
   fLastSentLen := Source.FrameLen;
-  FreeOnTerminate := true;
   FormatUtf8('%#% % %', [TFTP_OPCODE[Source.OpCode],
     InterlockedIncrement(TTftpConnectionThreadCounter), fContext.FileName,
     KB(fFileSize)], name);
-  inherited Create({suspended=}false, nil, nil, fOwner.LogClass, name);
+  inherited Create({suspended=}true, nil, nil, fOwner.LogClass, name);
+  FreeOnTerminate := false; // fOwner.fConnection owns and joins this thread
 end;
 
 destructor TTftpConnectionThread.Destroy;
 begin
   Terminate;
+  inherited Destroy; // join before releasing the context used by DoExecute
   fContext.Shutdown;
-  if Assigned(fOwner.fConnection) then // may be nil from fOwner.Destroy
-    fOwner.fConnection.Remove(self); // ownobject=false: just decrease Count
-  inherited Destroy;
   FreeMem(fLastSent);
   FreeMem(fContext.Frame);
+end;
+
+function TTftpConnectionThread.HasFinished: boolean;
+begin
+  result := Finished;
 end;
 
 procedure TTftpConnectionThread.DoExecute;
@@ -432,7 +437,7 @@ var
   ok: boolean;
 {$endif OSPOSIX}
 begin
-  fConnection := TSynObjectListLocked.Create({ownobject=}false);
+  fConnection := TSynObjectListLocked.Create({ownobject=}true);
   SetFileFolder(SourceFolder);
   fMaxConnections := 100; // = 100 threads, good enough for regular TFTP server
   fMaxRetry := 2;
@@ -476,8 +481,8 @@ end;
 destructor TTftpServerThread.Destroy;
 begin
   inherited Destroy;
+  FreeAndNil(fConnection); // normally emptied and joined by OnShutdown
   fFileCache.Free;
-  FreeAndNil(fConnection); // paranoid (usually done in OnShutdown)
   {$ifdef OSPOSIX}
   FreeAndNil(fPosixFileNames);
   {$endif OSPOSIX}
@@ -490,7 +495,23 @@ begin
   if fConnection = nil then
     exit;
   NotifyShutdown;
-  fConnection.Clear;
+  fConnection.Clear; // owns objects: join workers before owner teardown
+end;
+
+procedure TTftpServerThread.CleanupFinishedConnections;
+var
+  i: integer;
+begin
+  if fConnection = nil then
+    exit;
+  fConnection.Safe.WriteLock;
+  try
+    for i := fConnection.Count - 1 downto 0 do
+      if TTftpConnectionThread(fConnection.List[i]).HasFinished then
+        fConnection.Delete(i); // OwnObjects=true: release the finished thread
+  finally
+    fConnection.Safe.WriteUnLock;
+  end;
 end;
 
 procedure TTftpServerThread.NotifyShutdown;
@@ -505,11 +526,13 @@ begin
   try
     t := pointer(fConnection.List);
     for i := 1 to fConnection.Count do
-    try
-      t^.Terminate;
+    begin
+      try
+        t^.Terminate;
+      except
+        // ignore any exception here and notify the remaining workers
+      end;
       inc(t);
-    except
-      // ignore any exception here
     end;
   finally
     fConnection.Safe.WriteUnLock;
@@ -957,6 +980,7 @@ var
   range, retry: integer;
   nr: TNetResult;
   local: TNetAddr;
+  connection: TTftpConnectionThread;
 begin
   // is called from TTftpServerThread.DoExecute context (so fLog is set)
   // with a RRQ/WRQ incoming UDP frame on port 69
@@ -970,6 +994,7 @@ begin
   if (fConnection = nil) or
      not (op in [toRrq, toWrq]) then
     exit; // just ignore to avoid DoS on fuzzing
+  CleanupFinishedConnections;
   if fConnection.Count >= fMaxConnections then
   begin
     // this request will be ignored with no ERR sent -> client will retry later
@@ -1040,8 +1065,22 @@ begin
       [ToText(c.Frame^, c.FrameLen)], self);
   nr := c.SendFrame;
   if nr = nrOk then
-    // actual RRQ/WRQ transmission will take place on a dedicated thread
-    fConnection.Add(TTftpConnectionThread.Create(c, self))
+  begin
+    // register before Start so that the owner never misses a short-lived worker
+    connection := TTftpConnectionThread.Create(c, self);
+    try
+      fConnection.Add(connection);
+    except
+      connection.Free;
+      raise;
+    end;
+    try
+      connection.Start;
+    except
+      fConnection.Remove(connection); // OwnObjects=true: also frees it
+      raise;
+    end;
+  end
   else
   begin
     c.Shutdown;
@@ -1052,6 +1091,7 @@ end;
 
 procedure TTftpServerThread.OnIdle(tix64: Int64);
 begin
+  CleanupFinishedConnections;
   fFileCache.DeleteDeprecated(tix64);
   {$ifdef OSPOSIX}
   if fPosixFileNames <> nil then

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -31,8 +31,9 @@ uses
   mormot.core.zip,
   mormot.crypt.core,
   mormot.crypt.secure,
-  {$ifdef OSPOSIX}
+  mormot.net.tftp.client,
   mormot.net.tftp.server,
+  {$ifdef OSPOSIX}
   mormot.lib.curl, // client code for TFTP server validation
   {$endif OSPOSIX}
   mormot.net.sock,
@@ -128,6 +129,8 @@ type
     /// validate 'Range:' file responses, especially against invalid offsets
     procedure DoHttpFileRange(Sender: TObject);
   published
+    /// validate that a TFTP server owns all connection threads until shutdown
+    procedure TFTPShutdown;
     /// Engine.IO and Socket.IO regression tests
     procedure _SocketIO;
     /// validate DNS and LDAP clients (and NTP/SNTP)
@@ -156,6 +159,97 @@ type
 
 
 implementation
+
+var
+  TftpConnectionStarted: integer;
+  TftpConnectionDestroyed: integer;
+  TftpOwnerAccessed: integer;
+
+type
+  TSlowTftpConnection = class(TTftpConnectionThread)
+  protected
+    procedure DoExecute; override;
+  public
+    destructor Destroy; override;
+  end;
+
+  TTestTftpServer = class(TTftpServerThread)
+  public
+    procedure AddTestConnection(Connection: TTftpConnectionThread);
+    procedure TerminateAndWaitFinished(TimeOutMs: integer = 5000); override;
+  end;
+
+procedure TSlowTftpConnection.DoExecute;
+begin
+  InterlockedIncrement(TftpConnectionStarted);
+  while not Terminated do
+    SleepHiRes(1);
+  // remain alive past the deliberately short server timeout, then access owner
+  SleepHiRes(100);
+  if fOwner.MaxRetry >= 0 then
+    InterlockedIncrement(TftpOwnerAccessed);
+end;
+
+destructor TSlowTftpConnection.Destroy;
+begin
+  inherited Destroy;
+  InterlockedIncrement(TftpConnectionDestroyed);
+end;
+
+procedure TTestTftpServer.AddTestConnection(
+  Connection: TTftpConnectionThread);
+begin
+  fConnection.Add(Connection);
+  if Connection.Suspended then
+    Connection.Start;
+end;
+
+procedure TTestTftpServer.TerminateAndWaitFinished(TimeOutMs: integer);
+begin
+  inherited TerminateAndWaitFinished(1);
+end;
+
+procedure TNetworkProtocols.TFTPShutdown;
+var
+  context: TTftpContext;
+  connection: TSlowTftpConnection;
+  server: TTestTftpServer;
+  started: Int64;
+  destroyed: integer;
+begin
+  TftpConnectionStarted := 0;
+  TftpConnectionDestroyed := 0;
+  TftpOwnerAccessed := 0;
+  FillCharFast(context, SizeOf(context), 0);
+  context.BlockSize := 512;
+  context.FrameLen := 2;
+  GetMem(context.Frame, context.FrameLen);
+  FillCharFast(context.Frame^, context.FrameLen, 0);
+  server := nil;
+  try
+    context.FileStream := TMemoryStream.Create;
+    server := TTestTftpServer.Create('', [], nil, '127.0.0.1', '0',
+      'tftp-lifetime', {CacheTimeoutSecs=}0);
+    connection := TSlowTftpConnection.Create(context, server);
+    context.FileStream := nil; // ownership moved into connection.fContext
+    server.AddTestConnection(connection);
+    started := GetTickCount64;
+    while (TftpConnectionStarted = 0) and
+          (GetTickCount64 - started < 5000) do
+      SleepHiRes(1);
+    CheckEqual(TftpConnectionStarted, 1, 'connection started');
+  finally
+    server.Free;
+    FreeMem(context.Frame);
+    context.FileStream.Free;
+  end;
+  destroyed := TftpConnectionDestroyed;
+  if destroyed <> 1 then
+    // let a broken pre-fix worker finish before the test process continues
+    SleepHiRes(250);
+  CheckEqual(destroyed, 1, 'connection outlived its owner');
+  CheckEqual(TftpOwnerAccessed, 1, 'owner access after terminate');
+end;
 
 procedure TNetworkProtocols._SocketIO;
 var


### PR DESCRIPTION
## Problem

`TTftpConnectionThread` was started from its constructor with `FreeOnTerminate = true`, then registered in a non-owning `fConnection` list only after the constructor returned.

This left two lifetime races:

1. A short-lived worker could finish and destroy itself before being added, leaving a dangling pointer in the server list.
2. During shutdown, the server only called `Terminate` and cleared the non-owning list. A worker could therefore keep using `fOwner` after the server and its state had been released.

This can result in a use-after-free during TFTP server teardown.

## Fix

- Construct connection threads suspended.
- Register each worker before `Start`.
- Make the server list own non-self-freeing workers.
- Reap finished workers before accepting a new request and from `OnIdle`.
- On teardown, terminate all workers and let the owning list destroy and join them before releasing server state.
- Preserve the existing timeout behavior of `TerminateAndWaitFinished`; the mandatory unbounded join happens only when the owner is actually destroyed.
- Release socket, context, and stream state only after `TThread.Destroy` has joined `Execute`.

## Regression test

A cross-platform `TNetworkProtocols.TFTPShutdown` test creates a worker that deliberately remains alive beyond a 1 ms shutdown timeout and then accesses scalar owner state. `Server.Free` must return only after the worker destructor has run.

Results:

- Exact pre-fix upstream: deterministic failure, `connection outlived its owner`.
- Delphi 12.2 Win64: PASS.
- FPC 3.2.2 Linux x86-64 O2: PASS.
- Real 65,537-byte TFTP/libcurl transfer with content comparison: PASS.