### PR TITLE
core: fix numeric conversion overflow and malformed decimal input

### DIFF
--- a/src/core/mormot.core.base.pas
+++ b/src/core/mormot.core.base.pas
@@ -1445,7 +1445,7 @@ function GetIntegerDef(P: PUtf8Char; Default: PtrInt): PtrInt;
 
 /// get the signed 32-bit integer value stored in P^
 // - this version return 0 in err if no error occurred, and 1 if an invalid
-// character was found, not its exact index as for the val() function
+// character or a PtrInt overflow was found, not its exact index as for val()
 function GetInteger(P: PUtf8Char; var err: integer): PtrInt; overload;
 
 /// get the unsigned 32-bit integer value stored in P^
@@ -6335,6 +6335,9 @@ function GetInteger(P: PUtf8Char; var err: integer): PtrInt;
 var
   c: byte;
   minus: boolean;
+  {$ifdef CPU64}
+  digits: PUtf8Char;
+  {$endif CPU64}
 begin
   result := 0;
   err := 1; // don't return the exact index, just 1 as error flag
@@ -6366,23 +6369,46 @@ begin
         c := byte(P^);
       until c <> ord(' ');
   end;
+  while (c = ord('0')) and
+        (P[1] in ['0' .. '9']) do
+  begin
+    inc(P);
+    c := byte(P^);
+  end;
   dec(c, 48);
   if c > 9 then
     exit;
   result := c;
+  {$ifdef CPU64}
+  digits := P;
+  {$endif CPU64}
   repeat
     inc(P);
     c := byte(P^);
     dec(c, 48);
     if c <= 9 then
-      result := result * 10 + PtrInt(c)
+    begin
+      {$ifdef CPU64}
+      if P - digits >= 19 then
+        exit; // at most 19 significant digits: magnitude fits UInt64
+      {$else}
+      if PtrUInt(result) >= PtrUInt(High(PtrInt)) div 10 then
+        if (PtrUInt(result) > PtrUInt(High(PtrInt)) div 10) or
+           (c > High(PtrInt) mod 10 + ord(minus)) then
+          exit;
+      {$endif CPU64}
+      result := PtrInt(PtrUInt(result) * 10 + c);
+    end
     else if c <> 256 - 48 then
       exit
     else
       break;
   until false;
+  if PtrUInt(result) > PtrUInt(High(PtrInt)) + PtrUInt(ord(minus)) then
+    exit;
   err := 0; // success
-  if minus then
+  if minus and
+     (result <> Low(PtrInt)) then
     result := -result;
 end;
 

--- a/src/core/mormot.core.text.pas
+++ b/src/core/mormot.core.text.pas
@@ -6726,6 +6726,10 @@ end;
 {$ifndef WIN32DELPHI} // Delphi has its own x86/x87 asm version
 
 function GetExtended(P: PUtf8Char; out err: integer): TSynExtended;
+const
+  Scale: double = 1.3407807929942597e154; // 2^512
+  InvScale: double = 7.458340731200207e-155; // 2^-512
+  MaxScaled: double = 1.3407807929942596e154; // MaxDouble * 2^-512
 var
   remdigit: integer;
   frac, exp: PtrInt;
@@ -6774,7 +6778,8 @@ begin
     if byte(ord(P^) - ord('0')) <= 9 then
     begin
       if (remdigit <> 0) or // avoid 64-bit overflow, but allow 19 digits
-         (v64 > 922337203685477580) then
+         (v64 > 922337203685477580) or
+         ((v64 = 922337203685477580) and (P^ > '7')) then
         dec(remdigit);
       if remdigit >= 0 then // over-required digits are just ignored
       begin
@@ -6792,13 +6797,15 @@ begin
     if P^ <> '.' then
       break;
     inc(P);
-    if frac > 0 then
+    if frac <> 0 then
       goto e; // will return partial value but err=1
     dec(frac);
   until false;
   inc(frac, ord(frac < 0)); // adjust digits after '.'
   if ord(P^) or $20 = ord('e') then
   begin
+    if not (fValid in flags) then
+      goto e;
     exp := 0;
     exclude(flags, fValid);
     inc(P);
@@ -6812,19 +6819,25 @@ begin
     repeat
       if byte(ord(P^) - ord('0')) > 9 then
         break;
+      if exp >= High(PtrInt) div 10 then
+        if (exp > High(PtrInt) div 10) or
+           (ord(P^) - ord('0') > High(PtrInt) mod 10) then
+          goto e;
       exp := (exp * 10) + ord(P^) - ord('0');
       include(flags, fValid);
       inc(P);
     until false;
     if fNegExp in flags then
