### PR TITLE
net: fixed DHCPNAK frames not following RFC 2131 Table 3

### DIFF
--- a/src/net/mormot.net.dhcp.pas
+++ b/src/net/mormot.net.dhcp.pas
@@ -1893,7 +1893,8 @@ begin
   DhcpAddOptionByte(result, {doMessageType=} 53, ord(dmt));
   if serverid <> 0 then
   begin
-    dhcp.siaddr := serverid;
+    if dmt <> dmtNak then
+      dhcp.siaddr := serverid; // RFC 2131 Table 3: 'siaddr' is 0 in a DHCPNAK
     DhcpAddOption32(result, doServerIdentifier, serverid);
   end;
   result^ := #255;
@@ -5810,7 +5811,8 @@ begin
         DoLog(sllTrace, 'out-of-sync NAK', State);
         State.SendType := dmtNak;
         State.SendEnd := DhcpNew(State.Send, dmtNak, State.Recv.xid,
-          PNetMac(@State.Mac64)^, State.Scope^.ServerIdentifier);
+          // RFC 2131 Table 3: 'chaddr' is the client one, not its option 61
+          PNetMac(@State.Recv.chaddr)^, State.Scope^.ServerIdentifier);
         result := Flush(State);
       end;
     dsmDroppedPackets:
@@ -6113,15 +6115,20 @@ function TDhcpProcess.Flush(var State: TDhcpState): PtrInt;
 begin
   // recognize State.RecvBoot from options 60/77/93
   SetRecvBoot(State);
-  // append "rule" custom options - always first since have precedence
   integer(State.SendOptions) := 0;
-  if State.RecvRule <> nil then
-    State.AddRulesOptions;
-  // append "boot" specific options 60,66,67,97
-  if State.RecvBoot <> dcbDefault then
-    AddBootOptions(State);
-  // append regular DHCP 1,3,6,15,28,42 [+ 51,58,59] options
-  State.AddRegularOptions;
+  // RFC 2131 Table 3: a DHCPNAK excludes the lease time, the network settings
+  // and the boot options - the 61/82 copies below are RFC 6842/3046
+  if State.SendType <> dmtNak then
+  begin
+    // append "rule" custom options - always first since have precedence
+    if State.RecvRule <> nil then
+      State.AddRulesOptions;
+    // append "boot" specific options 60,66,67,97
+    if State.RecvBoot <> dcbDefault then
+      AddBootOptions(State);
+    // append regular DHCP 1,3,6,15,28,42 [+ 51,58,59] options
+    State.AddRegularOptions;
+  end;
   // optional callback support
   if Assigned(fOnComputeResponse) and
      RunCallbackAborted(State) then
@@ -6521,10 +6528,13 @@ begin
     fState.Send.giaddr := fState.Recv.giaddr;
     remote.SetIP4Port(fState.Recv.giaddr, fServerPort);
   end
+  else if fState.SendType = dmtNak then
+    // RFC 2131 4.3.2: with no relay, a DHCPNAK MUST be broadcasted to
+    // 0xffffffff because the client may have a wrong address or subnet mask
+    remote.SetIP4Port(cAnyHost32, fClientPort)
   else if (fState.Recv.ciaddr <> 0) and
           (fState.Recv.flags and DHCP_BROADCAST_FLAG = 0) and
-          (fState.RecvType in [dmtRequest, dmtInform]) and
-          (fState.SendType <> dmtNak) then
+          (fState.RecvType in [dmtRequest, dmtInform]) then
     // unicast to known client IP
     remote.SetIP4Port(fState.Recv.ciaddr, fClientPort)
   else

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -3169,6 +3169,46 @@ begin
       'domain-name:"mydomain",' +
       'subnet-mask:"255.252.0.0",lease-time:120,renewal-time:' +
       '60,rebinding-time:105}');
