### PR TITLE
Fix THttpMultiPartStream duplicated closing boundaries on keep-alive POST - fix #565

### DIFF
--- a/src/net/mormot.net.client.pas
+++ b/src/net/mormot.net.client.pas
@@ -80,6 +80,8 @@ type
   // proper multipart formatting as defined by RFC 2488 / RFC 1341
   // - AddFile() won't load the file content into memory so it is more
   // efficient than MultiPartFormDataEncode() from mormot.core.buffers
+  // - THttpClientSocket.Post() will call Flush and rewind the stream itself,
+  // so the very same instance can be sent several times, e.g. on retry
   THttpMultiPartStream = class(TNestedStreamReader)
   protected
     fSections: THttpMultiPartStreamSections;
@@ -88,6 +90,7 @@ type
     fMultipartContentType: RawUtf8;
     fFilesCount: integer;
     fRfc2388NestedFiles: boolean;
+    fFlushed: boolean;
     function Add(const name, content, contenttype,
       filename, encoding: RawUtf8): PHttpMultiPartStreamSection;
   public
@@ -108,6 +111,9 @@ type
       const contenttype: RawUtf8 = '');
     /// call this method before any Read() call to sent data to HTTP server
     // - it is called also when Seek(0, soBeginning) is called
+    // - the closing boundaries are appended once, so it is safe to call this
+    // method several times, e.g. on every THttpClientSocket.Post() retry
+    // - no Add*() method should be called after Flush
     procedure Flush; override;
     /// the content-type header value for this multipart content
     // - equals '' if no section has been added
@@ -2293,6 +2299,8 @@ var
   ns: PtrInt;
   s: RawUtf8;
 begin
+  if fFlushed then
+    EHttpSocket.RaiseUtf8('%.Add(%) after Flush', [self, name]);
   // same logic than MultiPartFormDataEncode() from mormot.core.buffers
   ns := length(fSections);
   SetLength(fSections, ns + 1);
@@ -2384,6 +2392,8 @@ var
   fs: TStream;
   fn: RawUtf8;
 begin
+  if fFlushed then // check before opening the file, as Add() would do
+    EHttpSocket.RaiseUtf8('%.AddFile(%) after Flush', [self, filename]);
   fs := TFileStreamEx.Create(filename, fmOpenReadShared);
   // an exception is raised in above line if filename is incorrect
   StringToUtf8(ExtractFileName(filename), fn);
@@ -2399,10 +2409,18 @@ var
 begin
   if fBounds = nil then
     exit;
