### PR TITLE
core: correctly rounded GetExtended() and GetNumericVariantFromJson() decimals

### DIFF
--- a/src/core/mormot.core.text.pas
+++ b/src/core/mormot.core.text.pas
@@ -6845,6 +6845,16 @@ e:  err := 1; // return the (partial) value even if not ended with #0
     goto x;
   end;
   d64 := v64;
+  if (frac < 0) and
+     (frac >= -22) and
+     (v64 <= MAX_SAFE_JS_INTEGER) then
+  begin
+    // Clinger's fast path: d64 and 10^-frac are both exact doubles, so a single
+    // IEEE division is correctly rounded - whereas POW10[frac] * d64 is not,
+    // since 1E-1..1E-22 are inexact (e.g. '1.2' returned 1.2000000000000002)
+    result := d64 / POW10[-frac];
+    goto x;
+  end;
   if PtrUInt(frac) + 31 <= 62 then // -31 .. +31: overwhelmingly common
     result := POW10[frac]
   else if frac < -31 then

--- a/src/core/mormot.core.variants.pas
+++ b/src/core/mormot.core.variants.pas
@@ -11662,19 +11662,31 @@ begin
      (frac <= -324) then // 5.0 x 10^-324 .. 1.7 x 10^308
     exit; // we can't convert into a double
   exp := PtrUInt(@POW10);
-  if frac >= -31 then
-    if frac <= 31 then
-      d := PPow10(exp)[frac] // -31 .. + 31 is the most common case
-    else if frac >= remdigit + 290 then
-      exit                   // +308 ..
-    else                     // +32 .. +307
-      d := PPow10(exp)[(frac and not 31) shr 5 + 34] * PPow10(exp)[frac and 31]
+  if (frac < 0) and
+     (frac >= -22) and
+     (v64 >= -MAX_SAFE_JS_INTEGER) then // v64 is negative here
+  begin
+    // Clinger's fast path: v64 and 10^-frac are both exact doubles, so a single
+    // IEEE division is correctly rounded - see GetExtended() in mormot.core.text
+    d := v64;
+    d := d / PPow10(exp)[-frac];
+  end
   else
   begin
-    frac := -frac; // .. -32
-    d := PPow10(exp)[(frac and not 31) shr 5 + 45] / PPow10(exp)[frac and 31];
+    if frac >= -31 then
+      if frac <= 31 then
+        d := PPow10(exp)[frac] // -31 .. + 31 is the most common case
+      else if frac >= remdigit + 290 then
+        exit                   // +308 ..
+      else                     // +32 .. +307
+        d := PPow10(exp)[(frac and not 31) shr 5 + 34] * PPow10(exp)[frac and 31]
+    else
+    begin
+      frac := -frac; // .. -32
+      d := PPow10(exp)[(frac and not 31) shr 5 + 45] / PPow10(exp)[frac and 31];
+    end;
+    d := d * v64;
   end;
-  d := d * v64;
   if not (fNeg in flags) then
     d := -d;
   vd.VType := varDouble;

--- a/test/test.core.base.pas
+++ b/test/test.core.base.pas
@@ -5085,6 +5085,60 @@ procedure TTestCoreBase.NumericalConversions;
     CheckEqual(TVarData(v).VInt64, expected, text);
   end;
 
