### PR TITLE
core: read Win64 thread ID directly from the TEB

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -1758,9 +1758,8 @@ asm     // size = rcx on Windows, = rdi on SystemV; use rsi = TSmallBlockType
         db $64, $48, $8B, $04, $25, $10, $00, $00, $00
         {$else}
         {$ifdef WINDOWS}
-        // inlined GetThreadID from Win64 kernel.dll (tested on Windows 7-11)
-        db $65, $48, $8B, $04, $25, $30, $00, $00, $00 // mov rax, gs:[$0030]
-        mov     eax, [rax + $48]
+        // TEB.ClientId.UniqueThread (tested on Windows 7-11)
+        db $65, $8B, $04, $25, $48, $00, $00, $00 // mov eax, gs:[$0048]
         {$else}
         unsupported
         {$endif WINDOWS}
@@ -2177,9 +2176,8 @@ asm     // size = rcx on Windows, = rdi on SystemV; use rsi = TSmallBlockType
         db $64, $48, $8B, $04, $25, $10, $00, $00, $00
         {$else}
         {$ifdef WINDOWS}
-        // inlined GetThreadID from Win64 kernel.dll (tested on Windows 7-11)
-        db $65, $48, $8B, $04, $25, $30, $00, $00, $00
-        mov     eax, [rax + $48]
+        // TEB.ClientId.UniqueThread (tested on Windows 7-11)
+        db $65, $8B, $04, $25, $48, $00, $00, $00 // mov eax, gs:[$0048]
         {$else}
         unsupported
         {$endif WINDOWS}


### PR DESCRIPTION
## Problem

The Win64 `FPCMM_TINYPERTHREAD` and `FPCMM_MEDIUMPERTHREAD` paths currently read the thread ID through two dependent loads: first the TEB pointer from `gs:[$30]`, then `TEB.ClientId.UniqueThread` from `[rax+$48]`.

On Win64 the GS base already points to the TEB, so the low DWORD of `UniqueThread` can be read directly from `gs:[$48]`.

## Change

Replace both two-instruction sequences with a direct `mov eax, gs:[$48]`. Arena selection semantics are unchanged.

## Measurements

A/B on current master (`aef05e96d`), Win64 x86-64, `-O3`, with identical compiler, source and workload:

| Case | Before | After | Change |
|---|---:|---:|---:|
| alloc/free 16 | 7.09 ns | 6.64 ns | -6.3% |
| alloc/free 64 | 6.91 ns | 6.66 ns | -3.6% |
| alloc/free 128 | 18.42 ns | 17.77 ns | -3.5% |
| ring 64 | 3.507 ns | 3.379 ns | -3.7% |

Sizes which do not use this path remained within measurement noise.

## Validation

- Disassembly contains exactly two direct `mov %gs:0x48,%eax` loads instead of the two old `gs:0x30` plus `[rax+0x48]` pairs.
- GUI, SERVER and BOOSTER profiles build and run.
- Full Win64 MM qualification passed 12 million randomized alloc/realloc/free operations, cross-thread ownership transfers, pool lifecycle boundaries and 30 seconds of 26-thread lock saturation.
- Linux code is unchanged by construction.

The benchmark and ownership-safe MM stress programs are available in [MoonCompiler qualification](https://github.com/Moonbot-Tech/MoonCompiler/tree/main/qualification).