### PR TITLE
net: NAK a DHCPREQUEST conflicting with a static reservation

### DIFF
--- a/src/net/mormot.net.dhcp.pas
+++ b/src/net/mormot.net.dhcp.pas
@@ -1073,6 +1073,7 @@ type
     function NotifyDnsScript(opt81: PAnsiChar; len: PtrInt; plain: boolean): boolean;
     procedure AddOption81;
     procedure ParseRecvLensRai;
+    function RequestConflictsWith(ip4: TNetIP4): boolean;
     function FakeLease(found: TNetIP4): PDhcpLease;
       {$ifdef HASINLINE} inline; {$endif}
     function ClientUuid(opt: TDhcpOption): PDhcpLease;
@@ -1936,7 +1937,7 @@ end;
 
 function DhcpIP4(dhcp: PDhcpPacket; len: PtrUInt): TNetIP4;
 begin
-  result := len;
+  result := 0; // an option with an unexpected length is no IPv4 address
   if len = 0 then
     exit;
   len := PtrUInt(@dhcp.options[len]);
@@ -4378,6 +4379,25 @@ begin
   until len = 0;
 end;
 
+function TDhcpState.RequestConflictsWith(ip4: TNetIP4): boolean;
+var
+  req: TNetIP4;
+  len: PtrUInt;
+begin
+  result := false;
+  // RFC 2131 3.1: a REQUEST selecting another server is none of our business
+  len := RecvLens[doServerIdentifier];
+  if (len <> 0) and
+     (DhcpIP4(@Recv, len) <> Scope^.ServerIdentifier) then
+    exit;
+  // option 50 on SELECTING/INIT-REBOOT, or ciaddr on RENEWING/REBINDING
+  req := DhcpIP4(@Recv, RecvLens[doRequestedAddress]);
+  if req = 0 then
+    req := Recv.ciaddr;
+  result := (req <> 0) and
+            (req <> ip4);
+end;
+
 function TDhcpState.FakeLease(found: TNetIP4): PDhcpLease;
 begin
   result := @Temp; // fake transient PDhcpLease for this StaticUuid[]
@@ -6237,9 +6257,19 @@ begin
              (State.Scope^.LeaseTimeLE < SecsPerHour) and // grace period
              (State.BootTix32 - p^.Expired <
                 State.Scope^.LeaseTimeLE * State.Scope^.GraceFactor))) then
+        begin
           // RFC 2131: lease is Reserved after OFFER = SELECTING
           //           lease is Ack/Static/Outdated = RENEWING/REBINDING
-          inc(State.Scope^.Metrics.Current[dsmLeaseRenewed])
+          if (p^.State = lsStatic) and
+             State.RequestConflictsWith(p^.IP4) then
+          begin
+            // RFC 2131 4.3.2: the requested address is not the one reserved
+            // for this client, so NAK for it to DISCOVER the current one
+            result := DoError(State, dsmNak);
+            exit;
+          end;
+          inc(State.Scope^.Metrics.Current[dsmLeaseRenewed]);
+        end
         else if RetrieveFrameIP(State, p) then // IP from option 50
         begin
           // no lease, but Option 50 = INIT-REBOOT

--- a/test/test.net.proto.pas
+++ b/test/test.net.proto.pas
@@ -3169,6 +3169,76 @@ begin
       'domain-name:"mydomain",' +
       'subnet-mask:"255.252.0.0",lease-time:120,renewal-time:' +
       '60,rebinding-time:105}');
