### PR TITLE
core: reset small pool reuse on cold release path

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -2016,10 +2016,6 @@ asm     // size = rcx on Windows, = rdi on SystemV; use rsi = TSmallBlockType
         // Adjust number of used blocks and sequential feed pool
         mov     [rsi].TSmallBlockType.NextSequentialFeedBlockAddress, rcx
         add     [rdx].TSmallBlockPoolHeader.BlocksInUse, 1
-        {$ifdef FPCMM_SERVER}
-        // More than one block fits: no longer consecutive single-block churn
-        mov     byte ptr [rsi].TSmallBlockType.EmptyPoolReuse, 0
-        {$endif FPCMM_SERVER}
         // Unlock the block type, set the block header and leave
         mov     byte ptr [rsi].TSmallBlockType.Locked, false
         mov     [rax - BlockHeaderSize], rdx
@@ -2677,6 +2673,11 @@ asm     // P = rcx on Windows, P = rdi on SystemV; use rsi = TSmallBlockType
         xor     eax, eax
         cmp     [rsi].TSmallBlockType.CurrentSequentialFeedPool, rdx
         jne     @NotSequentialFeedPool
+        {$ifdef FPCMM_SERVER}
+        // A drained multi-block sequential pool ends single-block churn.
+        // Reset on this cold release path, not on every sequential GetMem.
+        mov     byte ptr [rsi].TSmallBlockType.EmptyPoolReuse, 0
+        {$endif FPCMM_SERVER}
 @IsSequentialFeedPool:
         mov     [rsi].TSmallBlockType.MaxSequentialFeedBlockAddress, rax
 @NotSequentialFeedPool:


### PR DESCRIPTION
This follows up #563 and `8343fa49f`.

The reclaim fix correctly clears `EmptyPoolReuse` after a retained sequential pool starts serving multiple live blocks, but it currently does so on every successful sequential `GetMem` in `@TrySmallSequentialFeed`.

This change moves the same reset to the cold `_FreeMem` path where that multi-block sequential pool actually drains. The lifecycle remains unchanged:

- repeated single-block churn may retain one empty pool;
- the retained pool is reused;
- after the class serves multiple live blocks and the pool drains, reuse history is cleared and the pool is released;
- the next isolated allocation/free cycle starts the history again.

Validation on current `master` with MoonCompiler 1.0.0 (Free Pascal base 3.3.1):

- Win64 `memory_mega quick`: PASS (size sweep, realloc matrix, pool lifecycle, deterministic fuzz, cross-thread ownership, 26-thread saturation);
- Linux x86-64 `memory_mega quick`: PASS on 34 available CPUs with the same phases;
- paired Win64 A/B over eight small-block ring cases: cold-path version `0.997x` the time of the current hot-path reset (geometric mean).

No profile or retention threshold changes; this only removes the reset store from the allocation hot path.