+  procedure CheckJsonDoubleBits(const text: RawUtf8; expected: QWord);
+  var
+    v: variant;
+  begin
+    CheckUtf8(GetNumericVariantFromJson(pointer(text), TVarData(v), true) <> nil, text);
+    CheckEqual(TVarData(v).VType, varDouble, text);
+    CheckUtf8(PQWord(@TVarData(v).VDouble)^ = expected, text);
+  end;
+
+  procedure CheckDecimalRounding;
+  var
+    i, err, bad: integer;
+    s: RawUtf8;
+    d, d0: double;
+  begin
+    // decimal text should be parsed as the nearest IEEE double: digits*POW10[-n]
+    // was not, since 1E-1..1E-22 are inexact - e.g. '1.2' = 1.2000000000000002
+    CheckGetExtendedBits('1.2', $3FF3333333333333);
+    CheckGetExtendedBits('-1.2', QWord($BFF3333333333333));
+    CheckGetExtendedBits('12e-1', $3FF3333333333333);
+    CheckGetExtendedBits('0.1', $3FB999999999999A);
+    CheckGetExtendedBits('0.3', $3FD3333333333333);
+    CheckGetExtendedBits('0.7', $3FE6666666666666);
+    CheckGetExtendedBits('1.15', $3FF2666666666666);
+    CheckGetExtendedBits('39.9', $4043F33333333333);
+    CheckGetExtendedBits('100.1', $4059066666666666);
+    CheckGetExtendedBits('0.35', $3FD6666666666666);
+    CheckGetExtendedBits('4.52', $4012147AE147AE14);
+    CheckGetExtendedBits('452E-2', $4012147AE147AE14);
+    CheckGetExtendedBits('2.675', $4005666666666666);
+    CheckGetExtendedBits('0.009', $3F826E978D4FDF3B);
+    CheckGetExtendedBits('10000.05', $40C3880666666666);
+    CheckGetExtendedBits('0.0003', $3F33A92A30553261);
+    CheckGetExtendedBits('0.00003', $3EFF75104D551D69);
+    // 'x.y' and 'x.y0' are the same number, so should return the same double
+    bad := 0;
+    for i := 1 to 20000 do
+    begin
+      s := FormatUtf8('%.%', [i div 10, i mod 10]);
+      d := GetExtended(pointer(s), err);
+      s := s + '0';
+      d0 := GetExtended(pointer(s), err);
+      if PQWord(@d)^ <> PQWord(@d0)^ then
+        inc(bad);
+    end;
+    CheckEqual(bad, 0, 'x.y = x.y0');
+    // GetNumericVariantFromJson() had the same issue for varDouble values
+    // (with both SSE2 and x87 FPU, since its local d variable is a double)
+    CheckJsonDoubleBits('0.00003', $3EFF75104D551D69);
+    CheckJsonDoubleBits('0.00006', $3F0F75104D551D69);
+    CheckJsonDoubleBits('-0.00007', QWord($BF12599ED7C6FBD2));
+    CheckJsonDoubleBits('0.00012', $3F1F75104D551D69);
+  end;
+
   procedure CheckInvalidNumber(const text: RawUtf8; extendedToo: boolean = true);
   var
     v: variant;
@@ -5547,6 +5601,7 @@ begin
   CheckDoubleToShortSame(12.345678901234);
   CheckDoubleToShortSame(123.45678901234);
   CheckDoubleToShortSame(1234.5678901234);
+  CheckDecimalRounding;
   {$ifndef WIN32DELPHI} // fails when converted to FP80 in x87 asm
   d := GetExtended('0e400', err);
   CheckEqual(err, 0);


### PR DESCRIPTION
The following report is created by claude. I could not explain it like that. I just find the problem in results from my code's tests.

`GetExtended()` (Pascal implementation) and `GetNumericVariantFromJson()` do not always return the nearest IEEE-754 double for plain decimal text. About one short decimal in five comes out **one ulp too high**:

| text | returned | nearest double |
|---|---|---|
| `1.2` | `1.2000000000000002` | `1.2` |
| `0.3` | `0.30000000000000004` | `0.3` |
| `39.9` | `39.900000000000006` | `39.9` |
| `4.52` | `4.5200000000000005` | `4.52` |

As a consequence, `"1.2"` and `"1.20"` are parsed as two different doubles, and a value read from text does not compare equal to the same constant compiled by Delphi/FPC.

Affected:

- `GetExtended()` wherever the Pascal version is used, i.e. every target but Delphi Win32 (FPC on all CPUs, Delphi Win64...), and everything built on top of it: JSON `double`/`single` fields (`_JL_Double`), `ToDouble()`, `TOrmTableAbstract.GetAsFloat()`, `TSqlDBPostgresStatement.ColumnDouble()`, `TSqlDBStatement.Bind()` / `PrepareInlined()` of `ftDouble` text values...
- `GetNumericVariantFromJson()` on **all** targets, including Delphi Win32, whenever a `varDouble` is returned (more than 4 decimals, or out of the currency range), e.g. `TDocVariant` with `dvoAllowDoubleValue` / `JSON_FAST_FLOAT`.

