### PR TITLE
core: fix TMemoryMapText/TSynLogFile rows appended after loading

### DIFF
--- a/src/core/mormot.core.buffers.pas
+++ b/src/core/mormot.core.buffers.pas
@@ -1996,6 +1996,8 @@ type
     fFileName: TFileName;
     fAppendedLines: TRawUtf8DynArray;
     fAppendedLinesCount: integer;
+    function GetLineEnd(Line: PUtf8Char): PUtf8Char;
+      {$ifdef HASINLINE}inline;{$endif}
     function GetLine(aIndex: integer): RawUtf8;
       {$ifdef HASINLINE}inline;{$endif}
     function GetString(aIndex: integer): string;
@@ -9194,13 +9196,23 @@ begin
   end;
 end;
 
+function TMemoryMapText.GetLineEnd(Line: PUtf8Char): PUtf8Char;
+begin // AddInMemoryLine() ensures an appended row never aliases fMap.Buffer
+  if (PtrUInt(Line) >= PtrUInt(fMap.Buffer)) and
+     (PtrUInt(Line) < PtrUInt(fMapEnd)) then
+    result := fMapEnd
+  else
+    result := nil; // an AddInMemoryLine() entry is a standalone #0 string
+end;
+
 function TMemoryMapText.GetLine(aIndex: integer): RawUtf8;
 begin
   if (self = nil) or
      (cardinal(aIndex) >= cardinal(fCount)) then
     FastAssignNew(result)
   else
-    FastSetString(result, fLines[aIndex], GetLineSize(fLines[aIndex], fMapEnd));
+    FastSetString(result, fLines[aIndex],
+      GetLineSize(fLines[aIndex], GetLineEnd(fLines[aIndex])));
 end;
 
 function TMemoryMapText.GetString(aIndex: integer): string;
@@ -9209,7 +9221,8 @@ begin
      (cardinal(aIndex) >= cardinal(fCount)) then
     result := ''
   else