-      dec(frac, exp)
-    else
-      inc(frac, exp);
-    if (frac <= -324) or
-       (frac >= 308) then
     begin
-      frac := 0;
-      goto e; // limit to 5.0 x 10^-324 .. 1.7 x 10^308 double range
+      if frac < Low(PtrInt) + exp then
+        goto e;
+      dec(frac, exp);
+    end
+    else
+    begin
+      if frac > High(PtrInt) - exp then
+        goto e;
+      inc(frac, exp);
     end;
   end;
   if (fValid in flags) and
@@ -6832,7 +6845,28 @@ begin
     err := 0
   else
 e:  err := 1; // return the (partial) value even if not ended with #0
+  if (frac <= -324) or
+     (frac >= 308) then
+  begin
+    frac := 0;
+    err := 1; // also bound the scale of numbers without an exponent
+  end;
   d64 := v64;
+  if frac >= 290 then // avoid overflowing the final product, even with unmasked FPU
+  begin
+    result := (POW10[(frac and not 31) shr 5 + 34] *
+               POW10[frac and 31] * InvScale) * d64;
+    if result > MaxScaled then
+    begin
+      result := d64;
+      err := 1;
+    end
+    else
+      result := result * Scale;
+    if fNeg in flags then
+      result := -result;
+    exit;
+  end;
   if frac >= -31 then
     if frac <= 31 then // -31 .. + 31
       result := POW10[frac]

--- a/src/core/mormot.core.variants.pas
+++ b/src/core/mormot.core.variants.pas
@@ -11515,16 +11515,18 @@ end;
 
 const
   CURRENCY_FACTOR: array[-4 .. -1] of integer = (1, 10, 100, 1000);
+  CURRENCY_MAX: array[-4 .. -1] of UInt64 = (
+    High(Int64), High(Int64) div 10, High(Int64) div 100, High(Int64) div 1000);
 
 function GetNumericVariantFromJson(Json: PUtf8Char; var Value: TVarData;
   AllowVarDouble: boolean): PUtf8Char;
 var
-  // logic below is extracted from mormot.core.base.pas' GetExtended()
+  // logic below is extracted from mormot.core.text.pas' GetExtended()
   remdigit: integer;
   frac, exp {$ifdef CPUX86NOTPIC}, f {$endif}: PtrInt;
   c: AnsiChar;
   flags: set of (fNeg, fNegExp, fValid);
-  v64: Int64; // allows 64-bit resolution for the digits (match 80-bit extended)
+  v64: UInt64; // up to 19 digits, including the magnitude of Low(Int64)
   d: double;
 begin
   // 1. parse input text as number into v64, frac, digit, exp
@@ -11541,6 +11543,8 @@ begin
     inc(Json);
     include(flags, fNeg);
   end;
+  if not (c in ['0' .. '9']) then
+    exit;
   if (c = '0') and
      (Json[1] in ['0' .. '9']) then // '012' is not Json, but '0.xx' and '0' are
     exit;
@@ -11573,8 +11577,8 @@ begin
     if c <> '.' then
       break;
     c := Json[1];