+    // validate the DHCPNAK frame content as expected by RFC 2131 Table 3
+    mac := MacToText(@macs[1500]);
+    f := d.ClientNew(dmtRequest, macs[1500]);
+    DhcpAddOption32(f, doRequestedAddress, ToIP4('8.8.8.8')); // wrong network
+    d.ClientFlush(f);
+    Check(server.ComputeResponse(d) > 0, 'nak');
+    CheckEqual(d.SendToJson(true), // no yiaddr/siaddr, no lease time, no network
+      '{op:"reply",chaddr:"' + mac + '",message-type:"NAK",' +
+      'server-identifier:"192.168.0.1"}', 'nak frame');
+    // a DHCPNAK should not be polluted by the options of a matching "rule"
+    pool.AddRule(['{always:{202:"titi"}}']); // no all/any = default rule
+    mac := MacToText(@macs[1501]);
+    f := d.ClientNew(dmtRequest, macs[1501]);
+    DhcpAddOption32(f, doRequestedAddress, ToIP4('8.8.8.8'));
+    d.ClientFlush(f);
+    Check(server.ComputeResponse(d) > 0, 'nak with rule');
+    CheckEqual(d.SendToJson(true),
+      '{op:"reply",chaddr:"' + mac + '",message-type:"NAK",' +
+      'server-identifier:"192.168.0.1"}', 'nak rule option');
+    // RFC 2131 Table 3: DHCPNAK 'chaddr' is the client hardware address, which
+    // may not be the MAC supplied within its option 61 client identifier - and
+    // the options 61/82 are still echoed back as RFC 6842/3046 expect
+    f := d.ClientNew(dmtRequest, macs[1502]);
+    DhcpAddOption32(f, doRequestedAddress, ToIP4('8.8.8.8'));
+    option[0] := #7;
+    option[1] := #1; // hardware type = Ethernet
+    PNetMac(@option[2])^ := macs[1503];
+    DhcpAddOptionShort(f, doClientIdentifier, option);
+    option[0] := #6;
+    option[1] := #1;                     // T = circuit-id
+    option[2] := #4;                     // L = 4
+    PCardinal(@option[3])^ := $41424344; // V = DCBA
+    DhcpAddOptionShort(f, doRelayAgentInformation, option);
+    d.ClientFlush(f);
+    Check(server.ComputeResponse(d) > 0, 'nak with options 61/82');
+    CheckEqual(d.SendToJson(true),
+      '{op:"reply",chaddr:"' + MacToText(@macs[1502]) + '",message-type:"NAK",' +
+      'server-identifier:"192.168.0.1",client-identifier:"' +
+      MacToText(@macs[1503]) + '",relay-agent-information:{circuit-id:"DCBA"}}',
+      'nak 61/82');
   finally
     server.Free;
     settings.Free;


### PR DESCRIPTION
A `DHCPNAK` is built by `DoError(dsmNak)` and then goes through the shared `Flush()`, so it currently carries everything a `DHCPACK` does. Four points of RFC 2131 are not met:

- **`siaddr`** — Table 3 has it as `0` in a DHCPNAK, but `DhcpNew()` fills it with the server identifier for every message type.
- **options** — Table 3 excludes the lease time (51/58/59), the network settings (1/3/6/15/28/42) and the boot options from a DHCPNAK, but the shared `Flush()` appends them, plus any matching `"rule"` options. The option 61/82 copies done by `TDhcpState.Flush()` stay, as RFC 6842/3046 expect.
- **`chaddr`** — Table 3 wants the `chaddr` of the client DHCPREQUEST, but the NAK is built from `State.Mac64`, which `DhcpParse()` takes from option 61 when the client supplies one.
- **destination** — with no relay agent, 4.3.2 has *"the server MUST broadcast the DHCPNAK message to the 0xffffffff broadcast address because the client may not have a correct network address or subnet mask"*, but it goes to the scope broadcast address (e.g. `192.168.0.255`), which a client whose address is no longer in that subnet may well drop.

The relay case is unchanged: a NAK with `giaddr` set still goes to the relay agent, and `DhcpNew()` already sets the broadcast flag that 4.3.2 requires there. Moving the NAK case first in `OnFrameReceived` also lets the `dmtNak` condition be removed from the unicast branch.

### Tests

Three cases on the resulting frame, checked as JSON through `SendToJson`: a plain NAK, a NAK while a default `"rule"` matches, and a NAK from a client whose option 61 holds another MAC and which supplies an option 82 (so the same assertion covers the `chaddr` echo and the 61/82 copies). They are appended at the end of the DHCP test so the existing metrics assertions are untouched.

The broadcast destination lives in `TDhcpServerThread.OnFrameReceived`, which the `ComputeResponse()` level tests cannot reach — that one line is not covered.

`TNetworkProtocols` is 175,112 assertions passed (FPC 3.2.3, i386-win32).