-    Utf8DecodeToString(fLines[aIndex], GetLineSize(fLines[aIndex], fMapEnd), result);
+    Utf8DecodeToString(fLines[aIndex],
+      GetLineSize(fLines[aIndex], GetLineEnd(fLines[aIndex])), result);
 end;
 
 function TMemoryMapText.LineContains(const aUpperSearch: RawUtf8;
@@ -9220,17 +9233,19 @@ begin
      (aUpperSearch = '') then
     result := false
   else
-    result := GetLineContains(fLines[aIndex], fMapEnd, pointer(aUpperSearch));
+    result := GetLineContains(fLines[aIndex], GetLineEnd(fLines[aIndex]),
+      pointer(aUpperSearch));
 end;
 
 function TMemoryMapText.LineSize(aIndex: integer): integer;
 begin
-  result := GetLineSize(fLines[aIndex], fMapEnd);
+  result := GetLineSize(fLines[aIndex], GetLineEnd(fLines[aIndex]));
 end;
 
 function TMemoryMapText.LineSizeSmallerThan(aIndex, aMinimalCount: integer): boolean;
 begin
-  result := GetLineSizeSmallerThan(fLines[aIndex], fMapEnd, aMinimalCount);
+  result := GetLineSizeSmallerThan(fLines[aIndex], GetLineEnd(fLines[aIndex]),
+    aMinimalCount);
 end;
 
 procedure TMemoryMapText.ProcessOneLine(LineBeg, LineEnd: PUtf8Char);
@@ -9292,16 +9307,30 @@ begin
     inc(P, 3); // ignore any UTF-8 BOM (still appears on Windows)
   ParseLines(P, fMapEnd, self);
   if fLinesMax > fCount + 16384 then
+  begin
     ReallocMem(fLines, fCount * SizeOf(pointer)); // size down only if worth it
+    fLinesMax := fCount;
+  end;
 end;
 
 procedure TMemoryMapText.AddInMemoryLine(const aNewLine: RawUtf8);
 var
   P: PUtf8Char;
+  unaliased: RawUtf8;
 begin
   if aNewLine = '' then
     exit;
-  AddRawUtf8(fAppendedLines, fAppendedLinesCount, aNewLine);
+  P := pointer(aNewLine);
+  if (PtrUInt(P) >= PtrUInt(fMap.Buffer)) and
+     (PtrUInt(P) < PtrUInt(fMapEnd)) then
+  begin
+    // never share a reference into the memory mapped buffer, so that a line
+    // pointer alone tells an appended row apart - see GetLineEnd()
+    FastSetString(unaliased, P, length(aNewLine));
+    AddRawUtf8(fAppendedLines, fAppendedLinesCount, unaliased);
+  end
+  else
+    AddRawUtf8(fAppendedLines, fAppendedLinesCount, aNewLine);
   P := pointer(fAppendedLines[fAppendedLinesCount - 1]);
   ProcessOneLine(P, P + StrLen(P));
 end;

--- a/src/core/mormot.core.log.pas
+++ b/src/core/mormot.core.log.pas
@@ -7496,11 +7496,13 @@ function TSynLogFile.LineContains(const aUpperSearch: RawUtf8;
 begin // overriden to take fLineTextOffset into account
   if (self = nil) or
      (cardinal(aIndex) >= cardinal(fCount)) or
-     (aUpperSearch = '') then
+     (aUpperSearch = '') or
+     (fLevels = nil) or
+     (fLevels[aIndex] = sllNone) then // an unparsed row has no text at offset
     result := false
   else
     result := GetLineContains(PUtf8Char(fLines[aIndex]) + fLineTextOffset,
-      fMapEnd, pointer(aUpperSearch));
+      GetLineEnd(fLines[aIndex]), pointer(aUpperSearch));
 end;
 
 function TSynLogFile.EventDateTime(aIndex: integer): TDateTime;
@@ -7841,6 +7843,7 @@ begin
       if fThreads <> nil then
       begin
         SetLength(fThreads, fCount);
+        fThreadsCount := fCount; // so that AddInMemoryLine() can grow it back
         SetLength(fThreadInfo, fThreadMax + 1);
       end;
     end;
@@ -7891,7 +7894,14 @@ begin
     Utf8DecodeToString(P, StrLen(P), string(fFileName));
   end
   else
+  begin
+    if fLogProcStack = nil then
+    begin // released by LoadFromMap(), but needed again by ProcessOneLine()
+      SetLength(fLogProcStack, NextGrow(length(fThreadInfo)));
+      SetLength(fLogProcStackCount, length(fLogProcStack));
+    end;
     inherited AddInMemoryLine(aNewLine);
+  end;
 end;
 
 procedure TSynLogFile.LogProcSort(Order: TLogProcSortOrder);
@@ -8103,7 +8113,15 @@ begin
       begin
         AddInteger(fLogProcStack[thread], fLogProcStackCount[thread], fLogProcNaturalCount);
         if fLogProcNaturalCount >= length(fLogProcNatural) then
+        begin
           SetLength(fLogProcNatural, NextGrow(fLogProcNaturalCount));
+          if (fLogProcCurrent <> nil) and
+             not fLogProcIsMerged then
+            fLogProcCurrent := pointer(fLogProcNatural); // realloc may move it
+        end;
+        // .Index is overwritten by CleanLevels() after an initial parsing,
+        // but is needed as such for any AddInMemoryLine() appended row
+        fLogProcNatural[fLogProcNaturalCount].Index := fCount - 1;
         // fLogProcNatural[].### fields will be set later during parsing
         inc(fLogProcNaturalCount);
       end;
@@ -8162,7 +8180,7 @@ begin
               break;
             end;
         end;
-        FastSetString(result, found, GetLineSize(found, fMapEnd));
+        FastSetString(result, found, GetLineSize(found, GetLineEnd(found)));
         delete(result, 1, PosEx('=', result, 40)); // raw thread name
       end;
     end;
@@ -8204,7 +8222,7 @@ begin
     FastAssignNew(result)
   else
   begin
-    L := GetLineSize(fLines[index], fMapEnd);
+    L := GetLineSize(fLines[index], GetLineEnd(fLines[index]));
     if L <= fLineTextOffset then
       FastAssignNew(result)
     else

--- a/src/core/mormot.core.unicode.pas
+++ b/src/core/mormot.core.unicode.pas
@@ -2357,8 +2357,10 @@ function FindNameValuePointer(NameValuePairs: PUtf8Char; UpperName: PAnsiChar;
 function GetLineSize(P, PEnd: PUtf8Char): PtrUInt;
   {$ifdef HASINLINE}inline;{$endif}
 
-/// returns true if the line length from source array of chars is not less than
-// the specified count
+/// returns true if the line length from source array of chars is not bigger
+// than the specified count
+// - if PEnd = nil, end counting at either #0, #13 or #10, as GetLineSize() does
+// - otherwise, end counting at either #13 or #10
 function GetLineSizeSmallerThan(P, PEnd: PUtf8Char; aMinimalCount: integer): boolean;
 
 {$ifndef PUREMORMOT2}
@@ -9592,13 +9594,22 @@ function GetLineSizeSmallerThan(P, PEnd: PUtf8Char; aMinimalCount: integer): boo
 begin
   result := false;
   if P <> nil then
-    while (P < PEnd) and
-          (P^ <> #10) and
-          (P^ <> #13) do
-      if aMinimalCount = 0 then
-        exit
-      else
+    if PEnd = nil then
+      // an in-memory line is #0 ended, as GetLineSize/GetLineContains expect
+      while not (P^ in [#0, #10, #13]) do
       begin
+        if aMinimalCount = 0 then
+          exit;
+        dec(aMinimalCount);
+        inc(P);
+      end
+    else
+      while (P < PEnd) and
+            (P^ <> #10) and
+            (P^ <> #13) do
+      begin
+        if aMinimalCount = 0 then
+          exit;
         dec(aMinimalCount);
         inc(P);
       end;

--- a/test/test.core.base.pas
+++ b/test/test.core.base.pas
@@ -10761,6 +10761,124 @@ end;
 
 procedure TTestCoreBase.Debugging;
 
+  procedure TestLiveAppendedLines;
+  const
+    STAMPS: array[0..1] of RawUtf8 = ( // calendar and high resolution layouts
+      '20250213 16410200', '0000000000001234');
+    THREADS: array[0..2] of integer = (0, 1, 4096);
+    HEADER = 'C:\mormot2tests.exe 1.0.0 (2025-02-13 16:41:00)'#13#10 +
+      'Host=Test User=Test CPU=1 OS=0 Wow64=0 Freq=1000000'#13#10 +
+      'TSynLog 2.0 2025-02-13T16:41:00'#13#10#13#10;
+  var
+    log: TSynLogFile;
+    s, t, i, n: integer;
+    stamp, input, source: RawUtf8;
+  begin
+    // AddInMemoryLine() rows are standalone #0 ended strings which don't belong
+    // to the memory mapped buffer: fMapEnd is no valid line end for them, for
+    // any layout - e.g. with or without ptIdentifiedInOneFile thread columns
+    for s := low(STAMPS) to high(STAMPS) do
+      for t := low(THREADS) to high(THREADS) do
+      begin
+        input := STAMPS[s];
+        if THREADS[t] <> 0 then
+          input := input + Int18ToChars3(THREADS[t]);
+        input := input + ' info  Mapped payload';
+        source := HEADER;
+        for i := 1 to 4 do
+          source := source + input + #13#10;
+        log := TSynLogFile.Create(pointer(source), length(source));
+        try
+          CheckEqual(log.Count, 4, 'mapped rows');
+          CheckEqual(log.EventText[0], ' Mapped payload');
+          if THREADS[t] = 0 then
+            Check(log.EventThread = nil)
+          else
+            CheckEqual(log.EventThread[0], THREADS[t]);
+          log.AddInMemoryLine(input);
+          CheckEqual(log.Count, 5, 'appended row');
+          CheckEqual(log.Lines[4], input);
+          CheckEqual(log.LineSize(4), length(input));
+          Check(not log.LineSizeSmallerThan(4, length(input) - 1));
+          Check(log.LineSizeSmallerThan(4, length(input)));
+          CheckEqual(log.EventText[4], ' Mapped payload');
+          Check(log.LineContains('PAYLOAD', 4));
+          if THREADS[t] <> 0 then
+            CheckEqual(log.EventThread[4], THREADS[t]);
+        finally
+          log.Free;
+        end;
+      end;
+    // LoadFromMap() did size fLines[] and fThreads[] down without adjusting
+    // their fLinesMax/fThreadsCount capacity, so the next AddInMemoryLine()
+    // rows were stored past the reallocated buffers
+    n := 1700; // long enough lines to trigger the down-sizing
+    for t := 0 to 1 do
+    begin
+      stamp := STAMPS[0];
+      if t <> 0 then
+        stamp := stamp + Int18ToChars3(THREADS[2]);
+      input := stamp + ' info  ' + RawUtf8OfChar('m', 1078);
+      source := input + #13#10;
+      while length(source) < n * (length(input) + 2) do
+        source := source + source; // O(log n) instead of O(n2) concatenation
+      SetLength(source, n * (length(input) + 2));
+      source := HEADER + source;
+      log := TSynLogFile.Create(pointer(source), length(source));
+      try
+        CheckEqual(log.Count, n, 'big mapped rows');
+        for i := 1 to 100 do
+          log.AddInMemoryLine(input); // did corrupt the heap before the fix
+        CheckEqual(log.Count, n + 100);
+        for i := n to log.Count - 1 do
+        begin
+          CheckEqual(log.LineSize(i), length(input));
+          if t <> 0 then
+            CheckEqual(log.EventThread[i], THREADS[2]);
+        end;
+        // a row shorter than fLineTextOffset is no valid search start - the
+        // invalid read itself is not observable in-process, so this asserts
+        // the guard's result, and that longer rows still are searchable
+        log.AddInMemoryLine('short');
+        Check(not log.LineContains('SHORT', log.Count - 1));
+        Check(log.LineContains('MMM', log.Count - 2));
+        // fLogProcStack[] is released by LoadFromMap() but needed on append
+        log.AddInMemoryLine(stamp + '  +    Work');
+        log.AddInMemoryLine(stamp + '  -    Work 00.020.006');
+        CheckEqual(log.Count, n + 103);
+        Check(log.EventLevel[log.Count - 2] = sllEnter);
+        Check(log.EventLevel[log.Count - 1] = sllLeave);
+        Check(log.LogProc = nil, 'no sllEnter among the mapped rows');
+        log.LogProcMerged := false; // sets LogProc[] from fLogProcNatural[]
+        Check(log.LogProc <> nil);
+        for i := 1 to 10 do
+          log.AddInMemoryLine(stamp + '  +    More'); // reallocs fLogProcNatural
+        CheckEqual(log.LogProc[0].Index, n + 101); // the appended sllEnter row
+        CheckEqual(log.LogProc[0].Time, 20006);    // no dangling LogProc[]
+        // note: LogProcCount is a snapshot made by LogProcMerged, and
+        // LogProc[].ProperTime is computed by LoadFromMap() only: both are
+        // not maintained for appended rows - out of scope for this fix
+        CheckEqual(log.LogProcCount, 1);
+      finally
+        log.Free;
+      end;
+    end;
+    // an appended row is never stored as a reference into the mapped buffer,
+    // so that its line pointer alone tells it apart from a mapped line
+    source := RawUtf8OfChar('x', 64);
+    with TMemoryMapText.Create(pointer(source), 32) do
+    try
+      AddInMemoryLine(source);
+      CheckEqual(Count, 2);
+      Check(LinePointers[1] <> pointer(source), 'unaliased');
+      CheckEqual(LineSize(0), 32);
+      CheckEqual(LineSize(1), 64);
+      CheckEqual(Lines[1], source);
+      Check(LineContains('XXX', 1));
+    finally
+      Free;
+    end;
+  end;
   procedure Test(const LOG: RawUtf8; ExpectedDate: TDateTime);
   var
     L: TSynLogFile;
@@ -10931,6 +11049,7 @@ begin
   Check(dst[len] = #0, 'ending #0');
   Check(dst[len + 1] = #1, 'buffer');
   // validate TSynLogFile
+  TestLiveAppendedLines;
   Test('D:\Dev\lib\SQLite3\exe\TestSQL3.exe 1.2.3.4 (2011-04-07 11:09:06)'#13#10 +
     'Host=MyPC User=MySelf CPU=2*0-15-1027 OS=2.3=5.1.2600 Wow64=0 Freq=3579545 ' +
     'Instance=D:\Dev\MyLibrary.dll'#13#10 +


### PR DESCRIPTION
AddInMemoryLine() stores its rows as standalone #0 ended RawUtf8 in fAppendedLines[], not inside the memory mapped buffer - as used e.g. by the LogView tool in remote logging server mode. Every line accessor still passed fMapEnd as their end pointer, which is out of range for such a row.

- TMemoryMapText.GetLineEnd() returns nil for an appended row, which is the existing convention of GetLineSize()/GetLineContains() for "scan until #0", and AddInMemoryLine() no longer keeps a reference into the mapped buffer, so that a line pointer alone tells both apart
- GetLineSizeSmallerThan() was the only one of those three helpers without a PEnd=nil branch, and returned a constant true for it
- LoadFromMap() sized fLines[] and fThreads[] down without adjusting their fLinesMax/fThreadsCount capacity, so the next AddInMemoryLine() rows were written past the reallocated buffers
- TSynLogFile.LineContains() added fLineTextOffset to the line start without checking that the row was parsed at all, reading past a shorter one
- fLogProcStack[]/fLogProcStackCount[] are released by LoadFromMap() but indexed by the sllEnter/sllLeave branches, and growing fLogProcNatural[] could leave LogProc[] dangling; .Index is now also set for appended rows

ref #344