### PR TITLE
Fix Windows compilation of TAsyncConnectionsThread.DoExecute after a333a689f

### DIFF
--- a/src/net/mormot.net.async.pas
+++ b/src/net/mormot.net.async.pas
@@ -2841,8 +2841,8 @@ begin
         EAsyncConnections.RaiseUtf8('%.Execute: unexpected fProcess=%',
           [self, ord(fProcess)]);
       end;
-    {$endif USE_WINIOCP}
     end;
+    {$endif USE_WINIOCP}
     fOwner.DoLog(sllInfo, 'Execute: done %', [fProcessName], self);
   except
     on E: Exception do


### PR DESCRIPTION
a333a689f wrapped the non-IOCP polling loop of `TAsyncConnectionsThread.DoExecute` in a `begin`/`end` block, but the closing `end;` landed after `{$endif USE_WINIOCP}`. Every Windows build with `USE_WINIOCP` (the default) currently fails:

```
mormot.net.async.pas(2845,5) Fatal: (2003) Syntax error, "EXCEPT" expected but "END" found
```

This moves the `end;` inside the `{$else}` branch. Verified with FPC 3.3.1 aarch64-win64 and Delphi 13 Win64: the full test project compiles again, and `TNetworkProtocols` passes.