### PR TITLE
core: skip medium-to-large fallback with per-thread arenas

### DIFF
--- a/src/core/mormot.core.fpcx64mm.pas
+++ b/src/core/mormot.core.fpcx64mm.pas
@@ -60,7 +60,7 @@ unit mormot.core.fpcx64mm;
 
 // target a multi-threaded service on a modern CPU (default)
 // - define FPCMM_DEBUG, FPCMM_ASSUMEMULTITHREAD, FPCMM_ERMS, FPCMM_TINYPERTHREAD
-// and FPCMM_MEDIUMTOLARGE
+// and FPCMM_MEDIUMTOLARGE unless FPCMM_MEDIUMPERTHREAD is active
 // - currently mormot2tests run with no contention when FPCMM_SERVER is set :)
 {$define FPCMM_SERVER}
 
@@ -72,7 +72,8 @@ unit mormot.core.fpcx64mm;
 // target high-end CPU/process when FPCMM_SERVER/FPCMM_BOOST are not enough
 // - will use 128 arenas for <= 256B blocks to scale on high number of cores;
 // - enable FPCMM_MULTIPLESMALLNOTWITHMEDIUM to reduce small pools locks;
-// - enable FPCMM_MEDIUMPERTHREAD for 4 user-medium arenas on Linux/Win64.
+// - enable FPCMM_MEDIUMPERTHREAD for 4 user-medium arenas on Linux/Win64,
+//   so FPCMM_MEDIUMTOLARGE is no longer enabled automatically.
 {.$define FPCMM_BOOSTER}
 
 // target a GUI/console mono-threaded app
@@ -140,7 +141,8 @@ unit mormot.core.fpcx64mm;
 {.$define FPCMM_TINYPERTHREAD}
 
 // allocate any medium block > 48KB using the large allocator on contention
-// - defined for FPCMM_SERVER since mmap/VirtualAlloc is cheaper than waiting
+// - defined for FPCMM_SERVER unless FPCMM_MEDIUMPERTHREAD already spreads
+//   contention across 4 arenas
 // - would slightly increase OS memory but usually seldom happens
 {.$define FPCMM_MEDIUMTOLARGE}
 
@@ -217,7 +219,9 @@ interface
     {$define FPCMM_ASSUMEMULTITHREAD}
     {$define FPCMM_ERMS}
     {$define FPCMM_TINYPERTHREAD} // thread affinity matters with a few threads
-    {$define FPCMM_MEDIUMTOLARGE} // mmap is better than sleeping
+    {$ifndef FPCMM_MEDIUMPERTHREAD}
+      {$define FPCMM_MEDIUMTOLARGE} // mmap is better than sleeping
+    {$endif FPCMM_MEDIUMPERTHREAD}
   {$endif FPCMM_SERVER}
   {$ifdef FPCMM_BOOSTER}
     {$undef FPCMM_DEBUG} // when performance matters more than stats


### PR DESCRIPTION
This follows up the `FPCMM_MEDIUMTOLARGE` question in #563.

`FPCMM_BOOSTER` already distributes medium allocations across four per-thread arenas and probes the other arenas before waiting. This change keeps `FPCMM_MEDIUMTOLARGE` enabled automatically for the ordinary `FPCMM_SERVER` profile, but stops enabling it automatically when `FPCMM_MEDIUMPERTHREAD` is active. Fine-grained users may still define `FPCMM_MEDIUMTOLARGE` explicitly.

Paired A/B on the same current source, 16 workers, sizes straddling the actual promotion boundary (48936/48937 bytes) and 49/64/100 KiB:

- Win64 BOOSTER, 9 alternating pairs: MEDIUMTOLARGE on/off = `1.017x` over promoted sizes;
- Linux x86-64 BOOSTER, 7 alternating pairs on CPUs 0-15: `1.006x`.

Once the four arenas are active, the fallback was parity to 1.7% slower in this mixed contention workload and gave no measured win. SERVER behavior is unchanged by this PR.

Validation of this profile change:

- Win64 and Linux builds report BOOSTER with `medpt` and without `medlrg`;
- SERVER still reports `medlrg` and without `medpt`;
- Linux `memory_mega quick`: PASS, including deterministic fuzz, cross-thread ownership, remote-free hot cases, and 26-thread saturation.