-    if (frac > 0) or
-       (c = #0) then // avoid ##.
+    if (frac <> 0) or
+       not (c in ['0' .. '9']) then // require a single dot followed by a digit
       exit;
     inc(json);
     dec(frac);
@@ -11601,33 +11605,54 @@ begin
         break;
       inc(Json);
       dec(c, ord('0'));
+      if exp >= High(PtrInt) div 10 then
+        if (exp > High(PtrInt) div 10) or
+           (byte(c) > High(PtrInt) mod 10) then
+          exit;
       exp := (exp * 10) + byte(c);
       include(flags, fValid);
     until false;
     if fNegExp in flags then
-      dec(frac, exp)
+    begin
+      if frac < Low(PtrInt) + exp then
+        exit;
+      dec(frac, exp);
+    end
     else
+    begin
+      if frac > High(PtrInt) - exp then
+        exit;
       inc(frac, exp);
+    end;
   end;
   if not (fValid in flags) then
     exit;
-  if fNeg in flags then
-    v64 := -v64;
   // 2. now v64, frac, digit, exp contain number parsed from Json
   if (frac = 0) and
-     (remdigit >= 0) then // return an integer or Int64 value
+     (remdigit >= 0) and
+     ((v64 <= UInt64(High(Int64))) or
+      ((v64 = UInt64(High(Int64)) + 1) and (fNeg in flags))) then
   begin
-    Value.VInt64 := v64;
+    Value.VInt64 := Int64(v64);
+    if (fNeg in flags) and
+       (v64 <= UInt64(High(Int64))) then
+      Value.VInt64 := -Value.VInt64;
     if remdigit <= 9 then
       TSynVarData(Value).VType := varInt64
     else
       TSynVarData(Value).VType := varInteger;
   end
   else if (frac < 0) and
-          (frac >= -4) then // currency as ###.0123
+          (frac >= -4) and
+          ((v64 <= CURRENCY_MAX[frac]) or
+           ((frac = -4) and (v64 = UInt64(High(Int64)) + 1) and
+            (fNeg in flags))) then // currency as ###.0123
   begin
     TSynVarData(Value).VType := varCurrency;
-    Value.VInt64 := v64 * CURRENCY_FACTOR[frac]; // as round(CurrValue*10000)
+    Value.VInt64 := Int64(v64 * UInt64(CURRENCY_FACTOR[frac]));
+    if (fNeg in flags) and
+       (Value.VInt64 <> Low(Int64)) then
+      Value.VInt64 := -Value.VInt64; // as round(CurrValue*10000)
   end
   else if AllowVarDouble and
           (frac > -324) then // 5.0 x 10^-324 .. 1.7 x 10^308
@@ -11637,7 +11662,7 @@ begin
     if f >= -31 then
       if f <= 31 then
         d := POW10[f] // -31 .. + 31
-      else if (18 - remdigit) + integer(f) >= 308 then
+      else if f >= remdigit + 290 then
         exit          // +308 ..
       else
         d := POW10[(f and not 31) shr 5 + 34] * POW10[f and 31] // +32 .. +307
@@ -11651,7 +11676,7 @@ begin
     if frac >= -31 then
       if frac <= 31 then
         d := PPow10(exp)[frac] // -31 .. + 31 is the most common case
-      else if (18 - remdigit) + integer(frac) >= 308 then
+      else if frac >= remdigit + 290 then
         exit                   // +308 ..
       else                     // +32 .. +307
         d := PPow10(exp)[(frac and not 31) shr 5 + 34] * PPow10(exp)[frac and 31]
@@ -11662,6 +11687,9 @@ begin
     end;
     {$endif CPUX86NOTPIC}
     Value.VDouble := d * v64;
+    if (fNeg in flags) and
+       (v64 <> 0) then
+      Value.VDouble := -Value.VDouble;
     TSynVarData(Value).VType := varDouble;
   end
   else

--- a/test/test.core.base.pas
+++ b/test/test.core.base.pas
@@ -5023,6 +5023,56 @@ procedure TTestCoreBase.NumericalConversions;
     CheckSame(d, v);
   end;
 
+  {$ifdef CPU64}
+  procedure CheckIntegerValue(const text: RawUtf8; expected: Int64);
+  var
+    err: integer;
+    value: Int64;
+  begin
+    value := GetInt64(pointer(text), err);
+    CheckEqual(err, 0, text);
+    CheckEqual(value, expected, text);
+  end;
+
+  {$endif CPU64}
+
+  procedure CheckJsonValue(const text: RawUtf8; kind: integer; expected: double);
+  var
+    v: variant;
+    p: PUtf8Char;
+  begin
+    p := GetNumericVariantFromJson(pointer(text), TVarData(v), true);
+    Check(p = PUtf8Char(pointer(text)) + length(text), text);
+    CheckEqual(TVarData(v).VType, kind, text);
+    CheckSame(double(v), expected, 0, text);
+  end;
+
+  procedure CheckJsonExact(const text: RawUtf8; kind: integer; expected: Int64);
+  var
+    v: variant;
+  begin
+    Check(GetNumericVariantFromJson(pointer(text), TVarData(v), false) <> nil, text);
+    CheckEqual(TVarData(v).VType, kind, text);
+    CheckEqual(TVarData(v).VInt64, expected, text);
+  end;
+
+  procedure CheckInvalidNumber(const text: RawUtf8; extendedToo: boolean = true);
+  var
+    v: variant;
+    d: double;
+    err: integer;
+  begin
+    Check(GetNumericVariantFromJson(pointer(text), TVarData(v), true) = nil, text);
+    {$ifndef WIN32DELPHI}
+    if extendedToo then
+    begin
+      d := GetExtended(pointer(text), err);
+      Check(err <> 0, text);
+      Check(not IsInfinite(d) and not IsNan(d), text);
+    end;
+    {$endif WIN32DELPHI}
+  end;
+
 var
   i, j, b, err: integer;
   juint: cardinal absolute j;
@@ -5503,6 +5553,65 @@ begin
   CheckDoubleToShortSame(184467440737095514);
   CheckDoubleToShortSame(1844674407370955148);
   {$endif FPC}
+  // signed numeric boundaries and JSON grammar
+  {$ifdef CPU64}
+  CheckIntegerValue('9223372036854775807', High(Int64));
+  CheckIntegerValue('-9223372036854775808', Low(Int64));
+  CheckIntegerValue('  -  00000000000000000000000000000000123', -123);
+  CheckIntegerValue('+0000', 0);
+  for i := 0 to 3 do
+  begin
+    s := GetCsvItemString('9223372036854775808,-9223372036854775809,' +
+      '18446744073709551616,99999999999999999999', i);
+    GetInt64(pointer(s), err);
+    Check(err <> 0, s);
+  end;
+  {$endif CPU64}
+  CheckJsonExact('0', varInteger, 0);
+  CheckJsonExact('-123', varInteger, -123);
+  CheckJsonExact('9223372036854775807', varInt64, High(Int64));
+  CheckJsonExact('-9223372036854775808', varInt64, Low(Int64));
+  CheckJsonExact('922337203685477.5807', varCurrency, High(Int64));
+  CheckJsonExact('-922337203685477.5808', varCurrency, Low(Int64));
+  CheckJsonExact('922337203685477.58', varCurrency, High(Int64) - 7);
+  CheckJsonExact('-922337203685477.58', varCurrency, Low(Int64) + 8);
+  CheckJsonValue('9223372036854775808', varDouble, 9223372036854775808.0);
+  CheckJsonValue('-9223372036854775809', varDouble, -9223372036854775809.0);
+  CheckJsonValue('9999999999999999999', varDouble, 9999999999999999999.0);
+  CheckJsonValue('922337203685477.5808', varDouble, 922337203685477.5808);
+  CheckJsonValue('-922337203685477.5809', varDouble, -922337203685477.5809);
+  CheckJsonValue('9223372036854775.8', varDouble, 9223372036854775.8);
+  s := '9223372036854775808';
+  Check(GetNumericVariantFromJson(pointer(s), TVarData(vj), false) = nil);
+  s := '9223372036854775.8';
+  Check(GetNumericVariantFromJson(pointer(s), TVarData(vj), false) = nil);
+  CheckInvalidNumber('1.2.3');
+  CheckInvalidNumber('0..1');
+  CheckInvalidNumber('e1');
+  CheckInvalidNumber('-.e2');
+  CheckInvalidNumber('1e');
+  CheckInvalidNumber('1e+');
+  CheckInvalidNumber('.5', false); // GetExtended intentionally also accepts Pascal syntax
+  CheckInvalidNumber('1.', false);
+  CheckInvalidNumber('1.e2', false);
+  CheckInvalidNumber('01', false);
+  CheckInvalidNumber('+1', false);
+  CheckInvalidNumber('1e400');
+  CheckInvalidNumber('1e-400');
+  {$ifndef WIN32DELPHI}
+  s := '9223372036854775808';
+  d := GetExtended(pointer(s), err);
+  CheckEqual(err, 0);
+  CheckSame(d, 9223372036854775808.0, 0);
+  s := '1.7976931348623157e308';
+  d := GetExtended(pointer(s), err);
+  CheckEqual(err, 0);
+  Check(not IsInfinite(d) and (d > 1.79e308));
+  s := '99e307';
+  d := GetExtended(pointer(s), err);
+  Check(err <> 0);
+  Check(not IsInfinite(d));
+  {$endif WIN32DELPHI}
   // validate ScanUtf8()
   Check(ScanUtf8('1 2 3', '  %', [@i, @j, @d]) = 0);
   Check(ScanUtf8('', '%d%d%f', [@i, @j, @d]) = 0);


### PR DESCRIPTION
Numeric conversions can silently wrap at signed integer and Currency boundaries. The patch validates mantissa/exponent ranges and decimal grammar, with Double fallback when enabled. It retains the current upstream NaN/Inf handling and normal conversion path.

Regression checks are included in the existing TTestCoreBase.NumericalConversions method and cover signed bounds, Currency limits, exponent overflow and malformed decimal input.

Validation on Win64, with a full rebuild for each configuration:
- Delphi 12.2: Release (O+) and Debug (O-, DEBUG).
- Stock FPC 3.2.2: Release (O3) and Debug (O-, DEBUG).
- All four runs pass NumericalConversions, Curr64 and Variants: over 2.68 million assertions per run, zero failures.
- A 40,000-number differential corpus on Delphi: GetExtended results match bit-for-bit; JSON results differ only for 188 previously overflowing Currency values, which now become Double.