+    // validate DHCPNAK on a REQUEST conflicting with a static reservation
+    mac := MacToText(@macs[1510]);
+    Check(server.AddStatic(Join([mac, '=192.168.0.120'])), 'static120');
+    ip4 := ToIP4('192.168.0.120');
+    // a client asking for the reserved IP is acknowledged as usual
+    f := d.ClientNew(dmtRequest, macs[1510]);
+    DhcpAddOption32(f, doRequestedAddress, ip4);
+    d.ClientFlush(f);
+    Check(server.ComputeResponse(d) > 0, 'static ack');
+    Check(d.SendType = dmtAck, 'static ack type');
+    CheckEqual(d.Send.yiaddr, ip4, 'static ack ip');
+    // a client asking for no IP at all (e.g. PXE) is acknowledged as usual
+    d.ClientFlush(d.ClientNew(dmtRequest, macs[1510]));
+    Check(server.ComputeResponse(d) > 0, 'static noip');
+    Check(d.SendType = dmtAck, 'static noip type');
+    CheckEqual(d.Send.yiaddr, ip4, 'static noip ip');
+    // once the reservation points to another IP, the previous one is NAKed
+    Check(server.RemoveStatic('192.168.0.120'), 'del120');
+    Check(server.AddStatic(Join([mac, '=192.168.0.121'])), 'static121');
+    f := d.ClientNew(dmtRequest, macs[1510]);
+    DhcpAddOption32(f, doRequestedAddress, ip4); // INIT-REBOOT with option 50
+    DhcpAddOption32(f, doServerIdentifier, ToIP4('192.168.0.1')); // this server
+    d.ClientFlush(f);
+    Check(server.ComputeResponse(d) > 0, 'nak opt50');
+    Check(d.SendType = dmtNak, 'nak opt50 type');
+    // ... and on RENEWING, i.e. from ciaddr with no option 50
+    d.ClientFlush(d.ClientNew(dmtRequest, macs[1510]));
+    d.Recv.ciaddr := ip4;
+    Check(server.ComputeResponse(d) > 0, 'nak ciaddr');
+    Check(d.SendType = dmtNak, 'nak ciaddr type');
+    // the DISCOVER following a NAK returns the current reservation
+    d.ClientFlush(d.ClientNew(dmtDiscover, macs[1510]));
+    Check(server.ComputeResponse(d) > 0, 'discover after nak');
+    Check(d.SendType = dmtOffer, 'offer type');
+    CheckEqual(d.Send.yiaddr, ToIP4('192.168.0.121'), 'offer new ip');
+    // a ciaddr matching the reservation is of course acknowledged
+    d.ClientFlush(d.ClientNew(dmtRequest, macs[1510]));
+    d.Recv.ciaddr := ToIP4('192.168.0.121');
+    Check(server.ComputeResponse(d) > 0, 'ciaddr ok');
+    Check(d.SendType = dmtAck, 'ciaddr ok type');
+    // a REQUEST which did select another server is left alone
+    f := d.ClientNew(dmtRequest, macs[1510]);
+    DhcpAddOption32(f, doRequestedAddress, ip4);
+    DhcpAddOption32(f, doServerIdentifier, ToIP4('192.168.0.2'));
+    d.ClientFlush(f);
+    Check(server.ComputeResponse(d) > 0, 'other server');
+    Check(d.SendType = dmtAck, 'other server type');
+    // ... and so are unparsable option 54 or option 50 values
+    option := 'bad'; // length is 3, not SizeOf(TNetIP4)
+    f := d.ClientNew(dmtRequest, macs[1510]);
+    DhcpAddOption32(f, doRequestedAddress, ip4);
+    DhcpAddOptionShort(f, doServerIdentifier, option);
+    d.ClientFlush(f);
+    Check(server.ComputeResponse(d) > 0, 'bad opt54');
+    Check(d.SendType = dmtAck, 'bad opt54 type');
+    f := d.ClientNew(dmtRequest, macs[1510]);
+    DhcpAddOptionShort(f, doRequestedAddress, option);
+    d.ClientFlush(f);
+    Check(server.ComputeResponse(d) > 0, 'bad opt50');
+    Check(d.SendType = dmtAck, 'bad opt50 type');
+    // a dynamic lease is still acknowledged whatever the client did ask for
+    d.ClientFlush(d.ClientNew(dmtDiscover, macs[1511]));
+    Check(server.ComputeResponse(d) > 0, 'dyn discover');
+    ip4 := d.Send.yiaddr;
+    f := d.ClientNew(dmtRequest, macs[1511]);
+    DhcpAddOption32(f, doRequestedAddress, ToIP4('192.168.0.121'));
+    d.ClientFlush(f);
+    Check(server.ComputeResponse(d) > 0, 'dyn ack');
+    Check(d.SendType = dmtAck, 'dyn ack type');
+    CheckEqual(d.Send.yiaddr, ip4, 'dyn ack ip');
   finally
     server.Free;
     settings.Free;


### PR DESCRIPTION
When a MAC already has a lease, the `dmtRequest` branch acknowledges the IP the server has, whatever the client did ask for. For dynamic and PXE clients that is deliberate — 39ba4b2ec used to say so in a comment: *"especially for PXE networks, it is safe and common to ignore Option 50 and ciaddr in REQUEST and ACK the already OFFERed IP"* — and **this PR leaves that path alone**.

A static reservation is a different statement though: the address is the one the administrator configured for that MAC. When the client insists on another one, ACKing a different `yiaddr` leaves it to the client whether it switches at all, and when. RFC 2131 4.3.2 has *"Server SHOULD send a DHCPNAK message to the client if the 'requested IP address' is incorrect"* on INIT-REBOOT, and *"The DHCP server SHOULD check 'ciaddr' for correctness before replying"* on REBINDING — a NAK makes the client DISCOVER and get the reserved address at once, which is what a standard server does here.

A NAK is returned only when all of these hold:

1. the lease is `lsStatic` — nothing from a dynamic pool is affected;
2. the client did ask for an explicit address, from option 50 (SELECTING / INIT-REBOOT) or from `ciaddr` (RENEWING / REBINDING) — a REQUEST asking for no address at all, as PXE firmware often sends, is still acknowledged;
3. that address is not the reserved one;
4. the REQUEST did not select another server through option 54 — RFC 2131 3.1 has *"Those servers not selected by the DHCPREQUEST message use the message as notification that the client has declined that server's offer"*.

### What this really changes

To be explicit, because it is the part worth your judgement: **this is a policy change, not merely the detection of an edited reservation.** The server has no memory of what the reservation used to be, so it cannot tell a stale client address from one the administrator just changed. A client of a never-modified reservation that insists on some other address now gets a NAK where it used to get an ACK.

That also reaches the `lsStatic` leases `FakeLease()` builds from an option 61/97 UUID or from a `"rule"` holding an `"ip"` — for instance when a PXE chainload presents a different identity than the firmware stage did, and keeps asking for the address of the previous stage.

If that tolerance is something you want to keep for static entries too, this PR is the wrong shape and I would rather drop it than weaken the reasoning.

`DhcpIP4()` had to be fixed first: it returned the option offset instead of `0` when the option is present with a length other than 4, which would make a malformed option 50 look like a conflicting address. No caller relies on that offset — both `GetScope(DhcpIP4(...))` ones already fall back when no scope matches.

### Tests

The two NAK paths (option 50 and `ciaddr`), plus everything that must *not* change: a dynamic lease is still acknowledged whatever is requested, the reserved IP and a matching `ciaddr` are acknowledged, a REQUEST with no requested IP at all is acknowledged, another server's REQUEST is left alone, unparsable option 50 or 54 values are ignored, and the DISCOVER following a NAK returns the reservation.

They are appended at the end of the DHCP test so the existing metrics assertions are untouched. `TNetworkProtocols` is 175,134 assertions passed (FPC 3.2.3, i386-win32).

This is independent of the DHCPNAK frame fixes in the other PR, and will be rebased if that one lands first — they do touch the same spot in the test file.