Delphi Win32 `GetExtended()` is not affected, since its x87 asm computes in 80-bit extended precision.

We found it because a FPC/Linux server and its Delphi Win32 clients disagreed on comparisons like `"1.2" > 1.2`, and because the 1 ulp error was persisted into PostgreSQL `float8` columns (binary bind) and then served back as `1.2000000000000002`.

## Root cause

The digits are accumulated exactly into `v64`, then the result is computed as `POW10[frac] * v64`. For `frac < 0`, `POW10[frac]` is `1E-1 .. 1E-22`, which are not exactly representable as doubles (`1E-1` .. `1E-5` are all slightly *above* the true value), so the multiplication propagates this error. For instance, `12 * 0.1000000000000000055511151231257827` is exactly the midpoint between `1.1999999999999999556` and `1.2000000000000001776`, and ties-to-even selects the latter.

In `GetNumericVariantFromJson()`, `POW10[frac]` is first stored into the `d: double` local, so the same happens even with an x87 FPU.

The existing text/double round-trip tests use `CheckSame()` with a tolerance, so a 1 ulp difference could not be detected.

## Fix

Clinger's fast path (William D. Clinger, *How to Read Floating Point Numbers Accurately*, PLDI 1990), as used by the fast paths of Go `strconv`, Rust `core::num::dec2flt` and `fast_float`: when the mantissa is exactly representable (`|v64| <= MAX_SAFE_JS_INTEGER` = 2^53 - 1) and `-22 <= frac < 0`, both `v64` and `10^-frac` are exact doubles, so a **single IEEE division** `v64 / POW10[-frac]` is correctly rounded.

Positive exponents up to 22 were already correct (`exact * exact`). All other inputs (more than 15-16 significant digits, |exponent| > 22, huge or tiny values) keep the existing code path, unchanged.

## Environment

| compiler | version | target |
|---|---|---|
| Delphi 13.1 Florence | dcc32 / dcc64 compiler version 37.0 (build 37.0.59082.6021) | Win32, Win64 |
| FPC 3.2.3 (native) | 3.2.3-940-g0eeb544f39 (fixes_3_2, 2026/09/10), Ubuntu 26.04.1 LTS on WSL2 | x86_64-linux |
| FPC 3.2.3 (cross, Win64 host) | 3.2.3-924-g483299735f (fixes_3_2, 2026/07/17) | x86_64-linux |

mORMot 2 master at 5817814 ("core: fixed regression in GetNumericVariantFromJson() - 0.0 was not parsed as expected"). Hardware: Intel Core i7-1255U (hybrid P/E cores), Windows 11 Pro 26200.

## Tests

New nested `CheckDecimalRounding` in `TTestCoreBase.NumericalConversions`, placed *outside* of the `{$ifndef WIN32DELPHI}` block so that it also runs on Delphi Win32:

- bit-exact `GetExtended()` results for values which were 1 ulp off (expected bits computed with CPython `float()`, which is correctly rounded);
- `'x.y'` and `'x.y0'` must return the very same double, for 20,000 values (3,460 of them differed before);
- bit-exact `GetNumericVariantFromJson()` `varDouble` results (values which were wrong with both SSE2 and x87).

`TTestCoreBase.NumericalConversions` on master 5817814 with these new tests, versus this branch:

| target | master | this PR |
|---|---|---|
| Delphi 13.1 Win32 | 4 failed | passed |
| Delphi 13.1 Win64 | 21 failed | passed |
| FPC 3.2.3 x86_64-linux (native) | 21 failed | passed |

`TTestCoreBase` + `TTestCoreProcess` on this branch:

- Delphi 13.1 Win32 and Win64: 0 failed / 134 million assertions;
- FPC 3.2.3 x86_64-linux (native): `TTestCoreBase` passed; `TTestCoreProcess` reports 10 failures (`Encode decode JSON`, `Mustache renderer`) which are identical on master, i.e. unrelated to this change.