-  for i := length(fBounds) - 1 downto 0 do
-    mormot.core.text.Append(s, ['--', fBounds[i], '--'#13#10]);
-  Append(s);
-  inherited Flush; // compute fSize
+  if not fFlushed then
+  begin
+    // append the closing boundaries only once: Flush is called again by any
+    // Seek(0, soBeginning), e.g. from THttpClientSocket.RequestInternal after
+    // an explicit Flush, or on retry - the duplicated boundaries exceeded the
+    // Content-Length: header and broke the keep-alive connection - see #565
+    for i := length(fBounds) - 1 downto 0 do
+      mormot.core.text.Append(s, ['--', fBounds[i], '--'#13#10]);
+    Append(s);
+    fFlushed := true;
+  end;
+  inherited Flush; // rewind nested streams and compute fSize
 end;
 
 
@@ -3906,6 +3924,10 @@ begin
       else
         SockSend('Connection: Close');
       dat := ctxt.Data; // local var copy for Data to be compressed in-place
+      if ctxt.InStream <> nil then
+        // InStream may be a THttpMultiPartStream -> Seek(0) calls Flush, so
+        // that its Size is known when Content-Length: is computed below
+        ctxt.InStream.Seek(0, soBeginning); // rewind
       if (dat <> '') or
          (not IsGet(ctxt.Method) and // no message body len/type for GET/HEAD
           not IsHead(ctxt.Method)) then
@@ -3921,8 +3943,6 @@ begin
         FillCharFast(pointer(fSndBuf)^, buflen, 0); // hide SPI bearer
       if ctxt.InStream <> nil then
       begin
-        // InStream may be a THttpMultiPartStream -> Seek(0) calls Flush
-        ctxt.InStream.Seek(0, soBeginning); // rewind
         res := SockSendStream(ctxt.InStream, 1 shl 20,
              {noraise=}false, {checkrecv=}true);
         AppendLine(fRequestContext, [ctxt.InStream, ' = ', _NR[res]]);

--- a/test/test.core.base.pas
+++ b/test/test.core.base.pas
@@ -10204,7 +10204,7 @@ var
   i, j, n: integer;
   fa: TFileAge;
   fdt: TDateTime;
-  fs: Int64;
+  fs, sz: Int64;
   fu: TUnixMSTime;
   fn: array[0..10] of TFileName;
   mp, mp2: TMultiPartDynArray;
@@ -10413,6 +10413,34 @@ begin
     DecodeAndTest;
     DecodeStreamAndTest(4096);
     DecodeStreamAndTest(65536);
+    // Flush should be idempotent: THttpClientSocket calls Seek(0, soBeginning)
+    // before sending the body, which triggers Flush again - the closing
+    // boundary was appended once more and the sent body exceeded the
+    // Content-Length: computed from Size - see #565
+    sz := st.Size;
+    CheckEqual(sz, length(mpc), 'st size');
+    st.Flush;
+    CheckEqual(st.Size, sz, 'st flush twice');
+    st.Seek(0, soBeginning);
+    CheckEqual(st.Size, sz, 'st rewind');
+    CheckEqual(StreamToRawByteString(st), mpc, 'st read twice');
+    raised := false;
+    try
+      st.AddContent('late', 'not allowed after Flush');
+    except
+      on EHttpSocket do
+        raised := true;
+    end;
+    Check(raised, 'st add after flush');
+    raised := false;
+    try
+      st.AddFile('late', fn[0]); // should not even open the file
+    except
+      on EHttpSocket do
+        raised := true;
+    end;
+    Check(raised, 'st addfile after flush');
+    CheckEqual(st.Size, sz, 'st size after failed add');
     st.Free;
     for i := 0 to high(fn) do
       check(DeleteFile(fn[i]));

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -4820,6 +4820,8 @@ var
   mp, ok, hosthead, mpct, mptext, mptrunc, cmd: RawUtf8;
   keepfile: TFileName;
   mpa: TMultiPartDynArray;
+  mps: THttpMultiPartStream;
+  mpssize: Int64;
 begin
   TSynLog.Family.ExceptionIgnore.AddSeveral([
     EWriteError, EHttpSocketOverflow, ENetSock]);
@@ -4911,6 +4913,51 @@ begin
           CheckEqual(clt.Content,
             Make(['ok ', CardinalToHexShort(bodyhash)]), 'mp resp');
           WaitDeleted(bodyfile, 'mp');
+          // two THttpMultiPartStream POST over the same keep-alive connection:
+          // the client should send exactly Content-Length bytes, so that no
+          // duplicated closing boundary is left on the socket, to be parsed
+          // by the server as an invalid next request line - see #565
+          mps := THttpMultiPartStream.Create;
+          try
+            mps.AddContent('field', mptext);
+            mps.Flush; // explicit call before Post(), as documented
+            mpssize := mps.Size;
+            Check(mpssize > length(mptext), 'mps flushed');
+            bodytype := mps.MultipartContentType;
+            for n := 1 to 2 do
+            begin
+              status := clt.Post('/mp', mps, bodytype, {keepalive=}30000);
+              CheckEqual(status, HTTP_SUCCESS, 'mps status');
+              CheckEqual(clt.Content,
+                Make(['ok ', CardinalToHexShort(bodyhash)]), 'mps resp');
+              CheckEqual(mps.Size, mpssize, 'mps size unchanged');
+              CheckEqual(mps.Position, mpssize, 'mps sent whole body');
+              if n = 2 then // the first POST reopens the previously closed socket
+                CheckUtf8(PosEx('DoRetry', clt.RequestContext) = 0,
+                  'mps keep-alive %', [clt.RequestContext]);
+              WaitDeleted(bodyfile, 'mps');
+            end;
+          finally
+            mps.Free;
+          end;
+          // a stream which was never explicitly flushed should work as well,
+          // since the client rewinds (and therefore flushes) it before the
+          // Content-Length: header is computed from its Size
+          mps := THttpMultiPartStream.Create;
+          try
+            mps.AddContent('field', mptext);
+            CheckEqual(mps.Size, 0, 'mps2 not flushed yet');
+            bodytype := mps.MultipartContentType;
+            status := clt.Post('/mp', mps, bodytype, {keepalive=}30000);
+            CheckEqual(status, HTTP_SUCCESS, 'mps2 status');
+            CheckEqual(clt.Content,
+              Make(['ok ', CardinalToHexShort(bodyhash)]), 'mps2 resp');
+            CheckEqual(mps.Size, mpssize, 'mps2 flushed once');
+            CheckEqual(mps.Position, mpssize, 'mps2 sent whole body');
+            WaitDeleted(bodyfile, 'mps2');
+          finally
+            mps.Free;
+          end;
           // spool a chunked body, i.e. with no Content-Length
           bodytype := 'application/dummy';
           bodyhash := crc32cHash(mptext);


### PR DESCRIPTION
Fixes #565.

## Root cause

`THttpMultiPartStream.Flush` appends the closing `--boundary--` line on every call. The documented usage is to call `Flush` before `Post()`, and `THttpClientSocket.RequestInternal` then

1. computes `Content-Length:` from `InStream.Size` (in `CompressDataAndWriteHeaders`), and only afterwards
2. calls `InStream.Seek(0, soBeginning)` - which `TNestedStreamReader.Seek` turns into another `Flush`.

So the body actually streamed is 22 bytes longer than the header announces. The server consumes `Content-Length` bytes, answers, and then finds `--boundary--\r\n` on the socket: http.sys parses it as the next request line and answers `400 Bad Request - Invalid Verb` (the mORMot servers simply drop the connection). With NTLM/Negotiate the same stream instance is re-sent on every `RequestInternal` call of the handshake, and the overflow grows with each round trip - which matches the `response during SockSendStream` trace in the issue.

## Fix

- `THttpMultiPartStream.Flush` appends the closing boundaries only once (`fFlushed` flag), so it is safe to call it any number of times, e.g. on every retry. `Add*()` after `Flush` now raise `EHttpSocket` instead of silently producing a broken body (`AddFile` checks before opening the file, so nothing leaks).
- `THttpClientSocket.RequestInternal` rewinds `InStream` before `Content-Length:` is computed, so `Size` is right even when the caller never called `Flush` explicitly.

## Tests

- `TTestCoreBase.MultiPartDecoder`: `Flush`/`Seek(0)` keep `Size` unchanged, the stream reads back byte-identical, and `AddContent`/`AddFile` after `Flush` raise.
- `TNetworkProtocols.DoHttpBodyDownload`: the same `THttpMultiPartStream` is posted twice over one keep-alive connection, plus a never-flushed instance once, against both `THttpServer` and `THttpAsyncServer`; checks that exactly `Size` bytes were sent, `Size` did not grow, and the client never had to reconnect (`RequestContext` has no `DoRetry`).

Both tests were red before the fix (22 extra bytes per `Flush`; the async server variant even hung the second POST until the 10 s header timeout) and are green after it, on FPC 3.3.1 aarch64-win64 and Delphi 13 Win64.
