### PR TITLE
core: fix TSynLogFile ZonedTimestamp layout detection

### DIFF
--- a/src/core/mormot.core.log.pas
+++ b/src/core/mormot.core.log.pas
@@ -8037,7 +8037,7 @@ begin
     begin
       // YYYYMMDD HHMMSSXX[Z] is one/two chars bigger than Timestamp
       fLineLevelOffset := 19;
-      if LineBeg[fLineLevelOffset] = 'Z' then
+      if LineBeg[fLineLevelOffset - 2] = 'Z' then
         inc(fLineLevelOffset); // did have TSynLogFamily.ZonedTimestamp
       fDayCurrent := PInt64(LineBeg)^;
       AddInteger(fDayChangeIndex, fCount - 1);

--- a/test/test.core.base.pas
+++ b/test/test.core.base.pas
@@ -10761,6 +10761,40 @@ end;
 
 procedure TTestCoreBase.Debugging;
 
+  procedure TestZonedLayout;
+  const
+    HEADER = 'C:\mormot2tests.exe 1.0.0 (2025-02-13 16:41:00)'#13#10 +
+      'Host=Test User=Test CPU=1 OS=0 Wow64=0 Freq=1000000'#13#10 +
+      'TSynLog 2.0 2025-02-13T16:41:00'#13#10#13#10;
+  var
+    log: TSynLogFile;
+    t, i: integer;
+    input, source: RawUtf8;
+  begin
+    // Int18ToText() encodes a thread number as $20 + 6-bit chars, so thread 58
+    // ends with 'Z' - which the ZonedTimestamp detection did read as its own
+    // 'Z' marker, shifting fLineLevelOffset and loading the whole file empty
+    for t := 0 to 1 do
+    begin
+      input := '20250213 16410200';
+      if t <> 0 then
+        input := input + 'Z'; // TSynLogFamily.ZonedTimestamp layout
+      input := input + Int18ToChars3(58) + ' info  Zoned payload';
+      source := HEADER;
+      for i := 1 to 4 do
+        source := source + input + #13#10;
+      log := TSynLogFile.Create(pointer(source), length(source));
+      try
+        CheckEqual(log.Count, 4, 'zoned rows');
+        CheckEqual(log.EventThread[0], 58);
+        CheckEqual(log.EventText[0], ' Zoned payload');
+        Check(log.EventLevel[0] = sllInfo);
+      finally
+        log.Free;
+      end;
+    end;
+  end;
+
   procedure Test(const LOG: RawUtf8; ExpectedDate: TDateTime);
   var
     L: TSynLogFile;
@@ -10931,6 +10965,7 @@ begin
   Check(dst[len] = #0, 'ending #0');
   Check(dst[len + 1] = #1, 'buffer');
   // validate TSynLogFile
+  TestZonedLayout;
   Test('D:\Dev\lib\SQLite3\exe\TestSQL3.exe 1.2.3.4 (2011-04-07 11:09:06)'#13#10 +
     'Host=MyPC User=MySelf CPU=2*0-15-1027 OS=2.3=5.1.2600 Wow64=0 Freq=3579545 ' +
     'Instance=D:\Dev\MyLibrary.dll'#13#10 +


### PR DESCRIPTION
The calendar timestamp is 17 chars ('20110325 19241502'), so the optional 'Z' marker written for TSynLogFamily.ZonedTimestamp is at index 17, whereas fLineLevelOffset points at the level text start plus 2, i.e. 19 - because GetLogLevelFromText() compares PCardinal(@LOG_LEVEL_TEXT[L][3])^.

Index 19 is the third thread number char of a ptIdentifiedInOneFile line, which Int18ToText() encodes as $20 + (thread and $3f) - so it is 'Z' for thread 58, 122, 186 and so on. When such a line was the first one of a .log file, the layout detection shifted fLineLevelOffset and no line matched a level any more: the whole file loaded empty.

ref #344