Side note: the same tests built with the *cross* compiler (Win64 host, where `extended = double`) show many other failures (`TDynArray`, `TDecimal128`, `BSON`, `XML`, two `NumericalConversions` checks...) - identical on master and on this branch, and absent from the native build - most likely constant folding in the cross compiler.

## Measurements

200,000 decimal strings (x.y 0.1-2000.0, x.yz 0.01-200.00, x.yyy 0.001-100.000, 10000.00-10199.99, 4 and 5 decimals), compared bit-by-bit with CPython `float()`:

| function / target | master | this PR |
|---|---|---|
| `GetExtended()` - FPC 3.2.3 x86_64-linux (native) | 42,536 wrong (all +1 ulp) | 0 |
| `GetExtended()` - Delphi 13.1 Win64 | 42,536 wrong (all +1 ulp) | 0 |
| `GetExtended()` - Delphi 13.1 Win32 (x87 asm) | 0 | 0 |
| JSON `TDoubleDynArray` load - FPC / Delphi Win64 | 42,536 wrong | 0 |
| `TDocVariant` + `JSON_FAST_FLOAT` (5 decimals) - FPC / Win64 / Win32 | 10,468 / 10,468 / 10,469 wrong | 0 / 0 / 0 |

For reference, FPC RTL `Val()` / `TryStrToFloat()` gave 0 wrong values on x86_64-linux (80-bit `ValReal`).

## Performance

ns per call, 20,000 strings x 100 loops, best of 5, then the minimum of 3 runs:

| strings | GetExtended master | GetExtended PR | GetNumericVariantFromJson master | GetNumericVariantFromJson PR |
|---|---|---|---|---|
| **FPC 3.2.3 native x86_64-linux** | | | | |
| integer | 7.2 | 7.6 | 6.9 | 6.9 |
| x.y | 8.6 | 9.1 | 10.2 | 9.0 |
| x.yz | 9.2 | 10.0 | 9.8 | 8.0 |
| x.yyy | 9.2 | 10.0 | 8.6 | 7.5 |
| x.yyyyy | 12.1 | 12.3 | 12.8 | 9.4 |
| 18 digits | 25.5 | 25.3 | 22.6 | 21.5 |
| **Delphi 13.1 Win32** | | | | |
| integer | 4.5 | 4.3 | 19.8 | 19.8 |
| x.y | 5.7 | 5.8 | 21.5 | 20.9 |
| x.yz | 5.8 | 5.9 | 20.0 | 20.4 |
| x.yyy | 5.7 | 5.7 | 20.0 | 20.2 |
| x.yyyyy | 6.3 | 6.6 | 25.0 | 28.0 |
| 18 digits | 16.2 | 17.3 | 81.7 | 84.1 |
| **Delphi 13.1 Win64** | | | | |
| integer | 8.2 | 7.5 | 7.3 | 7.3 |
| x.y | 9.8 | 8.0 | 9.4 | 11.6 |
| x.yz | 9.7 | 8.4 | 7.9 | 11.1 |
| x.yyy | 9.7 | 8.7 | 7.3 | 10.3 |
| x.yyyyy | 11.5 | 10.5 | 9.7 | 12.0 |
| 18 digits | 29.8 | 23.0 | 22.4 | 24.4 |

Notes:

- FPC: `GetExtended()` is unchanged within noise (another build with the very same `GetExtended()` code gave exactly the master timings); `GetNumericVariantFromJson()` is faster, especially for `varDouble` values.
- Delphi Win32: `GetExtended()` is the untouched x87 asm; `GetNumericVariantFromJson()` is ~3 ns slower for `varDouble` values only (x87 `fdiv` instead of `fmul`).
- Delphi Win64 timings are position dependent on this hybrid CPU: the very same `GetExtended()` source measured anywhere between 8 and 12 ns depending on the executable. The `GetNumericVariantFromJson()` currency/integer paths look slower although their machine code is unchanged: `objdump` shows the same prologue and the same instructions, the function only grows by 48 bytes (the new fast path on the `varDouble` path). Alternative layouts of the patch (early exit, a single `v64 / POW10[-frac]` expression, a digit-count test instead of `MAX_SAFE_JS_INTEGER`) gave the same Win64 timings.
