### PR TITLE
Fix the command line FPC build of mormot2tests on Windows

### DIFF
--- a/test/build_fpc.sh
+++ b/test/build_fpc.sh
@@ -91,7 +91,8 @@ fi
 if [[ $TARGET == win* ]]; then
   # specific windows extension for executables
   dest_fn="$dest_fn.exe"
-  CONDITIONALS="$CONDITIONALS -CX -XX"
+  # no LCL widgetset in a command line build, so no HAS_UI_PDF/test.ui.pdf
+  CONDITIONALS="$CONDITIONALS -CX -XX -dNO_UI"
 fi
 if [ $TARGET = "linux" ]; then
   CONDITIONALS="$CONDITIONALS -CX -XX"

--- a/test/build_winarm.bat
+++ b/test/build_winarm.bat
@@ -44,6 +44,7 @@ rem  -Ci        - IO checking
 rem  -O2        - optimization level (no -O3/x64MM as on x86_64)
 rem  -g -gl -gw2 -Xg - debug information, line info, DWARFv2, in a separate file
 rem  -CX -XX    - smart linking
+rem  -dNO_UI    - no LCL widgetset here, so no HAS_UI_PDF and no test.ui.pdf
 rem  -veiq -v-n-h- - verbose(errors, info, message numbers) no warnings/notes/hints
 rem  -B         - build all
 rem  -Se10      - halt after 10 errors
@@ -56,7 +57,7 @@ rem  a local mormot2tests.cfg would override our command line switches
 if exist "%LIB2%\test\mormot2tests.cfg" ren "%LIB2%\test\mormot2tests.cfg" mormot2tests.cfg.bak
 
 echo Compiling for aarch64-win64 into %BIN%
-"%FPC%" -MDelphi -Sci -Ci -O2 -g -gl -gw2 -Xg -CX -XX ^
+"%FPC%" -MDelphi -Sci -Ci -O2 -g -gl -gw2 -Xg -CX -XX -dNO_UI ^
   -Twin64 -Paarch64 ^
   -veiq -v-n-h- %SUPRESS_WARN% ^
   -Fi"%INCLUDES%" ^


### PR DESCRIPTION
Since fe0b21d2a, `HAS_UI` / `HAS_UI_LCL` / `HAS_UI_VCL_LCL` are defined for every FPC target, so `HAS_UI_PDF` is set on Windows even when no Lazarus LCL is around. `mormot2tests.dpr` then needs the LCL `Interfaces` unit and `test.ui.pdf`, which are not in a command line build's unit path:

```
mormot2tests.dpr(73,3) Fatal: (10022) Can't find unit Interfaces used by mormot2tests
Fatal: (1018) Compilation aborted
```

This currently breaks `test/build_winarm.bat`, and `test/build_fpc.sh` for its `win32`/`win64` targets.

`NO_UI` is documented right there as the project level opt-out for exactly this case:

```pascal
{.$define NO_UI}     // disable whole UI path e.g. in mormot2tests
```

so this PR just uses it where there is no widgetset, rather than touching the conditional itself:

* `test/build_winarm.bat`
* `test/build_fpc.sh`, inside its existing `if [[ $TARGET == win* ]]` block only - a POSIX target never defines `HAS_UI_PDF` anyway

Lazarus builds are unaffected: `test/mormot2tests.lpi` and `packages/lazarus/mormot2ui.lpk` both require the LCL packages, so they keep `LCL` defined and the whole UI path enabled.

### Verified

* FPC 3.3.1 `aarch64-win64` native: `mormot2tests` builds again, and `TTestCoreBase` passes 118,617,589 assertions with 0 failures.
* Delphi 13 `dcc64` Win64 is untouched and still runs `TTestUiPdf` with 34/34 assertions.