### PR TITLE
net: fix lost thread wakeup in TAsyncConnections.ThreadPollingWakeupOne/Events

### DIFF
--- a/src/net/mormot.net.async.pas
+++ b/src/net/mormot.net.async.pas
@@ -2675,9 +2675,13 @@ begin
   // wake up one thread after accept() on idle server or on slow REST process
   if acoThreadSmooting in fOptions then
     fThreadPollingLastWakeUpTix := mormot.core.os.GetTickCount64; // 16ms / 4ms
-  if LockedExc32(fWakeupOne, 1, 0) then // if not already notified
-    if fWakeupSafe.TryLock then
-      ThreadPollingWakeupLocked; // only a single thread does the wakeup
+  LockedExc32(fWakeupOne, 1, 0); // notify (idempotent if already notified)
+  // always try to do the wakeup ourselves, even if fWakeupOne was already
+  // set: a previous notification may have been left pending by a caller
+  // which failed its TryLock, and a TryLock is cheap - otherwise a stuck
+  // fWakeupOne=1 would silently disable any further accept() wakeup
+  if fWakeupSafe.TryLock then
+    ThreadPollingWakeupLocked; // only a single thread does the wakeup
 end;
 
 procedure TAsyncConnections.ThreadPollingWakeupEvents(Events: integer);
@@ -3881,6 +3885,16 @@ begin
   // notify threads outside fWakeupSafe
   for i := 0 to n - 1 do
     fThreads[ndx[i]].fEvent.SetEvent;
+  // a concurrent ThreadPollingWakeupOne/Events may have incremented a counter
+  // just after our LockedGet32() above, then failed its TryLock because we
+  // were still holding fWakeupSafe: its request would be lost (e.g. fWakeupOne
+  // stuck to 1 with no thread notified) until the next epoll event - which
+  // never comes on an idle server with R0 in WaitForEver, so the server would
+  // accept() new connections but never process them
+  if ((fWakeupOne <> 0) or
+      (fWakeupEvents <> 0)) and
+     fWakeupSafe.TryLock then
+    ThreadPollingWakeupLocked; // process the request(s) we may have missed
 end;
 
 {$endif USE_WINIOCP}


### PR DESCRIPTION
## Symptom

Since 73cb95431 (2026-08-28) a `THttpAsyncServer` (POSIX/epoll) can silently stop serving: the process stays alive, `accept()` keeps succeeding, but new connections are never read and pile up in `CLOSE-WAIT`. Everything else in the process keeps running.

We hit it on production RK3588 boards (aarch64, FPC, 8 worker threads) 8 to 18 hours after start, then reproduced it in about 4 minutes (114 rounds) with a mix of concurrent HTTP/1.0 short-lived and HTTP/1.1 keep-alive connections separated by short idle gaps.

`/proc/<tid>/syscall` + `/proc/<pid>/mem` stack scan (symbolized with the `.dbg` file) showed:

- `R0:port` (atpReadPoll) blocked in `TSynEvent.WaitFor(INFINITE)` from `TAsyncConnectionsThread.DoExecute` (the "no connection any more: wait for next accept" branch), or in a second variant polling `epoll_wait(1000)` forever;
- `R1:port` (atpReadPending) idle in `WaitForEver`;
- the accept thread in `Accept()`;
- no thread ever changing its `voluntary_ctxt_switches`.

## Cause

`ThreadPollingWakeupOne` / `ThreadPollingWakeupEvents` register a request in `fWakeupOne` / `fWakeupEvents` and only run `ThreadPollingWakeupLocked` after a successful `fWakeupSafe.TryLock`. `ThreadPollingWakeupLocked` consumes the counters with `LockedGet32()` (atomic read-and-clear).

If a caller increments a counter just after the current holder did its `LockedGet32()` and then fails its own `TryLock`, nobody consumes that request. `fWakeupOne` stays at 1, and every further `ThreadPollingWakeupOne` fails its `LockedExc32(fWakeupOne, 1, 0)` "if not already notified" gate and returns without doing anything. Accepted sockets are not subscribed to epoll before their first read (`ProcessClientStart` only calls `AddOnePending`), so R0 has nothing to wake it up either.

Before 73cb95431 this path used a blocking `fThreadPollingWakeupSafe.Lock`, so no request could be lost.

## Fix (one file, +17/-3)

- `ThreadPollingWakeupLocked`: after `UnLock` and the `SetEvent` loop, re-check both counters and run once more if any is non-zero and the lock can be re-acquired, so a request raced against the holder is never left pending.
- `ThreadPollingWakeupOne`: always attempt the `TryLock`, even when `fWakeupOne` was already set, so a pending notification is self-healing on the next `accept()` instead of silently disabling all further wakeups. `TryLock` is cheap and the "only a single thread does the wakeup" property is kept.

## Verification

Same stress on the same board:

| build                          | result                                  |
|--------------------------------|-----------------------------------------|
| current master code            | stalled at round 114 (about 4.5 min)    |
| with this patch                | 1910 rounds / 45 min, no stall          |

Our own regression suite (3592 assertions) passes unchanged. Compiles with FPC 3.2 / Lazarus for aarch64-linux and x86_64-win64.
