### PR TITLE
crypt: support original Keccak-256

### DIFF
--- a/src/crypt/mormot.crypt.core.pas
+++ b/src/crypt/mormot.crypt.core.pas
@@ -2278,16 +2278,18 @@ type
   PSha512 = ^TSha512;
 
 type
-  /// SHA-3 instances, as defined by NIST Standard for Keccak sponge construction
+  /// SHA-3, SHAKE and original Keccak instances
   // - SHA3_224..SHA3_512 output 224, 256, 384 and 512 bits of cryptographic hash
   // - SHAKE_128 and SHAKE_256 implements a XOF/cipher generator
+  // - KECCAK_256 uses the original padding, as required e.g. by Ethereum
   TSha3Algo = (
     SHA3_224,
     SHA3_256,
     SHA3_384,
     SHA3_512,
     SHAKE_128,
-    SHAKE_256);
+    SHAKE_256,
+    KECCAK_256);
 
   /// implements SHA-3 (Keccak) hashing
   // - Keccak was the winner of the NIST hashing competition for a new hashing
@@ -2755,6 +2757,12 @@ function Sha3(Algo: TSha3Algo; const s: RawByteString;
 // output memory buffer, according to the specified TSha3Algo
 function Sha3(Algo: TSha3Algo; Buffer: pointer; Len: integer;
   DigestBits: integer = 0): RawUtf8; overload;
+
+/// compute an original Keccak-256 binary digest (distinct from SHA3-256)
+procedure Keccak256Full(Buffer: pointer; Len: integer; out Digest: THash256);
+
+/// compute an original Keccak-256 lowercase hexadecimal digest
+function Keccak256(const s: RawByteString): RawUtf8;
 
 /// SHA-256 hash calculation with length padding if shorter than 256 bytes
 // - WARNING: this algorithm is DEPRECATED, and supplied only for backward
@@ -8969,7 +8977,7 @@ type
 
 const
   SHA3_DEF_LEN: array[TSha3Algo] of integer = (
-    224, 256, 384, 512, 256, 512);
+    224, 256, 384, 512, 256, 512, 256);
 
 procedure TSha3Context.Init(aAlgo: TSha3Algo);
 var
@@ -8977,7 +8985,8 @@ var
 begin
   FillCharFast(self, SizeOf(self), 0);
   bits := SHA3_DEF_LEN[aAlgo];
-  if aAlgo < SHAKE_128 then
+  if (aAlgo < SHAKE_128) or
+     (aAlgo = KECCAK_256) then
     bits := bits shl 1;
   Rate := cKeccakPermutationBits - bits;
   Capacity := bits;
@@ -9124,7 +9133,9 @@ begin
   else
     lw := bits and Pred(cardinal(1) shl bitlen);
   // append the domain separation bits
-  if Algo >= SHAKE_128 then
+  if Algo = KECCAK_256 then
+    ll := bitlen // original Keccak: pad10*1 without SHA-3 domain bits
+  else if Algo >= SHAKE_128 then
   begin
     // SHAKE: append four MSB bits 1111
     lw := lw or (cardinal($0f) shl bitlen);
@@ -10498,6 +10509,21 @@ var
   sha: TSha3;
 begin
   result := sha.FullStr(Algo, Buffer, Len, DigestBits);
+end;
+
+procedure Keccak256Full(Buffer: pointer; Len: integer; out Digest: THash256);
+var
+  sha: TSha3;
+begin
+  sha.Full(KECCAK_256, Buffer, Len, @Digest, 256);
+end;
+
+function Keccak256(const s: RawByteString): RawUtf8;
+var
+  dig: THash256;
+begin
+  Keccak256Full(pointer(s), length(s), dig);
+  BinToHexLower(@dig, SizeOf(dig), result);
 end;
 
 // required by read_h -> deprecated even if available with PUREMORMOT2

--- a/test/test.core.crypt.pas
+++ b/test/test.core.crypt.pas
@@ -730,6 +730,33 @@ end;
 
 procedure TTestCoreCrypto._SHA3;
 
+  procedure Keccak(const data, expected: RawByteString);
+  var
+    instance: TSha3;
+    dig: THash256;
+    split, i: PtrInt;
+  begin
+    CheckEqual(Keccak256(data), expected);
+    Keccak256Full(pointer(data), length(data), dig);
+    CheckEqual(Sha256DigestToString(dig), expected);
+    CheckEqual(instance.FullStr(KECCAK_256, pointer(data), length(data)), UpperCase(expected));
+    for split := 0 to length(data) do
+    begin
+      instance.Init(KECCAK_256);
+      Check(instance.Algorithm = KECCAK_256);
+      instance.Update(pointer(data), split);
+      instance.Update(nil, 0);
+      instance.Update(PAnsiChar(pointer(data)) + split, length(data) - split);
+      instance.Final(dig);
+      CheckEqual(Sha256DigestToString(dig), expected);
+    end;
+    instance.Init(KECCAK_256);
+    for i := 1 to length(data) do
+      instance.Update(@data[i], 1);
+    instance.Final(dig);
+    CheckEqual(Sha256DigestToString(dig), expected);
+  end;
+
   procedure DoTest;
   const
     HASH1 = '79f38adec5c20307a98ef76e8324afbfd46cfd81b22e3973c65fa1bd9de31787';
@@ -743,6 +770,18 @@ procedure TTestCoreCrypto._SHA3;
     s, i: PtrInt;
     sign: TSynSigner;
   begin
+    // Original Keccak-256 vectors, independently checked with PyCryptodome.
+    Keccak('', 'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470');
+    Keccak('abc', '4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45');
+    SetLength(data, 1024);
+    for i := 1 to length(data) do
+      data[i] := AnsiChar((i - 1) and 255);
+    // One less than, exactly, and one more than the 136-byte absorption rate.
+    Keccak(copy(data, 1, 135), 'cbdfd9dee5faad3818d6b06f95a219fd290b0e1706f6a82e5a595b9ce9faca62');
+    Keccak(copy(data, 1, 136), '7ce759f1ab7f9ce437719970c26b0a66ff11fe3e38e17df89cf5d29c7d7f807e');
+    Keccak(copy(data, 1, 137), 'ac73d4fae68b8453f764007c1a20ce95994187861f0c3227a3a8e99a73a3b1db');
+    Keccak(copy(data, 1, 272), 'fdf2ec49e749960d3c8521a0219af8d03e30e2b3bf19bd16150ee0eaf133d66e');
+    Keccak(data, '5902e53903be0d0f9656bdbd5b9f0d8c2d815f865645d629eef77f5185f6cd7f');
     // validate against official NIST vectors
     // taken from http://csrc.nist.gov/groups/ST/toolkit/examples.html#aHashing
     // see also https://www.di-mgt.com.au/sha_testvectors.html


### PR DESCRIPTION
Adds original Keccak-256 for Ethereum-compatible hashing through the existing TSha3 sponge. SHA3-256 has different domain-separation padding and cannot substitute for it.

KECCAK_256 is appended to TSha3Algo without changing existing ordinal values. The patch adds its rate/padding selection and Keccak256Full / Keccak256 helpers; the permutation kernels are unchanged.

Validation: the existing TTestCoreCrypto._SHA3 suite passes 31,372 assertions in each Delphi 12.2 Win64 Release and Debug build, including both available x64 backends. New vectors cover empty input, abc, 135/136/137/272/1024-byte binary messages, every two-part split, and byte-at-a-time updates. Expected hashes were independently checked with PyCryptodome 3.23.0; all existing SHA-3 and SHAKE tests remain enabled. FPC and other targets were not run for this PR.