### PR TITLE
Fix ValueVarToVariant managed value leak on NULL

### DIFF
--- a/src/orm/mormot.orm.base.pas
+++ b/src/orm/mormot.orm.base.pas
@@ -3624,7 +3624,7 @@ var
 begin
   if Value = nil then
   begin
-    TSynVarData(result).VType := varNull;
+    VarClearAndSetType(variant(result), varNull);
     exit;
   end;
   VarClearAndSetType(variant(result), SQL_ELEMENTTYPES[fieldType]);

--- a/test/test.core.data.pas
+++ b/test/test.core.data.pas
@@ -512,6 +512,9 @@ var
   vd: TVarData absolute v;
   info: TGetJsonField;
   t: pointer;
+  s: RawUtf8;
+  r: RawByteString;
+  rc: integer;
   dt: TDateTime;
   ni: TNullableInteger;
   nt: TNullableUtf8Text;
@@ -530,9 +533,16 @@ begin
   TextToVariant('1e308', true, v);
   Check(VarIsStr(v));
   Check(VarIsString(v));
+  s := FormatUtf8('value-%', [123]); // ensure a regular ref-counted string
+  TextToVariant(s, true, v);
+  VariantToRawByteString(v, r);
+  rc := GetRefCount(r);
+  Check(rc > 1);
   t := nil; // makes the compiler happy
   ValueVarToVariant(nil, 0, oftBoolean, vd, false, t);
   CheckEqual(TVarData(v).VType, varNull);
+  CheckEqual(GetRefCount(r), rc - 1);
+  r := '';
   ValueVarToVariant('0', 1, oftBoolean, vd, false, t);
   Check(not boolean(v));
   Check(VariantTypeName(v)^ = 'Boolean');


### PR DESCRIPTION
## Problem

`ValueVarToVariant(nil, ..., result)` directly changed `VType` to `varNull`.

If `result` already contained a string or another managed value, its reference was lost without clearing the Variant, leaking the value.

## Fix

Use `VarClearAndSetType(..., varNull)` for the NULL branch, as already done by the regular `ValueVarToVariant` path.

The existing `TTestCoreProcess.Variants` test now verifies that replacing a string Variant with NULL releases exactly one reference.

## Validation

- Pre-fix focused regression: the reference count was unchanged.
- FPC 3.2.2 Win32: focused regression passed.
- Delphi 12.2 Win64: focused regression passed.
- `TTestCoreProcess.Variants`: 197 assertions passed.