### PR TITLE
core: retain repeatedly reused small-block pools

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -990,6 +990,7 @@ const
   SmallBlockDownsizeCheckAdder = 64;
   SmallBlockUpsizeAdder        = 32;
   SmallBlockTypePO2            = 6;  // SizeOf(TSmallBlockType)=64
+  SmallBlockPoolRetentionThreshold = 8;
 
   MediumBlockPoolSize          = MediumBlockPoolSizeMem - 16;
   {$ifdef FPCMM_MEDIUMPERTHREAD}
@@ -1071,7 +1072,8 @@ type
     GetmemCount: cardinal;
     FreememCount: cardinal;
     LastFreeLocked: boolean;
-    Padding: array[1 .. 3] of byte;
+    EmptyPoolReuseCount: byte;
+    Padding: array[1 .. 2] of byte;
     LastFreeCount: cardinal;
   end;
   PSmallBlockType = ^TSmallBlockType;
@@ -2548,6 +2550,7 @@ asm     // P = rcx on Windows, P = rdi on SystemV; use rsi = TSmallBlockType
         mov     rax, [rdx].TSmallBlockPoolHeader.FirstFreeBlock
         sub     [rdx].TSmallBlockPoolHeader.BlocksInUse, 1
         jz      @PoolIsNowEmpty
+@StoreFreeBlock:
         // Store this as the new first free block
         mov     [rdx].TSmallBlockPoolHeader.FirstFreeBlock, rcx
         // Store the previous first free block as the block header
@@ -2584,7 +2587,11 @@ asm     // P = rcx on Windows, P = rdi on SystemV; use rsi = TSmallBlockType
 @PoolIsNowEmpty:
         // FirstFreeBlock=nil means it is the sequential feed pool with a single block
         test    rax, rax
+        {$ifdef FPCMM_SERVER}
+        jz      @EmptySequentialFeedPool
+        {$else}
         jz      @IsSequentialFeedPool
+        {$endif FPCMM_SERVER}
         // Pool is now empty: Remove it from the linked list and free it
         mov     rax, [rdx].TSmallBlockPoolHeader.PreviousPartiallyFreePool
         mov     rcx, [rdx].TSmallBlockPoolHeader.NextPartiallyFreePool
@@ -2622,6 +2629,18 @@ asm     // P = rcx on Windows, P = rdi on SystemV; use rsi = TSmallBlockType
         {$else}
         jmp     @Done // on Win64, a stack frame is required
         {$endif NOSFRAME}
+        {$ifdef FPCMM_SERVER}
+@EmptySequentialFeedPool:
+        // Larger small classes share one block type process-wide. Keep one pool
+        // only after repeated single-block churn; all classes together retain
+        // at most about 1.2 MiB with the current pool table.
+        cmp     word ptr [rsi].TSmallBlockType.BlockSize, 256
+        jbe     @IsSequentialFeedPool
+        cmp     byte ptr [rsi].TSmallBlockType.EmptyPoolReuseCount, SmallBlockPoolRetentionThreshold
+        jae     @StoreFreeBlock
+        inc     byte ptr [rsi].TSmallBlockType.EmptyPoolReuseCount
+        jmp     @IsSequentialFeedPool
+        {$endif FPCMM_SERVER}
 @ProcessPendingBin:
         // Release the next SmallLastFree list block while we own the lock
         cmp     byte ptr [rsi].TSmallBlockType.LastFreeLocked, false


### PR DESCRIPTION
## Problem

When a sequential-feed pool contains one allocated block, freeing that block returns the whole pool to the medium allocator. A subsequent request for the same size recreates a pool under the shared lock. Repeated single-block churn therefore pays the full pool teardown/rebuild cost on every cycle.

## Change

For `FPCMM_SERVER`:

- the first eight empty-pool cycles still release the pool;
- from the ninth cycle onward, one current pool is retained for that size class;
- only physical block classes above 256 bytes participate, so per-thread tiny arenas are untouched;
- one byte of existing padding stores the counter, keeping `TSmallBlockType` at 64 bytes;
- normal `GetMem` gets no additional branch; the logic runs only in the already locked last-free path.

With the current size table, retained pool capacity is bounded at about 1.18 MiB process-wide, with no per-thread reservation.

## Measurements

A/B on current master (`aef05e96d`), Win64 x86-64, `-O3`, default `FPCMM_SERVER`:

| Case | Before | After | Speedup |
|---|---:|---:|---:|
| alloc/free 256 | 16.81 ns | 7.40 ns | 2.27x |
| alloc/free 512 | 16.83 ns | 7.42 ns | 2.27x |
| alloc/free 1024 | 17.18 ns | 7.40 ns | 2.32x |
| alloc/free 2048 | 16.82 ns | 7.41 ns | 2.27x |
| fragmented mixed | 107.86 ns | 10.31 ns | 10.46x |
| ring 512 | 3.827 ns | 3.822 ns | parity |

Under BOOSTER, the targeted churn cases improved by about 2.37x, while ring and mixed workloads remained around parity. Three alternating Horse server A/B rounds also remained around parity with a small positive median shift.

## Validation

- The GUI build is byte-for-byte identical before and after the change.
- GUI, SERVER and BOOSTER profiles build and run on Win64.
- Full MM qualification passed on Win64 SERVER/BOOSTER and Linux BOOSTER: 12 million randomized alloc/realloc/free operations, realloc matrices, cross-thread ownership transfers, pool lifecycle boundaries and 30 seconds of 26-thread lock saturation.
- The benchmark and ownership-safe MM stress programs are available in [MoonCompiler qualification](https://github.com/Moonbot-Tech/MoonCompiler/tree/main/qualification).

We found this optimization after compiling and load-testing the Brazilian [Horse](https://github.com/HashLoad/horse) web framework with [MoonCompiler](https://github.com/Moonbot-Tech/MoonCompiler).