### PR TITLE
net: DHCP server was never sending the domain-name option 15

### DIFF
--- a/src/net/mormot.net.dhcp.pas
+++ b/src/net/mormot.net.dhcp.pas
@@ -4321,6 +4321,7 @@ begin
   AddOptionOnce32(doBroadcastAddress,   Scope^.Broadcast);
   AddOptionOnce32(doRouters,            Scope^.Gateway);
   AddOptionOnceA32(doDomainNameServers, pointer(Scope^.DnsServers));
+  AddOptionOnceU(doDomainName,          pointer(Scope^.DomainName));
   AddOptionOnceA32(doNtpServers,        pointer(Scope^.NtpServers));
   // optional 51,58,59 lease timing options
   if (RecvType <> dmtInform) and

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -3141,6 +3141,34 @@ begin
       '",message-type:"OFFER",server-identifier:"192.168.0.1",' +
       '201:"toto",subnet-mask:"255.252.0.0",' +
       'lease-time:120,renewal-time:60,rebinding-time:105}');
+    // validate scope "domain-name" option 15 sent with the regular options
+    settings.Scope[0].DomainName := 'lan.local';
+    server.Setup(settings); // Setup() can be called again on a live server
+    mac := MacToText(@macs[9]);
+    f := d.ClientNew(dmtDiscover, macs[9]);
+    d.ClientFlush(f);
+    CheckNotEqual(server.ComputeResponse(d), 0, 'domain');
+    ip := IP4ToText(@d.Send.yiaddr);
+    CheckEqual(d.SendToJson(true),
+      '{op:"reply",yiaddr:"' + ip + '",siaddr:"192.168.0.1",chaddr:"' + mac +
+      '",message-type:"OFFER",server-identifier:"192.168.0.1",' +
+      'subnet-mask:"255.252.0.0",domain-name:"lan.local",' +
+      'lease-time:120,renewal-time:60,rebinding-time:105}');
+    // "rule" domain-name has precedence over the scope domain-name
+    pool := @server.Scope[0].Main; // Setup() did rebuild the scope
+    mac := MacToText(@macs[12]);
+    pool.AddRule([
+      '{mac:"', mac, '",requested:{domain-name:"mydomain"}}']);
+    f := d.ClientNew(dmtDiscover, macs[12]);
+    d.ClientFlush(f);
+    CheckNotEqual(server.ComputeResponse(d), 0, 'domain rule');
+    ip := IP4ToText(@d.Send.yiaddr);
+    CheckEqual(d.SendToJson(true),
+      '{op:"reply",yiaddr:"' + ip + '",siaddr:"192.168.0.1",chaddr:"' + mac +
+      '",message-type:"OFFER",server-identifier:"192.168.0.1",' +
+      'domain-name:"mydomain",' +
+      'subnet-mask:"255.252.0.0",lease-time:120,renewal-time:' +
+      '60,rebinding-time:105}');
   finally
     server.Free;
     settings.Free;


### PR DESCRIPTION
`TDhcpState.AddRegularOptions()` is documented twice (`mormot.net.dhcp.pas:1031` and `:6122`) as appending the `1,3,6,15,28,42` regular options, and the default `DHCP_REQUEST` client list does ask for option 15 - but `TDhcpScopeSettings.DomainName` was only ever used to build the DDNS FQDN, never written into the OFFER/ACK. So the documented `"domain-name"` setting silently had no effect, unless duplicated into a `"rule"` as `"always"`/`"requested"`.

The fix is one line, appended after `AddRulesOptions()` so a `"rule"` value still takes precedence, and using `AddOptionOnceU()` - as already used for options 66/67 - which skips an unset (nil) value, so scopes without a domain-name are unchanged.

Two cases added to `TNetworkProtocols.DHCP`: the scope value now shows up in the OFFER, and a `"rule"` one still overrides it. Checked both ways - with the line commented out again, the new assertion fails on the missing `domain-name`.
